### PR TITLE
More bbshd support

### DIFF
--- a/hwconf/hw_axiom.h
+++ b/hwconf/hw_axiom.h
@@ -35,6 +35,7 @@
 #define HW_HAS_3_SHUNTS
 #define HW_HAS_PHASE_SHUNTS
 #define HW_HAS_SIN_COS_ENCODER
+#define HW_HAS_GATE_DRIVER_SUPPLY_MONITOR
 
 // Macros
 #define ENABLE_GATE()			palSetPad(GPIOC, 14)

--- a/hwconf/hw_luna_bbshd.c
+++ b/hwconf/hw_luna_bbshd.c
@@ -28,6 +28,8 @@
 // Variables
 static volatile bool i2c_running = false;
 
+void hw_luna_bbshd_setup_dac(void);
+
 // I2C configuration
 static const I2CConfig i2cfg = {
 		OPMODE_I2C,
@@ -99,7 +101,11 @@ void hw_init_gpio(void) {
 	palSetPadMode(GPIOA, 1, PAL_MODE_INPUT_ANALOG);
 	palSetPadMode(GPIOA, 2, PAL_MODE_INPUT_ANALOG);
 	palSetPadMode(GPIOA, 3, PAL_MODE_INPUT_ANALOG);
+#ifdef HW_BBSHD_USE_DAC
+	hw_luna_bbshd_setup_dac();
+#else
 	palSetPadMode(GPIOA, 5, PAL_MODE_INPUT_ANALOG);
+#endif
 	palSetPadMode(GPIOA, 6, PAL_MODE_INPUT_ANALOG);
 
 	palSetPadMode(GPIOB, 0, PAL_MODE_INPUT_ANALOG);
@@ -242,4 +248,31 @@ void hw_try_restore_i2c(void) {
 
 		i2cReleaseBus(&HW_I2C_DEV);
 	}
+}
+
+void hw_luna_bbshd_setup_dac(void) {
+	// GPIOA clock enable
+	RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOA, ENABLE);
+
+	// DAC Periph clock enable
+	RCC_APB1PeriphClockCmd(RCC_APB1Periph_DAC, ENABLE);
+
+	// DAC channel 1 & 2 (DAC_OUT1 = PA.4)(DAC_OUT2 = PA.5) configuration
+	palSetPadMode(GPIOA, 4, PAL_MODE_INPUT_ANALOG);
+	palSetPadMode(GPIOA, 5, PAL_MODE_INPUT_ANALOG);
+
+	// Enable both DAC channels with output buffer disabled to achieve rail-to-rail output
+	DAC->CR |= DAC_CR_EN1 | DAC_CR_BOFF1 | DAC_CR_EN2 | DAC_CR_BOFF2;
+
+	// Set DAC channels at 1.65V
+	hw_luna_bbshd_DAC1_setdata(0x800);
+	hw_luna_bbshd_DAC2_setdata(0x800);
+}
+
+void hw_luna_bbshd_DAC1_setdata(uint16_t data) {
+	DAC->DHR12R1 = data;
+}
+
+void hw_luna_bbshd_DAC2_setdata(uint16_t data) {
+	DAC->DHR12R2 = data;
 }

