### PR TITLE
Fix Hallsensor reverse phase mapping

### DIFF
--- a/mcpwm.c
+++ b/mcpwm.c
@@ -494,7 +494,7 @@ void mcpwm_set_configuration(volatile mc_configuration *configuration) {
  * The commutations corresponding to the hall sensor states in the forward direction-
  */
 void mcpwm_init_hall_table(int8_t *table) {
-	const int fwd_to_rev[7] = {-1,4,3,2,1,6,5};
+	const int fwd_to_rev[7] = {-1,1,6,5,4,3,2};
 
 	for (int i = 0;i < 8;i++) {
 		hall_to_phase_table[8 + i] = table[i];
@@ -505,13 +505,7 @@ void mcpwm_init_hall_table(int8_t *table) {
 			continue;
 		}
 
-		ind_now += 2;
-		if (ind_now > 6) {
-			ind_now -= 6;
-		}
-		ind_now = fwd_to_rev[ind_now];
-
-		hall_to_phase_table[i] = ind_now;
+		hall_to_phase_table[i] = fwd_to_rev[ind_now];
 	}
 }
 


### PR DESCRIPTION
We believe to have found a bug in the hallsensor phase mapping from forward to reverse direction.
We use a 2-pole sensored motor and had the problem that the motor would run flawlessly in forward direction, but could not rotate in reverse direction (with heavy cogging). Since sensorless mode worked just fine and the sensored mode did so as well (with smooth startup) in forward direction, we figured that the problem must lie somewhere in the reverse direction handling of the sensored mode. 

The low-level direction mapping of the commutation phases is listed here: [mcpwm.c (Line 1408)](https://github.com/vedderb/bldc/blob/08a27cfbbd309d852a8a451b5e20839d8f248c3d/mcpwm.c#L1408)
Additionally, the `mcpwm_init_hall_table` function maps the hall-states to the commutation steps for forward and reverse direction. While the forward mapping is clear, the function calculates the following forward-reverse phase mapping:

| FWD | REV |
|-----|-----|
| 1   | 2   |
| 2   | 1   |
| 3   | 6   |
| 4   | 5   |
| 5   | 4   |
| 6   | 3   |

For instace for forward phase 1 we can read from the table listed in [mcpwm.c (Line 1408)](https://github.com/vedderb/bldc/blob/08a27cfbbd309d852a8a451b5e20839d8f248c3d/mcpwm.c#L1408) that `BR1=0`, `BR2=+`, `BR3=-`. The corresponding reverse phase is calculated as 2 which would be `BR1=+`, `BR2=-` and `BR3=0`

When comparing this for instance to the commutation sequences in http://cache.nxp.com/files/product/doc/AN1916.pdf or http://ww1.microchip.com/downloads/en/appnotes/00857a.pdf we find that the mapping from forward to reverse (or vice versa) is made here by switching the positive and negative phase for each commutation sequence step. Hence the mapping calculated by `init_hall_table` is as far as we can see incorrect since it does not switch the positive and negative phases but does something else. In order to achieve the desired behavior, we need to adapt the mapping as follows:

| FWD | REV |
|-----|-----|
| 1   | 1   |
| 2   | 6   |
| 3   | 5   |
| 4   | 4   |
| 5   | 3   |
| 6   | 2   |

We implemented this mapping (see patch), tested it with our motor and found it to be running perfectly in both forward and reverse direction. We've been using this for some time now and finally found the time to make a PR.

We'd really love to hear your take on this. It might be that we missed something serious here, but we're fairly sure that the forward-reverse mapping does not match the mappings we find everywhere else for BLDCs and this PR certainly fixes the issue for us.

CC @tobawo
