### PR TITLE
Modifying encoder spi_transfer to sample on falling edge

### DIFF
--- a/encoder.c
+++ b/encoder.c
@@ -606,6 +606,7 @@ static void spi_transfer(uint16_t *in_buf, const uint16_t *out_buf, int length) 
 
 			palSetPad(SPI_SW_SCK_GPIO, SPI_SW_SCK_PIN);
 			spi_delay();
+			palClearPad(SPI_SW_SCK_GPIO, SPI_SW_SCK_PIN);
 
 			int samples = 0;
 			samples += palReadPad(SPI_SW_MISO_GPIO, SPI_SW_MISO_PIN);
@@ -613,18 +614,12 @@ static void spi_transfer(uint16_t *in_buf, const uint16_t *out_buf, int length) 
 			samples += palReadPad(SPI_SW_MISO_GPIO, SPI_SW_MISO_PIN);
 			__NOP();
 			samples += palReadPad(SPI_SW_MISO_GPIO, SPI_SW_MISO_PIN);
-			__NOP();
-			samples += palReadPad(SPI_SW_MISO_GPIO, SPI_SW_MISO_PIN);
-			__NOP();
-			samples += palReadPad(SPI_SW_MISO_GPIO, SPI_SW_MISO_PIN);
 
 			receive <<= 1;
-			if (samples > 2) {
+			if (samples > 1) {
 				receive |= 1;
 			}
 
-			palClearPad(SPI_SW_SCK_GPIO, SPI_SW_SCK_PIN);
-			spi_delay();
 		}
 
 		if (in_buf) {
@@ -642,6 +637,18 @@ static void spi_end(void) {
 }
 
 static void spi_delay(void) {
+	__NOP();
+	__NOP();
+	__NOP();
+	__NOP();
+	__NOP();
+	__NOP();
+	__NOP();
+	__NOP();
+	__NOP();
+	__NOP();
+	__NOP();
+	__NOP();
 	__NOP();
 	__NOP();
 	__NOP();


### PR DESCRIPTION
I was having issues with encoder errors. After looking into the AS5047x manual, the data is meant to be sampled on the falling edge of CLK. This is not consistent with the current implementation which samples one spi_delay after the rising edge.

When moving the sampling to after the falling edge, I have found the encoder to be much more reliable.
It also has the advantage of compressing all of the delay into one place. I have increased the delay to bring the duty cycle of the clock closer to 50%. 
This correspond to approximately 48% duty cycle at 3.8MHz (compared to 77% at 4.0MHz previously).

I have not tested this with the AD2S1205 which also uses this function, though the datasheet for this device also specifies falling edge sampling. 