### PR TITLE
Dev fw 5 00

### DIFF
--- a/conf_general.h
+++ b/conf_general.h
@@ -24,7 +24,7 @@
 #define FW_VERSION_MAJOR			5
 #define FW_VERSION_MINOR			00
 // Set to 0 for building a release and iterate during beta test builds
-#define FW_TEST_VERSION_NUMBER		3
+#define FW_TEST_VERSION_NUMBER		4
 
 #include "datatypes.h"
 

--- a/conf_general.h
+++ b/conf_general.h
@@ -72,8 +72,8 @@
 // Mark3 version of HW60 with power switch and separate NRF UART.
 //#define HW60_IS_MK3
 
-#define HW_SOURCE "hw_60.c"
-#define HW_HEADER "hw_60.h"
+//#define HW_SOURCE "hw_60.c"
+//#define HW_HEADER "hw_60.h"
 
 //#define HW_SOURCE "hw_r2.c"
 //#define HW_HEADER "hw_r2.h"
@@ -137,8 +137,8 @@
 //#define HW_HEADER "hw_unity.h"
 
 //#define HW_DUAL_CONFIG_PARALLEL
-//#define HW_SOURCE "hw_stormcore_100d.c"
-//#define HW_HEADER "hw_stormcore_100d.h"
+#define HW_SOURCE "hw_stormcore_100d.c"
+#define HW_HEADER "hw_stormcore_100d.h"
 
 //#define HW_SOURCE "hw_stormcore_60d.c"
 //#define HW_HEADER "hw_stormcore_60d.h"

--- a/hwconf/hw.h
+++ b/hwconf/hw.h
@@ -431,6 +431,9 @@
 #ifndef ADC_IND_TEMP_MOTOR_2
 #define ADC_IND_TEMP_MOTOR_2	ADC_IND_TEMP_MOTOR
 #endif
+#ifndef  MOTOR_TEMP_LPF
+#define MOTOR_TEMP_LPF 			0.1
+#endif
 #ifndef HW_ADC_CHANNELS_EXTRA
 #define HW_ADC_CHANNELS_EXTRA	0
 #endif

--- a/hwconf/hw_stormcore_100d.c
+++ b/hwconf/hw_stormcore_100d.c
@@ -314,35 +314,37 @@ static THD_FUNCTION(mux_thread, arg) {
 
 	for (;;) {
 		ENABLE_MOS_TEMP1();
-		chThdSleepMilliseconds(1);
+		chThdSleepMicroseconds(400);
 		ADC_Value[ADC_IND_TEMP_MOS] = ADC_Value[ADC_IND_ADC_MUX];
 
 		ENABLE_MOS_TEMP2();
-		chThdSleepMilliseconds(1);
+		chThdSleepMicroseconds(400);
 		ADC_Value[ADC_IND_TEMP_MOS_M2] = ADC_Value[ADC_IND_ADC_MUX];
 
 		ENABLE_MOT_TEMP1();
-		chThdSleepMilliseconds(1);
+		chThdSleepMicroseconds(400);
 		ADC_Value[ADC_IND_TEMP_MOTOR] = ADC_Value[ADC_IND_ADC_MUX];
 
 		ENABLE_MOT_TEMP2();
-		chThdSleepMilliseconds(1);
+		chThdSleepMicroseconds(400);
 		ADC_Value[ADC_IND_TEMP_MOTOR_2] = ADC_Value[ADC_IND_ADC_MUX];
 
 		ENABLE_ADC_EXT_1();
-		chThdSleepMilliseconds(1);
+		chThdSleepMicroseconds(400);
 		ADC_Value[ADC_IND_EXT] = ADC_Value[ADC_IND_ADC_MUX];
 
+
 		ENABLE_ADC_EXT_2();
-		chThdSleepMilliseconds(1);
+		chThdSleepMicroseconds(400);
 		ADC_Value[ADC_IND_EXT2] = ADC_Value[ADC_IND_ADC_MUX];
 
 		ENABLE_ADC_EXT_3();
-		chThdSleepMilliseconds(1);
+		chThdSleepMicroseconds(400);
 		ADC_Value[ADC_IND_EXT3] = ADC_Value[ADC_IND_ADC_MUX];
 
+
 		ENABLE_V_BATT_DIV();
-		chThdSleepMilliseconds(1);
+		chThdSleepMicroseconds(300);
 		ADC_Value[ADC_IND_V_BATT] = ADC_Value[ADC_IND_ADC_MUX];
 	}
 }

