### PR TITLE
Add ramp input to the speed PID loop.

### DIFF
--- a/confgenerator.c
+++ b/confgenerator.c
@@ -118,6 +118,8 @@ int32_t confgenerator_serialize_mcconf(uint8_t *buffer, const mc_configuration *
 	buffer_append_float32_auto(buffer, conf->s_pid_kd_filter, &ind);
 	buffer_append_float32_auto(buffer, conf->s_pid_min_erpm, &ind);
 	buffer[ind++] = conf->s_pid_allow_braking;
+	buffer[ind++] = conf->s_pid_apply_input_ramp;
+	buffer_append_float32_auto(buffer, conf->s_pid_ramp_erpms_ms, &ind);
 	buffer_append_float32_auto(buffer, conf->p_pid_kp, &ind);
 	buffer_append_float32_auto(buffer, conf->p_pid_ki, &ind);
 	buffer_append_float32_auto(buffer, conf->p_pid_kd, &ind);
@@ -410,6 +412,8 @@ bool confgenerator_deserialize_mcconf(const uint8_t *buffer, mc_configuration *c
 	conf->s_pid_kd_filter = buffer_get_float32_auto(buffer, &ind);
 	conf->s_pid_min_erpm = buffer_get_float32_auto(buffer, &ind);
 	conf->s_pid_allow_braking = buffer[ind++];
+	conf->s_pid_apply_input_ramp = buffer[ind++];
+	conf->s_pid_ramp_erpms_ms = buffer_get_float32_auto(buffer, &ind);
 	conf->p_pid_kp = buffer_get_float32_auto(buffer, &ind);
 	conf->p_pid_ki = buffer_get_float32_auto(buffer, &ind);
 	conf->p_pid_kd = buffer_get_float32_auto(buffer, &ind);
@@ -698,6 +702,8 @@ void confgenerator_set_defaults_mcconf(mc_configuration *conf) {
 	conf->s_pid_kd_filter = MCCONF_S_PID_KD_FILTER;
 	conf->s_pid_min_erpm = MCCONF_S_PID_MIN_RPM;
 	conf->s_pid_allow_braking = MCCONF_S_PID_ALLOW_BRAKING;
+	conf->s_pid_apply_input_ramp = MCCONF_S_PID_APPLY_INPUT_RAMP;
+	conf->s_pid_ramp_erpms_ms = MCCONF_S_PID_RAMP_ERPMS_MS;
 	conf->p_pid_kp = MCCONF_P_PID_KP;
 	conf->p_pid_ki = MCCONF_P_PID_KI;
 	conf->p_pid_kd = MCCONF_P_PID_KD;

--- a/confgenerator.c
+++ b/confgenerator.c
@@ -118,8 +118,7 @@ int32_t confgenerator_serialize_mcconf(uint8_t *buffer, const mc_configuration *
 	buffer_append_float32_auto(buffer, conf->s_pid_kd_filter, &ind);
 	buffer_append_float32_auto(buffer, conf->s_pid_min_erpm, &ind);
 	buffer[ind++] = conf->s_pid_allow_braking;
-	buffer[ind++] = conf->s_pid_apply_input_ramp;
-	buffer_append_float32_auto(buffer, conf->s_pid_ramp_erpms_ms, &ind);
+	buffer_append_float32_auto(buffer, conf->s_pid_ramp_erpms_s, &ind);
 	buffer_append_float32_auto(buffer, conf->p_pid_kp, &ind);
 	buffer_append_float32_auto(buffer, conf->p_pid_ki, &ind);
 	buffer_append_float32_auto(buffer, conf->p_pid_kd, &ind);
@@ -412,8 +411,7 @@ bool confgenerator_deserialize_mcconf(const uint8_t *buffer, mc_configuration *c
 	conf->s_pid_kd_filter = buffer_get_float32_auto(buffer, &ind);
 	conf->s_pid_min_erpm = buffer_get_float32_auto(buffer, &ind);
 	conf->s_pid_allow_braking = buffer[ind++];
-	conf->s_pid_apply_input_ramp = buffer[ind++];
-	conf->s_pid_ramp_erpms_ms = buffer_get_float32_auto(buffer, &ind);
+	conf->s_pid_ramp_erpms_s = buffer_get_float32_auto(buffer, &ind);
 	conf->p_pid_kp = buffer_get_float32_auto(buffer, &ind);
 	conf->p_pid_ki = buffer_get_float32_auto(buffer, &ind);
 	conf->p_pid_kd = buffer_get_float32_auto(buffer, &ind);
@@ -702,8 +700,7 @@ void confgenerator_set_defaults_mcconf(mc_configuration *conf) {
 	conf->s_pid_kd_filter = MCCONF_S_PID_KD_FILTER;
 	conf->s_pid_min_erpm = MCCONF_S_PID_MIN_RPM;
 	conf->s_pid_allow_braking = MCCONF_S_PID_ALLOW_BRAKING;
-	conf->s_pid_apply_input_ramp = MCCONF_S_PID_APPLY_INPUT_RAMP;
-	conf->s_pid_ramp_erpms_ms = MCCONF_S_PID_RAMP_ERPMS_MS;
+	conf->s_pid_ramp_erpms_s = MCCONF_S_PID_RAMP_ERPMS_S;
 	conf->p_pid_kp = MCCONF_P_PID_KP;
 	conf->p_pid_ki = MCCONF_P_PID_KI;
 	conf->p_pid_kd = MCCONF_P_PID_KD;

--- a/confgenerator.h
+++ b/confgenerator.h
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 
 // Constants
-#define MCCONF_SIGNATURE		2111869092
+#define MCCONF_SIGNATURE		1775793947
 #define APPCONF_SIGNATURE		2460147246
 
 // Functions

--- a/confgenerator.h
+++ b/confgenerator.h
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 
 // Constants
-#define MCCONF_SIGNATURE		3698540221
+#define MCCONF_SIGNATURE		2111869092
 #define APPCONF_SIGNATURE		2460147246
 
 // Functions

--- a/datatypes.h
+++ b/datatypes.h
@@ -321,6 +321,8 @@ typedef struct {
 	float s_pid_kd_filter;
 	float s_pid_min_erpm;
 	bool s_pid_allow_braking;
+	bool s_pid_apply_input_ramp;
+	float s_pid_ramp_erpms_ms;
 	// Pos PID
 	float p_pid_kp;
 	float p_pid_ki;

--- a/datatypes.h
+++ b/datatypes.h
@@ -321,8 +321,7 @@ typedef struct {
 	float s_pid_kd_filter;
 	float s_pid_min_erpm;
 	bool s_pid_allow_braking;
-	bool s_pid_apply_input_ramp;
-	float s_pid_ramp_erpms_ms;
+	float s_pid_ramp_erpms_s;
 	// Pos PID
 	float p_pid_kp;
 	float p_pid_ki;

--- a/mcconf/mcconf_default.h
+++ b/mcconf/mcconf_default.h
@@ -136,11 +136,8 @@
 #ifndef MCCONF_S_PID_ALLOW_BRAKING
 #define MCCONF_S_PID_ALLOW_BRAKING		true	// Allow braking in speed control mode
 #endif
-#ifndef MCCONF_S_PID_APPLY_INPUT_RAMP
-#define MCCONF_S_PID_APPLY_INPUT_RAMP	false	// Apply Input Ramp in speed control mode
-#endif
-#ifndef MCCONF_S_PID_RAMP_ERPMS_MS
-#define MCCONF_S_PID_RAMP_ERPMS_MS		1.0	// Default Speed Input Ramp
+#ifndef MCCONF_S_PID_RAMP_ERPMS_S
+#define MCCONF_S_PID_RAMP_ERPMS_S		-1.0	// Default Speed Input Ramp
 #endif
 
 // Position PID parameters

--- a/mcconf/mcconf_default.h
+++ b/mcconf/mcconf_default.h
@@ -136,6 +136,12 @@
 #ifndef MCCONF_S_PID_ALLOW_BRAKING
 #define MCCONF_S_PID_ALLOW_BRAKING		true	// Allow braking in speed control mode
 #endif
+#ifndef MCCONF_S_PID_APPLY_INPUT_RAMP
+#define MCCONF_S_PID_APPLY_INPUT_RAMP	false	// Apply Input Ramp in speed control mode
+#endif
+#ifndef MCCONF_S_PID_RAMP_ERPMS_MS
+#define MCCONF_S_PID_RAMP_ERPMS_MS		1.0	// Default Speed Input Ramp
+#endif
 
 // Position PID parameters
 #ifndef MCCONF_P_PID_KP

--- a/mcpwm_foc.c
+++ b/mcpwm_foc.c
@@ -800,7 +800,7 @@ void mcpwm_foc_set_duty_noramp(float dutyCycle) {
  * The electrical RPM goal value to use.
  */
 void mcpwm_foc_set_pid_speed(float rpm) {
-	if( motor_now()->m_conf->s_pid_apply_input_ramp ){
+	if( motor_now()->m_conf->s_pid_ramp_erpms_s > 0.0 ){
 		if( motor_now()->m_control_mode != CONTROL_MODE_SPEED ||
 				motor_now()->m_state != MC_STATE_RUNNING ){
 			motor_now()->m_speed_pid_set_rpm = mcpwm_foc_get_rpm();
@@ -3643,8 +3643,8 @@ static void run_pid_control_speed(float dt, volatile motor_all_state_t *motor) {
 		return;
 	}
 
-	if(conf_now->s_pid_apply_input_ramp){
-		utils_step_towards((float*)&motor->m_speed_pid_set_rpm, motor->m_speed_command_rpm, conf_now->s_pid_ramp_erpms_ms);
+	if(conf_now->s_pid_ramp_erpms_s > 0.0){
+		utils_step_towards((float*)&motor->m_speed_pid_set_rpm, motor->m_speed_command_rpm, conf_now->s_pid_ramp_erpms_s * dt);
 	}
 
 	const float rpm = mcpwm_foc_get_rpm();

--- a/mcpwm_foc.c
+++ b/mcpwm_foc.c
@@ -111,6 +111,7 @@ typedef struct {
 	bool m_output_on;
 	float m_pos_pid_set;
 	float m_speed_pid_set_rpm;
+	float m_speed_command_rpm;
 	float m_phase_now_observer;
 	float m_phase_now_observer_override;
 	bool m_phase_observer_override;
@@ -164,6 +165,7 @@ typedef struct {
 	float m_hall_dt_diff_last;
 	float m_hall_dt_diff_now;
 } motor_all_state_t;
+
 
 // Private variables
 static volatile bool m_dccal_done = false;
@@ -798,8 +800,17 @@ void mcpwm_foc_set_duty_noramp(float dutyCycle) {
  * The electrical RPM goal value to use.
  */
 void mcpwm_foc_set_pid_speed(float rpm) {
+	if( motor_now()->m_conf->s_pid_apply_input_ramp ){
+		if( motor_now()->m_control_mode != CONTROL_MODE_SPEED ||
+				motor_now()->m_state != MC_STATE_RUNNING ){
+			motor_now()->m_speed_pid_set_rpm = mcpwm_foc_get_rpm();
+		}
+		motor_now()->m_speed_command_rpm = rpm;
+	}else{
+		motor_now()->m_speed_pid_set_rpm = rpm;
+	}
+
 	motor_now()->m_control_mode = CONTROL_MODE_SPEED;
-	motor_now()->m_speed_pid_set_rpm = rpm;
 
 	if (motor_now()->m_state != MC_STATE_RUNNING) {
 		motor_now()->m_state = MC_STATE_RUNNING;
@@ -3630,6 +3641,10 @@ static void run_pid_control_speed(float dt, volatile motor_all_state_t *motor) {
 		motor->m_speed_i_term = 0.0;
 		motor->m_speed_prev_error = 0.0;
 		return;
+	}
+
+	if(conf_now->s_pid_apply_input_ramp){
+		utils_step_towards((float*)&motor->m_speed_pid_set_rpm, motor->m_speed_command_rpm, conf_now->s_pid_ramp_erpms_ms);
 	}
 
 	const float rpm = mcpwm_foc_get_rpm();


### PR DESCRIPTION
This feature works together with a pull request in Vesc Tool that adds 2 control inputs in the config file.

The goal of this ramp is to prevent large steps commands being directly fed into the PID loop. 

In our tests this ramp was extremely useful to improve the startup of the motor in Speed Control Mode. We could be able for better tune the PID, because before this, we needed to apply very small proportional and integral gains to the loop to get a smooth startup, but with worse results in stable mode.

We believe this is also useful for safety reasons, preventing that for any reason a wrong speed command is entered, causing the PID loop to inmediately try to address that command.

We added a control to disable this in Vesc Tool, so user can decide to use the ramp, or continue with previous code.

Hope you find this useful, it was day and night for us in our Dyno tests with large loads, but we also tested this with a 4.10 hw and it worked better also.


This works together with a new config file of Vesc Tool, that adds 2 variables to the Speed Pid page.

Signed-off-by: Maximiliano Cordoba <mcordoba@powerdesigns.ca>