### PR TITLE
Include declaration of fsincos.

### DIFF
--- a/mcpwm_foc.c
+++ b/mcpwm_foc.c
@@ -22,6 +22,8 @@
  *      Author: benjamin
  */
 
+#define _GNU_SOURCE         /* for sincosf */
+
 #include "mcpwm_foc.h"
 #include "mc_interface.h"
 #include "ch.h"


### PR DESCRIPTION
Fix compilation warning about fsincos undeclared on Linux by defining
_GNU_SOURCE before including <math.h>