--- a/hwconf/hw_stormcore_100d.h
+++ b/hwconf/hw_stormcore_100d.h
@@ -387,9 +387,15 @@
 #ifdef HW_HAS_DUAL_PARALLEL
 #define HW_LIM_CURRENT				-300.0, 300.0
 #define HW_LIM_CURRENT_ABS			0.0, 400.0
+#ifndef MCCONF_L_MAX_ABS_CURRENT
+#define MCCONF_L_MAX_ABS_CURRENT	400.0	// The maximum absolute current above which a fault is generated
+#endif
 #else
 #define HW_LIM_CURRENT				-150.0, 150.0
 #define HW_LIM_CURRENT_ABS			0.0, 200.0
+#ifndef MCCONF_L_MAX_ABS_CURRENT
+#define MCCONF_L_MAX_ABS_CURRENT	200.0	// The maximum absolute current above which a fault is generated
+#endif
 #endif
 #define HW_LIM_CURRENT_IN			-150.0, 150.0
 #define HW_LIM_VIN					6.0, 94.0

--- a/hwconf/hw_stormcore_100d.h
+++ b/hwconf/hw_stormcore_100d.h
@@ -247,7 +247,9 @@
 
 #define NTC_RES_MOTOR(adc_val)	(10000.0 / ((4095.0 / (float)adc_val) - 1.0)) // Motor temp sensor on low side
 #define NTC_TEMP_MOTOR(beta)	(1.0 / ((logf(NTC_RES_MOTOR(ADC_Value[ADC_IND_TEMP_MOTOR]) / 10000.0) / beta) + (1.0 / 298.15)) - 273.15)
-#define NTC_TEMP_MOTOR2(beta)	(1.0 / ((logf(NTC_RES_MOTOR(ADC_Value[ADC_IND_TEMP_MOTOR2]) / 10000.0) / beta) + (1.0 / 298.15)) - 273.15)
+#define NTC_TEMP_MOTOR_2(beta)	(1.0 / ((logf(NTC_RES_MOTOR(ADC_Value[ADC_IND_TEMP_MOTOR_2]) / 10000.0) / beta) + (1.0 / 298.15)) - 273.15)
+#define MOTOR_TEMP_LPF			0.01
+
 // Double samples in beginning and end for positive current measurement.
 // Useful when the shunt sense traces have noise that causes offset.
 #ifndef CURR1_DOUBLE_SAMPLE

--- a/hwconf/hw_stormcore_60d.c
+++ b/hwconf/hw_stormcore_60d.c
@@ -314,35 +314,35 @@ static THD_FUNCTION(mux_thread, arg) {
 
 	for (;;) {
 		ENABLE_MOS_TEMP1();
-		chThdSleepMilliseconds(1);
+		chThdSleepMicroseconds(400);
 		ADC_Value[ADC_IND_TEMP_MOS] = ADC_Value[ADC_IND_ADC_MUX];
 
 		ENABLE_MOS_TEMP2();
-		chThdSleepMilliseconds(1);
+		chThdSleepMicroseconds(400);
 		ADC_Value[ADC_IND_TEMP_MOS_M2] = ADC_Value[ADC_IND_ADC_MUX];
 
 		ENABLE_MOT_TEMP1();
-		chThdSleepMilliseconds(1);
+		chThdSleepMicroseconds(400);
 		ADC_Value[ADC_IND_TEMP_MOTOR] = ADC_Value[ADC_IND_ADC_MUX];
 
 		ENABLE_MOT_TEMP2();
-		chThdSleepMilliseconds(1);
+		chThdSleepMicroseconds(400);
 		ADC_Value[ADC_IND_TEMP_MOTOR_2] = ADC_Value[ADC_IND_ADC_MUX];
 
 		ENABLE_ADC_EXT_1();
-		chThdSleepMilliseconds(1);
+		chThdSleepMicroseconds(400);
 		ADC_Value[ADC_IND_EXT] = ADC_Value[ADC_IND_ADC_MUX];
 
 		ENABLE_ADC_EXT_2();
-		chThdSleepMilliseconds(1);
+		chThdSleepMicroseconds(400);
 		ADC_Value[ADC_IND_EXT2] = ADC_Value[ADC_IND_ADC_MUX];
 
 		ENABLE_ADC_EXT_3();
-		chThdSleepMilliseconds(1);
+		chThdSleepMicroseconds(400);
 		ADC_Value[ADC_IND_EXT3] = ADC_Value[ADC_IND_ADC_MUX];
 
 		ENABLE_V_BATT_DIV();
-		chThdSleepMilliseconds(1);
+		chThdSleepMicroseconds(400);
 		ADC_Value[ADC_IND_V_BATT] = ADC_Value[ADC_IND_ADC_MUX];
 	}
 }

