### PR TITLE
Fix race condition between different command sources

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -49,6 +49,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#define SERVO_TIMEOUT	30    /* in ms */
+
 // Threads
 static THD_FUNCTION(detect_thread, arg);
 static THD_WORKING_AREA(detect_thread_wa, 2048);
@@ -186,33 +188,43 @@ void commands_process_packet(unsigned char *data, unsigned int len) {
 		break;
 
 	case COMM_SET_DUTY:
-		ind = 0;
-		mc_interface_set_duty((float)buffer_get_int32(data, &ind) / 100000.0);
-		timeout_reset();
+		if (servodec_get_time_since_update() > SERVO_TIMEOUT) {
+			ind = 0;
+			mc_interface_set_duty((float)buffer_get_int32(data, &ind) / 100000.0);
+			timeout_reset();
+		}
 		break;
 
 	case COMM_SET_CURRENT:
-		ind = 0;
-		mc_interface_set_current((float)buffer_get_int32(data, &ind) / 1000.0);
-		timeout_reset();
+		if (servodec_get_time_since_update() > SERVO_TIMEOUT) {
+			ind = 0;
+			mc_interface_set_current((float)buffer_get_int32(data, &ind) / 1000.0);
+			timeout_reset();
+		}
 		break;
 
 	case COMM_SET_CURRENT_BRAKE:
-		ind = 0;
-		mc_interface_set_brake_current((float)buffer_get_int32(data, &ind) / 1000.0);
-		timeout_reset();
+		if (servodec_get_time_since_update() > SERVO_TIMEOUT) {
+			ind = 0;
+			mc_interface_set_brake_current((float)buffer_get_int32(data, &ind) / 1000.0);
+			timeout_reset();
+		}
 		break;
 
 	case COMM_SET_RPM:
-		ind = 0;
-		mc_interface_set_pid_speed((float)buffer_get_int32(data, &ind));
-		timeout_reset();
+		if (servodec_get_time_since_update() > SERVO_TIMEOUT) {
+			ind = 0;
+			mc_interface_set_pid_speed((float)buffer_get_int32(data, &ind));
+			timeout_reset();
+		}
 		break;
 
 	case COMM_SET_POS:
-		ind = 0;
-		mc_interface_set_pid_pos((float)buffer_get_int32(data, &ind) / 1000000.0);
-		timeout_reset();
+		if (servodec_get_time_since_update() > SERVO_TIMEOUT) {
+			ind = 0;
+			mc_interface_set_pid_pos((float)buffer_get_int32(data, &ind) / 1000000.0);
+			timeout_reset();
+		}
 		break;
 
 	case COMM_SET_DETECT:


### PR DESCRIPTION
Since the VESC is able to receive motor commands from numerous sources (e.g. USB, PPM, ...) and there is currently no prioritization of the sources, there can be a race condition between them and if the same command arrives from multiple sources, then the action performed could be chosen at random.

This proposal prefers commands received from the RF transceiver (PPM input) over the other options. I use this behavior in order to automatically switch between the autonomous driving mode (commands send through the USB via the Robot Operating System VESC wrapper - https://github.com/mit-racecar/vesc) of a 1:10 scale model car and a manual override mode (PWM signal generated by a dedicated MCU based on change of output from the RF remote controller) for handling emergency situations (bug in code, system freeze, ...).

Perhaps this change could be useful for other VESC users as well.