### PR TITLE
stop script on errors

### DIFF
--- a/build_all/rebuild_all
+++ b/build_all/rebuild_all
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 FWPATH="../"
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )


### PR DESCRIPTION
I added 2 small fixes to the rebuild_all bash script

1) Stop execution of the script if any error occurs (set -e)
2) After executing the script return to the initial directory with popd. For example, if I am in my home directory and run ~/dev/bldc/build_all/rebuild_all, I do not want to end up in bldc/build_all, I want to stay in my home directory after the script finishes