--- a/hwconf/hw_stormcore_60d.h
+++ b/hwconf/hw_stormcore_60d.h
@@ -238,7 +238,9 @@
 
 #define NTC_RES_MOTOR(adc_val)	(10000.0 / ((4095.0 / (float)adc_val) - 1.0)) // Motor temp sensor on low side
 #define NTC_TEMP_MOTOR(beta)	(1.0 / ((logf(NTC_RES_MOTOR(ADC_Value[ADC_IND_TEMP_MOTOR]) / 10000.0) / beta) + (1.0 / 298.15)) - 273.15)
-#define NTC_TEMP_MOTOR2(beta)	(1.0 / ((logf(NTC_RES_MOTOR(ADC_Value[ADC_IND_TEMP_MOTOR2]) / 10000.0) / beta) + (1.0 / 298.15)) - 273.15)
+#define NTC_TEMP_MOTOR_2(beta)	(1.0 / ((logf(NTC_RES_MOTOR(ADC_Value[ADC_IND_TEMP_MOTOR_2]) / 10000.0) / beta) + (1.0 / 298.15)) - 273.15)
+#define MOTOR_TEMP_LPF			0.01
+
 // Double samples in beginning and end for positive current measurement.
 // Useful when the shunt sense traces have noise that causes offset.
 #ifndef CURR1_DOUBLE_SAMPLE

--- a/hwconf/hw_stormcore_60d.h
+++ b/hwconf/hw_stormcore_60d.h
@@ -368,17 +368,17 @@
 #define HW_CANTX_PIN			1
 
 
-#ifndef MCCONF_L_MAX_VOLTAGE
-#define MCCONF_L_MAX_VOLTAGE		92.0
-#endif
 #ifndef MCCONF_M_DRV8301_OC_ADJ
 #define MCCONF_M_DRV8301_OC_ADJ		14
+#endif
+#ifndef MCCONF_L_MAX_ABS_CURRENT
+#define MCCONF_L_MAX_ABS_CURRENT	200.0	// The maximum absolute current above which a fault is generated
 #endif
 // Setting limits
 #define HW_LIM_CURRENT				-150.0, 150.0
 #define HW_LIM_CURRENT_IN			-120.0, 120.0
 #define HW_LIM_CURRENT_ABS			0.0, 200.0
-#define HW_LIM_VIN					6.0, 94.0
+#define HW_LIM_VIN					6.0, 57.0
 #define HW_LIM_ERPM					-200e3, 200e3
 #define HW_LIM_DUTY_MIN				0.0, 0.1
 #define HW_LIM_DUTY_MAX				0.0, 0.95

--- a/hwconf/hw_unity.h
+++ b/hwconf/hw_unity.h
@@ -179,6 +179,7 @@
 #define NTC_RES_MOTOR(adc_val)	(10000.0 / ((4095.0 / (float)adc_val) - 1.0)) // Motor temp sensor on low side
 #define NTC_TEMP_MOTOR(beta)	(1.0 / ((logf(NTC_RES_MOTOR(ADC_Value[ADC_IND_TEMP_MOTOR]) / 10000.0) / beta) + (1.0 / 298.15)) - 273.15)
 #define NTC_TEMP_MOTOR_2(beta)	(1.0 / ((logf(NTC_RES_MOTOR(ADC_Value[ADC_IND_TEMP_MOTOR_2]) / 10000.0) / beta) + (1.0 / 298.15)) - 273.15)
+#define MOTOR_TEMP_LPF			0.01
 
 // UART Peripheral
 #define HW_UART_DEV				SD3

