### PR TITLE
Flux Weakening and MTPA support

### DIFF
--- a/confgenerator.c
+++ b/confgenerator.c
@@ -71,6 +71,8 @@ int32_t confgenerator_serialize_mcconf(uint8_t *buffer, const mc_configuration *
 	buffer_append_float32_auto(buffer, conf->foc_pll_kp, &ind);
 	buffer_append_float32_auto(buffer, conf->foc_pll_ki, &ind);
 	buffer_append_float32_auto(buffer, conf->foc_motor_l, &ind);
+	buffer_append_float32_auto(buffer, conf->foc_motor_ld, &ind);
+	buffer_append_float32_auto(buffer, conf->foc_motor_lq, &ind);
 	buffer_append_float32_auto(buffer, conf->foc_motor_r, &ind);
 	buffer_append_float32_auto(buffer, conf->foc_motor_flux_linkage, &ind);
 	buffer_append_float32_auto(buffer, conf->foc_observer_gain, &ind);
@@ -97,6 +99,10 @@ int32_t confgenerator_serialize_mcconf(uint8_t *buffer, const mc_configuration *
 	buffer[ind++] = conf->foc_temp_comp;
 	buffer_append_float32_auto(buffer, conf->foc_temp_comp_base_temp, &ind);
 	buffer_append_float32_auto(buffer, conf->foc_current_filter_const, &ind);
+	buffer[ind++] = conf->foc_mtpa_enable;
+	buffer[ind++] = conf->foc_field_weakening_enable;
+	buffer_append_float32_auto(buffer, conf->foc_field_weakening_kp, &ind);
+	buffer_append_float32_auto(buffer, conf->foc_field_weakening_ki, &ind);
 	buffer_append_int16(buffer, conf->gpd_buffer_notify_left, &ind);
 	buffer_append_int16(buffer, conf->gpd_buffer_interpol, &ind);
 	buffer_append_float32_auto(buffer, conf->gpd_current_filter_const, &ind);
@@ -290,6 +296,8 @@ bool confgenerator_deserialize_mcconf(const uint8_t *buffer, mc_configuration *c
 	conf->foc_pll_kp = buffer_get_float32_auto(buffer, &ind);
 	conf->foc_pll_ki = buffer_get_float32_auto(buffer, &ind);
 	conf->foc_motor_l = buffer_get_float32_auto(buffer, &ind);
+	conf->foc_motor_ld = buffer_get_float32_auto(buffer, &ind);
+	conf->foc_motor_lq = buffer_get_float32_auto(buffer, &ind);
 	conf->foc_motor_r = buffer_get_float32_auto(buffer, &ind);
 	conf->foc_motor_flux_linkage = buffer_get_float32_auto(buffer, &ind);
 	conf->foc_observer_gain = buffer_get_float32_auto(buffer, &ind);
@@ -316,6 +324,10 @@ bool confgenerator_deserialize_mcconf(const uint8_t *buffer, mc_configuration *c
 	conf->foc_temp_comp = buffer[ind++];
 	conf->foc_temp_comp_base_temp = buffer_get_float32_auto(buffer, &ind);
 	conf->foc_current_filter_const = buffer_get_float32_auto(buffer, &ind);
+	conf->foc_mtpa_enable = buffer[ind++];
+	conf->foc_field_weakening_enable = buffer[ind++];
+	conf->foc_field_weakening_kp = buffer_get_float32_auto(buffer, &ind);
+	conf->foc_field_weakening_ki = buffer_get_float32_auto(buffer, &ind);
 	conf->gpd_buffer_notify_left = buffer_get_int16(buffer, &ind);
 	conf->gpd_buffer_interpol = buffer_get_int16(buffer, &ind);
 	conf->gpd_current_filter_const = buffer_get_float32_auto(buffer, &ind);
@@ -505,6 +517,8 @@ void confgenerator_set_defaults_mcconf(mc_configuration *conf) {
 	conf->foc_pll_kp = MCCONF_FOC_PLL_KP;
 	conf->foc_pll_ki = MCCONF_FOC_PLL_KI;
 	conf->foc_motor_l = MCCONF_FOC_MOTOR_L;
+	conf->foc_motor_ld = MCCONF_FOC_MOTOR_LD;
+	conf->foc_motor_lq = MCCONF_FOC_MOTOR_LQ;
 	conf->foc_motor_r = MCCONF_FOC_MOTOR_R;
 	conf->foc_motor_flux_linkage = MCCONF_FOC_MOTOR_FLUX_LINKAGE;
 	conf->foc_observer_gain = MCCONF_FOC_OBSERVER_GAIN;
@@ -531,6 +545,10 @@ void confgenerator_set_defaults_mcconf(mc_configuration *conf) {
 	conf->foc_temp_comp = MCCONF_FOC_TEMP_COMP;
 	conf->foc_temp_comp_base_temp = MCCONF_FOC_TEMP_COMP_BASE_TEMP;
 	conf->foc_current_filter_const = MCCONF_FOC_CURRENT_FILTER_CONST;
+	conf->foc_mtpa_enable = MCCONF_FOC_MTPA_ENABLE;
+	conf->foc_field_weakening_enable = MCCONF_FOC_FIELD_WEAKENING_ENABLE;
+	conf->foc_field_weakening_kp = MCCONF_FOC_FIELD_WEAKENING_KP;
+	conf->foc_field_weakening_ki = MCCONF_FOC_FIELD_WEAKENING_KI;
 	conf->gpd_buffer_notify_left = MCCONF_GPD_BUFFER_NOTIFY_LEFT;
 	conf->gpd_buffer_interpol = MCCONF_GPD_BUFFER_INTERPOL;
 	conf->gpd_current_filter_const = MCCONF_GPD_CURRENT_FILTER_CONST;

--- a/confgenerator.h
+++ b/confgenerator.h
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 
 // Constants
-#define MCCONF_SIGNATURE		503309878
+#define MCCONF_SIGNATURE		1493606584
 #define APPCONF_SIGNATURE		725102789
 
 // Functions

--- a/datatypes.h
+++ b/datatypes.h
@@ -238,6 +238,8 @@ typedef struct {
 	float foc_encoder_cos_gain;
 	float foc_encoder_sincos_filter_constant;
 	float foc_motor_l;
+	float foc_motor_ld;
+	float foc_motor_lq;
 	float foc_motor_r;
 	float foc_motor_flux_linkage;
 	float foc_observer_gain;
@@ -260,6 +262,11 @@ typedef struct {
 	bool foc_temp_comp;
 	float foc_temp_comp_base_temp;
 	float foc_current_filter_const;
+	//MTPA and FW config
+	bool foc_mtpa_enable;
+	bool foc_field_weakening_enable;
+	float foc_field_weakening_kp;
+	float foc_field_weakening_ki;
 	// GPDrive
 	int gpd_buffer_notify_left;
 	int gpd_buffer_interpol;

--- a/mcconf/mcconf_default.h
+++ b/mcconf/mcconf_default.h
@@ -251,6 +251,12 @@
 #ifndef MCCONF_FOC_MOTOR_L
 #define MCCONF_FOC_MOTOR_L				0.000007
 #endif
+#ifndef MCCONF_FOC_MOTOR_LD
+#define MCCONF_FOC_MOTOR_LD				0.00002
+#endif
+#ifndef MCCONF_FOC_MOTOR_LQ
+#define MCCONF_FOC_MOTOR_LQ				0.00002
+#endif
 #ifndef MCCONF_FOC_MOTOR_R
 #define MCCONF_FOC_MOTOR_R				0.015
 #endif
@@ -328,6 +334,18 @@
 #endif
 #ifndef MCCONF_FOC_CURRENT_FILTER_CONST
 #define MCCONF_FOC_CURRENT_FILTER_CONST	0.1		// Filter constant for the filtered currents
+#endif
+#ifndef MCCONF_FOC_MTPA_ENABLE
+#define MCCONF_FOC_MTPA_ENABLE				false	// MTPA Enable
+#endif
+#ifndef MCCONF_FOC_FIELD_WEAKENING_ENABLE
+#define MCCONF_FOC_FIELD_WEAKENING_ENABLE	false	// Field Weakening enable
+#endif
+#ifndef MCCONF_FOC_FIELD_WEAKENING_KP
+#define MCCONF_FOC_FIELD_WEAKENING_KP		0.02	// Field Weakening proportional gain
+#endif
+#ifndef MCCONF_FOC_FIELD_WEAKENING_KI
+#define MCCONF_FOC_FIELD_WEAKENING_KI		0.02	// Field Weakening integral gain
 #endif
 
 // GPD

--- a/mcpwm_foc.h
+++ b/mcpwm_foc.h
@@ -81,6 +81,7 @@ void mcpwm_foc_get_current_offsets(volatile int *curr0_offset, volatile int *cur
 void mcpwm_foc_set_current_offsets(volatile int curr0_offset, volatile int curr1_offset, volatile int curr2_offset);
 float mcpwm_foc_get_ts(void);
 void mcpwm_foc_reset_vd_vq(void);
+void mtpa_setup(bool enable,float Lsd, float Lsq);
 
 // Interrupt handlers
 void mcpwm_foc_tim_sample_int_handler(void);

--- a/mcpwm_foc.h
+++ b/mcpwm_foc.h
@@ -81,7 +81,6 @@ void mcpwm_foc_get_current_offsets(volatile int *curr0_offset, volatile int *cur
 void mcpwm_foc_set_current_offsets(volatile int curr0_offset, volatile int curr1_offset, volatile int curr2_offset);
 float mcpwm_foc_get_ts(void);
 void mcpwm_foc_reset_vd_vq(void);
-void mtpa_setup(bool enable,float Lsd, float Lsq);
 
 // Interrupt handlers
 void mcpwm_foc_tim_sample_int_handler(void);

--- a/virtual_motor.c
+++ b/virtual_motor.c
@@ -211,6 +211,8 @@ static void connect_virtual_motor(float ml , float J, float Ld, float Lq,
 	virtual_motor.km = 1.5 * virtual_motor.pole_pairs;
 
 	virtual_motor.connected = true;
+
+	mtpa_setup(true, virtual_motor.Ld , virtual_motor.Lq);
 }
 
 /**

--- a/virtual_motor.h
+++ b/virtual_motor.h
@@ -23,7 +23,7 @@
 
 #include "datatypes.h"
 
-void virtual_motor_init(void);
+void virtual_motor_init(volatile mc_configuration *conf);
 void virtual_motor_int_handler(float v_alpha, float v_beta);
 bool virtual_motor_is_connected(void);
 float virtual_motor_get_angle_deg(void);


### PR DESCRIPTION
This is a major feature that will demand some careful review, its tested and crafted to be mergable.

The control scheme has been adopted from [here](http://www.ti.com/lit/an/spracf3/spracf3.pdf)

Here is a video of FW working, injecting a negative Id current to produce torque beyond base speed.

https://youtu.be/02jA0u5V-X0

In speed control mode there are some integrator issues, it takes too long to "forget" the error signal and an anti-windup didn't work very well.

Before trying this you may want to merge #90 as it comes with a fix for proper simulation of this. The simulation was super useful and allowed to test the new control. The real motor behaved just like the simulation.

This also simplifies the virtual motor command, as now it fetches the motor parameters from the stored motor configuration. It wasn't possible before because vesc wasn't aware of Lq and Ld inductances.

To enable this feature, VESC Tool requires this patch:
https://github.com/vedderb/vesc_tool/pull/34
to enable the features
![image](https://user-images.githubusercontent.com/309472/57170529-d4ff0f80-6de3-11e9-9c88-3b3b6cb99928.png)

If approved this will close #73 and #76 

Have fun!

