### PR TITLE
Fix incorrect scaling of cc_ramp_step_max parameter

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -329,7 +329,7 @@ void commands_process_packet(unsigned char *data, unsigned int len) {
 		mcconf.cc_startup_boost_duty = (float)buffer_get_int32(data, &ind) / 1000000.0;
 		mcconf.cc_min_current = (float)buffer_get_int32(data, &ind) / 1000.0;
 		mcconf.cc_gain = (float)buffer_get_int32(data, &ind) / 1000000.0;
-		mcconf.cc_ramp_step_max = buffer_get_float32(data, 1e5, &ind);
+		mcconf.cc_ramp_step_max = buffer_get_float32(data, 1e6, &ind);
 
 		mcconf.m_fault_stop_time_ms = buffer_get_int32(data, &ind);
 		mcconf.m_duty_ramp_step = (float)buffer_get_float32(data, 1000000.0, &ind);


### PR DESCRIPTION
A read configuration/write configuration loop in the gui multiplies the cc_ramp_step_max parameter by 10. Causes VESC's to blow up!

Found the culprit as a 1e5 scale factor on read instead of 1e6 (to match the 100000 scale factor on write and in the bldc-tool.)