--- a/mc_interface.c
+++ b/mc_interface.c
@@ -1878,7 +1878,7 @@ static void update_override_limits(volatile motor_if_state_t *motor, volatile mc
 		temp_motor = -100.0;
 	}
 
-	UTILS_LP_FAST(motor->m_temp_motor, temp_motor, 0.1);
+	UTILS_LP_FAST(motor->m_temp_motor, temp_motor, MOTOR_TEMP_LPF);
 
 #ifdef HW_HAS_GATE_DRIVER_SUPPLY_MONITOR
 	UTILS_LP_FAST(motor->m_gate_driver_voltage, GET_GATE_DRIVER_SUPPLY_VOLTAGE(), 0.01);

--- a/mc_interface.c
+++ b/mc_interface.c
@@ -1346,8 +1346,10 @@ float mc_interface_get_battery_level(float *wh_left) {
 	case BATTERY_TYPE_LIION_3_0__4_2:
 		battery_avg_voltage = ((3.2 + 4.2) / 2.0) * (float)(conf->si_battery_cells);
 		battery_avg_voltage_left = ((3.2 * (float)(conf->si_battery_cells) + v_in) / 2.0);
-		ah_left = utils_map(v_in / (float)(conf->si_battery_cells),
-				3.2, 4.2, 0.0, conf->si_battery_ah);
+		float batt_left = utils_map(v_in / (float)(conf->si_battery_cells),
+									3.2, 4.2, 0.0, 1.0);
+		batt_left = utils_batt_norm_v_to_capacity(batt_left);
+		ah_left = batt_left * conf->si_battery_ah;
 		break;
 
 	case BATTERY_TYPE_LIIRON_2_6__3_6:

--- a/utils.c
+++ b/utils.c
@@ -791,6 +791,27 @@ int utils_read_hall(bool is_second_motor) {
 	return (h1 > 1) | ((h2 > 1) << 1) | ((h3 > 1) << 2);
 }
 
+// A mapping of a samsung 30q cell for % remaining capacity vs. voltage from
+// 4.2 to 3.2, note that the you lose 15% of the 3Ah rated capacity in this range
+
+
+
+float utils_batt_norm_v_to_capacity(float norm_v) {
+	// constants for polynomial fit of lithium ion battery
+	const float li_p[] = {
+						  -2.979767, 5.487810, -3.501286, 1.675683, 0.317147};
+	utils_truncate_number(&norm_v,0.0,1.0);
+	float v2 = norm_v*norm_v;
+	float v3 = v2*norm_v;
+	float v4 = v3*norm_v;
+	float v5 = v4*norm_v;
+	float capacity = li_p[0] * v5 + li_p[1] * v4 + li_p[2] * v3 +
+			li_p[3] * v2 + li_p[4] * norm_v;
+	return capacity;
+}
+
+
+
 const float utils_tab_sin_32_1[] = {
 	0.000000, 0.195090, 0.382683, 0.555570, 0.707107, 0.831470, 0.923880, 0.980785,
 	1.000000, 0.980785, 0.923880, 0.831470, 0.707107, 0.555570, 0.382683, 0.195090,

--- a/utils.h
+++ b/utils.h
@@ -61,6 +61,7 @@ void utils_fft8_bin1(float *real_in, float *real, float *imag);
 void utils_fft8_bin2(float *real_in, float *real, float *imag);
 uint8_t utils_second_motor_id(void);
 int utils_read_hall(bool is_second_motor);
+float utils_batt_norm_v_to_capacity(float norm_v) ;
 
 // Return the sign of the argument. -1 if negative, 1 if zero or positive.
 #define SIGN(x)				((x < 0) ? -1 : 1)


### PR DESCRIPTION
Should provide a slightly more accurate estimate of the remaining battery, I fit a fifth order polynomial to a discharge graph of a samsung 30q cell. I fit the graph with 3.2V (2.57 Ah) as the 0% to match with the existing method. 

Technically the watt hours left should be integrated across this curve instead of using the average remaining voltage but maybe the combination of both provides a good midway estimate between the actual curve and a line since all cells are slightly different.

![image](https://user-images.githubusercontent.com/6923970/79248831-34a5cd80-7e31-11ea-9493-8acc37e8de62.png)


![image](https://user-images.githubusercontent.com/6923970/79248281-7b46f800-7e30-11ea-81ed-0244fe08a504.png)

