### PR TITLE
Adjustment to smart reverse.

### DIFF
--- a/applications/app_nunchuk.c
+++ b/applications/app_nunchuk.c
@@ -413,10 +413,16 @@ static THD_FUNCTION(output_thread, arg) {
 				duty_control = true;
 			}
 
+			if((!was_duty_control) && (rpm_lowest < -500) && (out_val < -0.1)){
+				duty_control = true;
+				duty_rev = is_reverse ? duty_highest_abs:-duty_highest_abs;
+			}
+
 			if (duty_control || (was_duty_control && out_val < -0.1)) {
 				was_duty_control = true;
 
 				float goal = config.smart_rev_max_duty * -out_val;
+
 				utils_step_towards(&duty_rev, is_reverse ? goal : -goal,
 						config.smart_rev_max_duty * dt / config.smart_rev_ramp_time);
 

--- a/applications/app_ppm.c
+++ b/applications/app_ppm.c
@@ -376,6 +376,11 @@ static THD_FUNCTION(ppm_thread, arg) {
 				duty_control = true;
 			}
 
+			if((!was_duty_control) && (rpm_lowest < -500) && (servo_val < -0.1)){
+				duty_control = true;
+				duty_rev = -duty_highest_abs;
+			}
+
 			if (duty_control || (was_duty_control && servo_val < -0.1)) {
 				was_duty_control = true;
 


### PR DESCRIPTION
If already rolling backward switch back into duty cycle mode rather than braking.  In my opinion this feels more intuitive and can still use forward throttle to "brake" from reverse speed. 

If going in reverse above max duty then it will ramp down at the same acceleration rate as it ramps up in smart reverse.


[Idea from forum via ducktaper](https://forum.esk8.news/t/vesc-fw-5-0-beta-testers-wanted/23342/325?u=deodand)

