### PR TITLE
PPM Current_noRev_Brake 'pulses_without_power' increment condition has Typo

### DIFF
--- a/applications/app_ppm.c
+++ b/applications/app_ppm.c
@@ -220,7 +220,7 @@ static THD_FUNCTION(ppm_thread, arg) {
 				current_mode_brake = true;
 			}
 
-			if (servo_val < 0.001) {
+			if (fabsf(servo_val) < 0.001) {
 				pulses_without_power++;
 			}
 			break;


### PR DESCRIPTION
pulses_without_power should be incremented if **Absolute value** of 'servo_val' is smaller than 0.001