### PR TITLE
Fixed compilation errors for HW_40 and HW_45

### DIFF
--- a/hwconf/hw_40.h
+++ b/hwconf/hw_40.h
@@ -51,7 +51,7 @@
  * 6:	VREFINT
  * 7:	IN11	NC
  * 8:	IN12	AN_IN
- * 9:	IN13	NC
+ * 9:	IN13	NC  (TEMP_MOSFET to make it compile)
  * 10:	IN15	ADC_EXT
  * 11:	IN10	TEMP_MOTOR
  */
@@ -68,7 +68,9 @@
 #define ADC_IND_CURR2			3
 #define ADC_IND_VIN_SENS		8
 #define ADC_IND_EXT				10
+#define ADC_IND_TEMP_MOS		9
 #define ADC_IND_VREFINT			6
+#define ADC_IND_TEMP_MOTOR		11
 
 // ADC macros and settings
 

--- a/hwconf/hw_45.h
+++ b/hwconf/hw_45.h
@@ -51,7 +51,7 @@
  * 6:	VREFINT
  * 7:	IN11	NC
  * 8:	IN12	AN_IN
- * 9:	IN13	NC
+ * 9:	IN13	NC (TEMP_MOSFET to make it compile)
  * 10:	IN15	ADC_EXT
  * 11:	IN10	TEMP_MOTOR
  */
@@ -68,6 +68,7 @@
 #define ADC_IND_CURR2			3
 #define ADC_IND_VIN_SENS		8
 #define ADC_IND_EXT				10
+#define ADC_IND_TEMP_MOS		9
 #define ADC_IND_VREFINT			6
 #define ADC_IND_TEMP_MOTOR		11
 


### PR DESCRIPTION
ADC_IND_TEMP_MOS was missing for both and has been added. 
ADC_IND_TEMP_MOTOR has been added for HW_40.
I haven't looked it up in the schematics if there is a mosfet temperature sensor for both but there is definitely a motor temperature input on the 40. I don't know why this was disabled / never enabled.