### PR TITLE
increase packet timeout

### DIFF
--- a/packet.c
+++ b/packet.c
@@ -23,7 +23,7 @@
 
 typedef struct {
 	volatile unsigned char rx_state;
-	volatile unsigned char rx_timeout;
+	volatile unsigned short rx_timeout;
 	void(*send_func)(unsigned char *data, unsigned int len);
 	void(*process_func)(unsigned char *data, unsigned int len);
 	unsigned int payload_length;

--- a/packet.h
+++ b/packet.h
@@ -23,7 +23,7 @@
 #include <stdint.h>
 
 // Settings
-#define PACKET_RX_TIMEOUT		2
+#define PACKET_RX_TIMEOUT		1000
 #define PACKET_HANDLERS			2
 #define PACKET_MAX_PL_LEN		1024
 


### PR DESCRIPTION
This patch increases packet timeout from 2ms to 1000ms. At first I tried to stay within unsigned char, but even timeout of 255ms was not enough for iOS with bluetooth low energy. Sometimes timeout value was up to 350ms. I decided to go little higher and set it to 1000ms just in case.