### PR TITLE
packet: remove rx_timeout

### DIFF
--- a/main.c
+++ b/main.c
@@ -68,10 +68,7 @@
  */
 
 // Private variables
-
-
 static THD_WORKING_AREA(periodic_thread_wa, 1024);
-static THD_WORKING_AREA(timer_thread_wa, 128);
 
 static THD_FUNCTION(periodic_thread, arg) {
 	(void)arg;
@@ -141,17 +138,6 @@ static THD_FUNCTION(periodic_thread, arg) {
 	}
 }
 
-static THD_FUNCTION(timer_thread, arg) {
-	(void)arg;
-
-	chRegSetThreadName("msec_timer");
-
-	for(;;) {
-		packet_timerfunc();
-		chThdSleepMilliseconds(1);
-	}
-}
-
 int main(void) {
 	halInit();
 	chSysInit();
@@ -198,7 +184,6 @@ int main(void) {
 
 	// Threads
 	chThdCreateStatic(periodic_thread_wa, sizeof(periodic_thread_wa), NORMALPRIO, periodic_thread, NULL);
-	chThdCreateStatic(timer_thread_wa, sizeof(timer_thread_wa), NORMALPRIO, timer_thread, NULL);
 
 	for(;;) {
 		chThdSleepMilliseconds(10);

--- a/packet.h
+++ b/packet.h
@@ -28,7 +28,6 @@
 #include <stdint.h>
 
 // Settings
-#define PACKET_RX_TIMEOUT		2
 #define PACKET_HANDLERS			2
 #define PACKET_MAX_PL_LEN		1024
 
@@ -36,7 +35,6 @@
 void packet_init(void (*s_func)(unsigned char *data, unsigned int len),
 		void (*p_func)(unsigned char *data, unsigned int len), int handler_num);
 void packet_process_byte(uint8_t rx_data, int handler_num);
-void packet_timerfunc(void);
 void packet_send_packet(unsigned char *data, unsigned int len, int handler_num);
 
 #endif /* PACKET_H_ */


### PR DESCRIPTION
- Saves memory (~136 bytes + thread overhead) and CPU time.
- When the value reaches zero, nothing happens.