### PR TITLE
Fix warnings in Travis tests

### DIFF
--- a/imu/BMI160_driver/bmi160_defs.h
+++ b/imu/BMI160_driver/bmi160_defs.h
@@ -760,7 +760,7 @@ enum bmi160_int_status_sel {
  */
 struct bmi160_int_status_bits
 {
-#if LITTLE_ENDIAN == 1
+#ifdef LITTLE_ENDIAN
     uint32_t step : 1;
     uint32_t sigmot : 1;
     uint32_t anym : 1;
@@ -793,7 +793,8 @@ struct bmi160_int_status_bits
     uint32_t orient_1_0 : 2;
     uint32_t orient_2 : 1;
     uint32_t flat : 1;
-#elif BIG_ENDIAN == 1
+#endif
+#ifdef BIG_ENDIAN
     uint32_t high_first_x : 1;
     uint32_t high_first_y : 1;
     uint32_t high_first_z : 1;
@@ -1102,7 +1103,7 @@ enum bmi160_any_sig_motion_active_interrupt_state {
 };
 struct bmi160_acc_tap_int_cfg
 {
-#if LITTLE_ENDIAN == 1
+#ifdef LITTLE_ENDIAN
 
     /*! tap threshold */
     uint16_t tap_thr : 5;
@@ -1121,7 +1122,8 @@ struct bmi160_acc_tap_int_cfg
 
     /*! tap enable, 1 - enable, 0 - disable */
     uint16_t tap_en : 1;
-#elif BIG_ENDIAN == 1
+#endif
+#ifdef BIG_ENDIAN
 
     /*! tap enable, 1 - enable, 0 - disable */
     uint16_t tap_en : 1;
@@ -1144,7 +1146,7 @@ struct bmi160_acc_tap_int_cfg
 };
 struct bmi160_acc_any_mot_int_cfg
 {
-#if LITTLE_ENDIAN == 1
+#ifdef LITTLE_ENDIAN
 
     /*! 1 any-motion enable, 0 - any-motion disable */
     uint8_t anymotion_en : 1;
@@ -1166,7 +1168,8 @@ struct bmi160_acc_any_mot_int_cfg
 
     /*! slope threshold */
     uint8_t anymotion_thr;
-#elif BIG_ENDIAN == 1
+#endif
+#ifdef BIG_ENDIAN
 
     /*! slope threshold */
     uint8_t anymotion_thr;
@@ -1192,7 +1195,7 @@ struct bmi160_acc_any_mot_int_cfg
 };
 struct bmi160_acc_sig_mot_int_cfg
 {
-#if LITTLE_ENDIAN == 1
+#ifdef LITTLE_ENDIAN
 
     /*! skip time of sig-motion interrupt */
     uint8_t sig_mot_skip : 2;
@@ -1208,7 +1211,8 @@ struct bmi160_acc_sig_mot_int_cfg
 
     /*! sig-motion threshold */
     uint8_t sig_mot_thres;
-#elif BIG_ENDIAN == 1
+#endif
+#ifdef BIG_ENDIAN
 
     /*! sig-motion threshold */
     uint8_t sig_mot_thres;
@@ -1228,7 +1232,7 @@ struct bmi160_acc_sig_mot_int_cfg
 };
 struct bmi160_acc_step_detect_int_cfg
 {
-#if LITTLE_ENDIAN == 1
+#ifdef LITTLE_ENDIAN
 
     /*! 1- step detector enable, 0- step detector disable */
     uint16_t step_detector_en : 1;
@@ -1244,7 +1248,8 @@ struct bmi160_acc_step_detect_int_cfg
 
     /*! minimum step buffer size*/
     uint16_t step_min_buf : 3;
-#elif BIG_ENDIAN == 1
+#endif
+#ifdef BIG_ENDIAN
 
     /*! minimum step buffer size*/
     uint16_t step_min_buf : 3;
@@ -1264,7 +1269,7 @@ struct bmi160_acc_step_detect_int_cfg
 };
 struct bmi160_acc_no_motion_int_cfg
 {
-#if LITTLE_ENDIAN == 1
+#ifdef LITTLE_ENDIAN
 
     /*! no motion interrupt x */
     uint16_t no_motion_x : 1;
@@ -1286,7 +1291,8 @@ struct bmi160_acc_no_motion_int_cfg
 
     /*! no motion threshold */
     uint8_t no_motion_thres;
-#elif BIG_ENDIAN == 1
+#endif
+#ifdef BIG_ENDIAN
 
     /*! no motion threshold */
     uint8_t no_motion_thres;
@@ -1312,7 +1318,7 @@ struct bmi160_acc_no_motion_int_cfg
 };
 struct bmi160_acc_orient_int_cfg
 {
-#if LITTLE_ENDIAN == 1
+#ifdef LITTLE_ENDIAN
 
     /*! thresholds for switching between the different orientations */
     uint16_t orient_mode : 2;
@@ -1334,7 +1340,8 @@ struct bmi160_acc_orient_int_cfg
 
     /*! 1 - orient enable, 0 - orient disable */
     uint8_t orient_en : 1;
-#elif BIG_ENDIAN == 1
+#endif
+#ifdef BIG_ENDIAN
 
     /*! 1 - orient enable, 0 - orient disable */
     uint8_t orient_en : 1;
@@ -1360,7 +1367,7 @@ struct bmi160_acc_orient_int_cfg
 };
 struct bmi160_acc_flat_detect_int_cfg
 {
-#if LITTLE_ENDIAN == 1
+#ifdef LITTLE_ENDIAN
 
     /*! flat threshold */
     uint16_t flat_theta : 6;
@@ -1374,7 +1381,8 @@ struct bmi160_acc_flat_detect_int_cfg
 
     /*! 1 - flat enable, 0 - flat disable */
     uint16_t flat_en : 1;
-#elif BIG_ENDIAN == 1
+#endif
+#ifdef BIG_ENDIAN
 
     /*! 1 - flat enable, 0 - flat disable */
     uint16_t flat_en : 1;
@@ -1392,7 +1400,7 @@ struct bmi160_acc_flat_detect_int_cfg
 };
 struct bmi160_acc_low_g_int_cfg
 {
-#if LITTLE_ENDIAN == 1
+#ifdef LITTLE_ENDIAN
 
     /*! low-g interrupt trigger delay */
     uint8_t low_dur;
@@ -1411,7 +1419,8 @@ struct bmi160_acc_low_g_int_cfg
 
     /*! 1 - enable low-g, 0 - disable low-g */
     uint8_t low_en : 1;
-#elif BIG_ENDIAN == 1
+#endif
+#ifdef BIG_ENDIAN
 
     /*! 1 - enable low-g, 0 - disable low-g */
     uint8_t low_en : 1;
@@ -1434,7 +1443,7 @@ struct bmi160_acc_low_g_int_cfg
 };
 struct bmi160_acc_high_g_int_cfg
 {
-#if LITTLE_ENDIAN == 1
+#ifdef LITTLE_ENDIAN
 
     /*! High-g interrupt x, 1 - enable, 0 - disable */
     uint8_t high_g_x : 1;
@@ -1456,7 +1465,8 @@ struct bmi160_acc_high_g_int_cfg
 
     /*! High-g duration */
     uint8_t high_dur;
-#elif BIG_ENDIAN == 1
+#endif
+#ifdef BIG_ENDIAN
 
     /*! High-g duration */
     uint8_t high_dur;
@@ -1482,7 +1492,7 @@ struct bmi160_acc_high_g_int_cfg
 };
 struct bmi160_int_pin_settg
 {
-#if LITTLE_ENDIAN == 1
+#ifdef LITTLE_ENDIAN
 
     /*! To enable either INT1 or INT2 pin as output.
      * 0- output disabled ,1- output enabled */
@@ -1504,7 +1514,8 @@ struct bmi160_int_pin_settg
 
     /*! latch duration*/
     uint16_t latch_dur : 4;
-#elif BIG_ENDIAN == 1
+#endif
+#ifdef BIG_ENDIAN
 
     /*! latch duration*/
     uint16_t latch_dur : 4;

--- a/mc_interface.c
+++ b/mc_interface.c
@@ -1420,7 +1420,7 @@ float mc_interface_get_distance_abs(void) {
 }
 
 setup_values mc_interface_get_setup_values(void) {
-	setup_values val = {0};
+	setup_values val = {0, 0, 0, 0, 0, 0, 0};
 	val.num_vescs = 1;
 
 	val.ah_tot += mc_interface_get_amp_hours(false);

--- a/mempools.c
+++ b/mempools.c
@@ -31,8 +31,8 @@ typedef struct {
 } appconf_container_t;
 
 // Private variables
-static mcconf_container_t m_mc_confs[MEMPOOLS_MCCONF_NUM] = {0};
-static appconf_container_t m_app_confs[MEMPOOLS_APPCONF_NUM] = {0};
+static mcconf_container_t m_mc_confs[MEMPOOLS_MCCONF_NUM] = {{0}};
+static appconf_container_t m_app_confs[MEMPOOLS_APPCONF_NUM] = {{0}};
 static int m_mcconf_highest = 0;
 static int m_appconf_highest = 0;
 


### PR DESCRIPTION
This PR fixed the warnings (such as https://travis-ci.com/github/vedderb/bldc/builds/163559020) in Travis' tests. Now the logs https://travis-ci.com/github/vedderb/bldc/builds/164865936 looks more clear.