--- a/hwconf/hw_luna_bbshd.c
+++ b/hwconf/hw_luna_bbshd.c
@@ -120,7 +120,7 @@ void hw_setup_adc_channels(void) {
 	ADC_RegularChannelConfig(ADC1, ADC_Channel_8,  3, ADC_SampleTime_15Cycles);	// 6	ADC_IND_EXT2
 	ADC_RegularChannelConfig(ADC1, ADC_Channel_14, 4, ADC_SampleTime_15Cycles); // 9	TEMP_MOTOR
 	ADC_RegularChannelConfig(ADC1, ADC_Channel_9,  5, ADC_SampleTime_15Cycles);	// 12	V_GATE_DRIVER
-	ADC_RegularChannelConfig(ADC1, ADC_Channel_5,  6, ADC_SampleTime_15Cycles);	// 15	UNUSED
+	ADC_RegularChannelConfig(ADC1, ADC_Channel_5,  6, ADC_SampleTime_15Cycles);	// 15	TEMP_FET
 
 	// ADC2 regular channels
 	ADC_RegularChannelConfig(ADC2, ADC_Channel_1,  1, ADC_SampleTime_15Cycles);	// 1	SENS2

--- a/hwconf/hw_luna_bbshd.h
+++ b/hwconf/hw_luna_bbshd.h
@@ -66,8 +66,8 @@
 #define ADC_IND_EXT				10
 #define ADC_IND_EXT2			6
 #define ADC_IND_EXT3			13
-#define ADC_IND_TEMP_MOS		8
-#define ADC_IND_TEMP_MOS_2		15
+#define ADC_IND_TEMP_MOS		15
+#define ADC_IND_TEMP_MOS_2		8
 #define ADC_IND_TEMP_MOS_3		16
 #define ADC_IND_TEMP_MOTOR		9
 #define ADC_IND_VREFINT			16
@@ -88,7 +88,7 @@
 #define CURRENT_AMP_GAIN		20.0
 #endif
 #ifndef CURRENT_SHUNT_RES
-#define CURRENT_SHUNT_RES		(0.0005 / 3.0)
+#define CURRENT_SHUNT_RES		(0.0005 / 2.0)
 #endif
 
 // Input voltage
@@ -96,7 +96,7 @@
 
 // NTC Termistors
 #define NTC_RES(adc_val)		((4095.0 * 10000.0) / adc_val - 10000.0)
-#define NTC_TEMP(adc_ind)		(1.0 / ((logf(NTC_RES(ADC_Value[adc_ind]) / 10000.0) / 3380.0) + (1.0 / 298.15)) - 273.15)
+#define NTC_TEMP(adc_ind)		(1.0 / ((logf(NTC_RES(ADC_Value[adc_ind]) / 10000.0) / 3984.0) + (1.0 / 298.15)) - 273.15)
 
 #define NTC_RES_MOTOR(adc_val)	(10000.0 / ((4095.0 / (float)adc_val) - 1.0)) // Motor temp sensor on low side
 
@@ -202,7 +202,7 @@
 #define READ_HALL3()			palReadPad(HW_HALL_ENC_GPIO3, HW_HALL_ENC_PIN3)
 
 // Override dead time.
-#define HW_DEAD_TIME_NSEC		660.0
+#define HW_DEAD_TIME_NSEC		460.0
 
 // Default setting overrides
 #ifndef MCCONF_L_MAX_VOLTAGE

--- a/hwconf/hw_luna_bbshd.h
+++ b/hwconf/hw_luna_bbshd.h
@@ -26,6 +26,7 @@
 // HW properties
 #define HW_HAS_3_SHUNTS
 #define HW_HAS_PHASE_SHUNTS
+#define HW_HAS_GATE_DRIVER_SUPPLY_MONITOR
 #define HW_USE_BRK
 
 // Macros
@@ -62,7 +63,7 @@
 #define ADC_IND_CURR2			4
 #define ADC_IND_CURR3			5
 #define ADC_IND_VIN_SENS		11
-#define ADC_IND_GATE_DRV		12
+#define ADC_IND_VOUT_GATE_DRV	12
 #define ADC_IND_EXT				10
 #define ADC_IND_EXT2			6
 #define ADC_IND_EXT3			13
@@ -93,6 +94,9 @@
 
 // Input voltage
 #define GET_INPUT_VOLTAGE()		((V_REG / 4095.0) * (float)ADC_Value[ADC_IND_VIN_SENS] * ((VIN_R1 + VIN_R2) / VIN_R2))
+
+// 12V supply voltage
+#define GET_GATE_DRIVER_SUPPLY_VOLTAGE()	((float)ADC_VOLTS(ADC_IND_VOUT_GATE_DRV) * 11.0)
 
 // NTC Termistors
 #define NTC_RES(adc_val)		((4095.0 * 10000.0) / adc_val - 10000.0)
@@ -236,6 +240,9 @@
 #define HW_LIM_DUTY_MIN			0.0, 0.1
 #define HW_LIM_DUTY_MAX			0.0, 0.99
 #define HW_LIM_TEMP_FET			-40.0, 110.0
+
+#define HW_GATE_DRIVER_SUPPLY_MIN_VOLTAGE	10.0
+#define HW_GATE_DRIVER_SUPPLY_MAX_VOLTAGE	14.0
 
 // HW-specific functions
 

--- a/hwconf/hw_luna_bbshd.h
+++ b/hwconf/hw_luna_bbshd.h
@@ -28,6 +28,7 @@
 #define HW_HAS_PHASE_SHUNTS
 #define HW_HAS_GATE_DRIVER_SUPPLY_MONITOR
 #define HW_USE_BRK
+#define HW_BBSHD_USE_DAC
 
 // Macros
 #define LED_GREEN_GPIO			GPIOB
@@ -245,5 +246,7 @@
 #define HW_GATE_DRIVER_SUPPLY_MAX_VOLTAGE	14.0
 
 // HW-specific functions
+void hw_luna_bbshd_DAC1_setdata(uint16_t data);
+void hw_luna_bbshd_DAC2_setdata(uint16_t data);
 
 #endif /* HW_LUNA_BBSHD_H_ */

--- a/mc_interface.c
+++ b/mc_interface.c
@@ -1660,7 +1660,7 @@ void mc_interface_mc_timer_isr(bool is_second_motor) {
 	}
 #endif
 
-#ifdef HW_VERSION_AXIOM
+#ifdef HW_HAS_GATE_DRIVER_SUPPLY_MONITOR
 	if(motor->m_gate_driver_voltage > HW_GATE_DRIVER_SUPPLY_MAX_VOLTAGE) {
 		mc_interface_fault_stop(FAULT_CODE_GATE_DRIVER_OVER_VOLTAGE, is_second_motor);
 	}
@@ -1917,7 +1917,7 @@ static void update_override_limits(volatile motor_if_state_t *motor, volatile mc
 
 	UTILS_LP_FAST(motor->m_temp_motor, temp_motor, 0.1);
 
-#ifdef HW_VERSION_AXIOM
+#ifdef HW_HAS_GATE_DRIVER_SUPPLY_MONITOR
 	UTILS_LP_FAST(motor->m_gate_driver_voltage, GET_GATE_DRIVER_SUPPLY_VOLTAGE(), 0.01);
 #endif
 

--- a/terminal.c
+++ b/terminal.c
@@ -128,7 +128,7 @@ void terminal_process_string(char *str) {
 				commands_printf("Current          : %.1f", (double)fault_vec[i].current);
 				commands_printf("Current filtered : %.1f", (double)fault_vec[i].current_filtered);
 				commands_printf("Voltage          : %.2f", (double)fault_vec[i].voltage);
-#ifdef HW_VERSION_AXIOM
+#ifdef HW_HAS_GATE_DRIVER_SUPPLY_MONITOR
 				commands_printf("Gate drv voltage : %.2f", (double)fault_vec[i].gate_driver_voltage);
 #endif
 				commands_printf("Duty             : %.3f", (double)fault_vec[i].duty);
@@ -194,7 +194,7 @@ void terminal_process_string(char *str) {
 		commands_printf("Current 2 sample: %u\n", current2_samp);
 	} else if (strcmp(argv[0], "volt") == 0) {
 		commands_printf("Input voltage: %.2f\n", (double)GET_INPUT_VOLTAGE());
-#ifdef HW_VERSION_AXIOM
+#ifdef HW_HAS_GATE_DRIVER_SUPPLY_MONITOR
 		commands_printf("Gate driver power supply output voltage: %.2f\n", (double)GET_GATE_DRIVER_SUPPLY_VOLTAGE());
 #endif
 	} else if (strcmp(argv[0], "param_detect") == 0) {


### PR DESCRIPTION
This branch supports minor bbshd hw features and an observer monitor:

Disabled by default, the monitor compares the encoder angle with the estimated observer angle when using an encoder.
When using hall sensors, it compares the interpolated hall sensor angle with the observer angle.

The comparison is done only beyond sensorless rpm, when the observer is supposed to work reliably. It prevents reaching very large angle errors that ultimately result in an overcurrent condition.

Fault is triggered with a hardcoded 20° angle difference but the threshold could be exposed to the user if we find its an useful feature.