### PR TITLE
Only init IMU once so an external unit doesn't override UART on reboot

### DIFF
--- a/main.c
+++ b/main.c
@@ -350,7 +350,6 @@ int main(void) {
 
 	timeout_init();
 	timeout_configure(appconf->timeout_msec, appconf->timeout_brake_current);
-	imu_init(&appconf->imu_conf);
 
 	mempools_free_appconf(appconf);
 


### PR DESCRIPTION
I also wanted to wrap imu_init in app.c in a check to see if any other app is using the pins when it is external, but i'm not convinced there is a way to do it for all device configurations.

Currently when using external it will init imu, read a few values and then get its pins stolen leaving the graph looking kinda random.