### PR TITLE
added proof of concept for detecting the precense of an AS5047 encoder

### DIFF
--- a/encoder.h
+++ b/encoder.h
@@ -32,5 +32,6 @@ void encoder_reset(void);
 void encoder_tim_isr(void);
 void encoder_set_counts(uint32_t counts);
 bool encoder_index_found(void);
+bool calculate_parity(uint16_t data);
 
 #endif /* ENCODER_H_ */


### PR DESCRIPTION
perhaps it should also generate an error after x wrong parities