### PR TITLE
Axiom: adds input current sensor capability.

### DIFF
--- a/hwconf/hw_axiom.c
+++ b/hwconf/hw_axiom.c
@@ -56,6 +56,7 @@
 #endif
 
 #define EEPROM_ADDR_CURRENT_GAIN	0
+#define EEPROM_ADDR_INPUT_CURRENT_GAIN	1
 
 #define BITSTREAM_CHUNK_SIZE		2000
 #define BITSTREAM_SIZE				104090		//ice40up5k
@@ -64,6 +65,11 @@
 // Variables
 static volatile bool i2c_running = false;
 static volatile float current_sensor_gain = 0.0;
+static volatile float input_current_sensor_gain = 0.0;
+static volatile float input_current_sensor_offset = 1.65;
+static volatile uint16_t input_current_sensor_offset_samples = 0;
+static volatile uint32_t input_current_sensor_offset_sum = 0;
+static volatile bool current_input_sensor_offset_start_measurement = false;
 //extern unsigned char FPGA_bitstream[BITSTREAM_SIZE];
 
 // I2C configuration
@@ -76,6 +82,7 @@ static const I2CConfig i2cfg = {
 // Private functions
 static void terminal_cmd_reset_oc(int argc, const char **argv);
 static void terminal_cmd_store_current_sensor_gain(int argc, const char **argv);
+static void terminal_cmd_store_input_current_sensor_gain(int argc, const char **argv);
 static void terminal_cmd_read_current_sensor_gain(int argc, const char **argv);
 static void spi_transfer(uint8_t *in_buf, const uint8_t *out_buf, int length);
 static void spi_begin(void);
@@ -86,6 +93,7 @@ void hw_axiom_setup_dac(void);
 void hw_axiom_configure_brownout(uint8_t);
 void hw_axiom_configure_VDD_undervoltage(void);
 float hw_axiom_read_current_sensor_gain(void);
+float hw_axiom_read_input_current_sensor_gain(void);
 inline float hw_axiom_get_current_sensor_gain(void);
 
 void hw_init_gpio(void) {
@@ -205,6 +213,12 @@ void hw_init_gpio(void) {
 			terminal_cmd_store_current_sensor_gain);
 
 	terminal_register_command_callback(
+			"axiom_store_input_current_sensor_gain",
+			"Store new input current sensor gain in [V/A]",
+			0,
+			terminal_cmd_store_input_current_sensor_gain);
+
+	terminal_register_command_callback(
 			"axiom_read_current_sensor_gain",
 			"Read current sensor gain.",
 			0,
@@ -214,6 +228,7 @@ void hw_init_gpio(void) {
 	hw_axiom_configure_FPGA();
 
 	current_sensor_gain = hw_axiom_read_current_sensor_gain();
+	input_current_sensor_gain = hw_axiom_read_input_current_sensor_gain();
 }
 
 void hw_setup_adc_channels(void) {
@@ -576,12 +591,58 @@ static void terminal_cmd_store_current_sensor_gain(int argc, const char **argv) 
 		}
 	}
 	else {
-		commands_printf("1 argument required. For example: axiom_store_current_sensor_gain 0.003761");
+		commands_printf("1 argument required. Here are some examples:");
+		commands_printf("ISB-425-A:  axiom_store_current_sensor_gain 0.003761");
+		commands_printf("HASS 100-S: axiom_store_current_sensor_gain 0.004994");
+		commands_printf("HASS 400-S: axiom_store_current_sensor_gain 0.001249");
+		commands_printf("HASS 600-S: axiom_store_current_sensor_gain 0.0008324");
+		commands_printf("HTFS 800-P: axiom_store_current_sensor_gain 0.001249");
 		commands_printf(" ");
 	}
 	commands_printf(" ");
 	return;
 }
+
+static void terminal_cmd_store_input_current_sensor_gain(int argc, const char **argv) {
+	(void)argc;
+	(void)argv;
+
+	eeprom_var current_gain;
+	if( argc == 2 ) {
+
+		sscanf(argv[1], "%f", &(current_gain.as_float));
+
+		//limit max an min argument
+		if( current_gain.as_float > 0.0 && current_gain.as_float < 1.0  ){
+			// Store data in eeprom
+			conf_general_store_eeprom_var_hw(&current_gain, EEPROM_ADDR_INPUT_CURRENT_GAIN);
+
+			//read back written data
+			input_current_sensor_gain = hw_axiom_read_input_current_sensor_gain();
+
+			if(input_current_sensor_gain == current_gain.as_float) {
+				commands_printf("Axiom input current sensor sensor gain set as %.8f", (double)input_current_sensor_gain);
+			}
+			else {
+				input_current_sensor_gain = 0.0;
+				commands_printf("Error storing EEPROM data.");
+			}
+
+		}
+		else{
+			commands_printf("argument should be > 0.00 and < 1.0");
+		}
+
+	}
+	else {
+		commands_printf("1 argument required, for example:");
+		commands_printf("4mV per A:  axiom_store_input_current_sensor_gain 0.004");
+		commands_printf(" ");
+	}
+	commands_printf(" ");
+	return;
+}
+
 
 static void terminal_cmd_read_current_sensor_gain(int argc, const char **argv) {
 	(void)argc;
@@ -589,8 +650,11 @@ static void terminal_cmd_read_current_sensor_gain(int argc, const char **argv) {
 
 	//read back written data
 	current_sensor_gain = hw_axiom_read_current_sensor_gain();
+	input_current_sensor_gain = hw_axiom_read_input_current_sensor_gain();
 
-	commands_printf("Axiom current sensor sensor gain is set as %.8f", (double)current_sensor_gain);
+	commands_printf("Axiom current sensor gain is set as %.8f", (double)current_sensor_gain);
+	commands_printf("Axiom input current sensor gain is set as %.8f", (double)input_current_sensor_gain);
+
 	commands_printf(" ");
 	return;
 }
@@ -604,6 +668,17 @@ float hw_axiom_read_current_sensor_gain() {
 		current_gain.as_float = DEFAULT_CURRENT_AMP_GAIN;
 	return current_gain.as_float;
 }
+
+float hw_axiom_read_input_current_sensor_gain(void){
+	eeprom_var current_gain;
+
+	conf_general_read_eeprom_var_hw(&current_gain, EEPROM_ADDR_INPUT_CURRENT_GAIN);
+
+	if( (current_gain.as_float <= 0.0) || (current_gain.as_float >= 1.0) )
+		current_gain.as_float = DEFAULT_INPUT_CURRENT_AMP_GAIN;
+	return current_gain.as_float;
+}
+
 
 inline float hw_axiom_get_current_sensor_gain() {
 	return current_sensor_gain;
@@ -624,4 +699,36 @@ float hw_axiom_get_highest_IGBT_temp() {
 	}
 
 	return res;
+}
+
+float hw_axiom_read_input_current(void) {
+	float ret_value = 0.0;
+	if(input_current_sensor_gain > 0.0001){
+		ret_value = ( (V_REG / 4095.0) * (float)ADC_Value[ADC_IND_EXT2] - input_current_sensor_offset ) / input_current_sensor_gain;
+	}
+	return ret_value;
+}
+
+void hw_axiom_get_input_current_offset(void){
+
+	if(current_input_sensor_offset_start_measurement){
+
+		if( input_current_sensor_offset_samples == 100 ){
+			current_input_sensor_offset_start_measurement = false;
+			input_current_sensor_offset = ((float)input_current_sensor_offset_sum) / 100.0;
+			input_current_sensor_offset *= (V_REG / 4095.0);
+		}
+		else{
+			input_current_sensor_offset_sum += 	ADC_Value[ADC_IND_EXT2];
+			input_current_sensor_offset_samples++;
+		}
+	}else{
+		input_current_sensor_offset_samples++;
+	}
+}
+
+void hw_axiom_start_input_current_sensor_offset_measurement(void){
+	current_input_sensor_offset_start_measurement = true;
+	input_current_sensor_offset_samples = 0;
+	input_current_sensor_offset_sum = 0;
 }

--- a/hwconf/hw_axiom.h
+++ b/hwconf/hw_axiom.h
@@ -27,6 +27,7 @@
 
 //#define HW_AXIOM_USE_DAC
 //#define HW_AXIOM_USE_MOTOR_TEMP
+//#define HW_HAS_INPUT_CURRENT_SENSOR
 #define HW_USE_LINE_TO_LINE
 #define	HW_AXIOM_FORCE_HIGH_CURRENT_MEASUREMENTS
 #define HW_VERSION_AXIOM
@@ -115,8 +116,11 @@
 #endif
 #define DEFAULT_CURRENT_AMP_GAIN		0.003761	//Transfer Function [V/A] for ISB-425-A
 //#define DEFAULT_CURRENT_AMP_GAIN		0.001249	//Transfer Function [V/A] for HTFS 800-P
+//#define DEFAULT_CURRENT_AMP_GAIN		0.004994	//Transfer Function [V/A] for HASS 100-S
 //#define DEFAULT_CURRENT_AMP_GAIN		0.001249	//Transfer Function [V/A] for HASS 400-S
 //#define DEFAULT_CURRENT_AMP_GAIN		0.0008324	//Transfer Function [V/A] for HASS 600-S
+
+#define DEFAULT_INPUT_CURRENT_AMP_GAIN		0.004	//Transfer Function [V/A] for 4mv/A
 
 // Component parameters (can be overridden)
 #ifndef V_REG
@@ -141,6 +145,11 @@
 
 // Input voltage
 #define GET_INPUT_VOLTAGE()				((V_REG / 4095.0) * (float)ADC_Value[ADC_IND_VIN_SENS] * (HVDC_TRANSFER_FUNCTION))
+
+//Input current
+#define GET_INPUT_CURRENT()				hw_axiom_read_input_current()
+#define GET_INPUT_CURRENT_OFFSET()		hw_axiom_get_input_current_offset()
+#define MEASURE_INPUT_CURRENT_OFFSET()	hw_axiom_start_input_current_sensor_offset_measurement()
 
 // NTC Termistors
 #define NTC_RES(adc_val)				((4095.0 * 10000.0) / adc_val - 10000.0)
@@ -319,5 +328,8 @@ void hw_axiom_DAC1_setdata(uint16_t data);
 void hw_axiom_DAC2_setdata(uint16_t data);
 float hw_axiom_get_current_sensor_gain(void);
 float hw_axiom_get_highest_IGBT_temp(void);
+float hw_axiom_read_input_current(void);
+void hw_axiom_get_input_current_offset(void);
+void hw_axiom_start_input_current_sensor_offset_measurement(void);
 
 #endif /* HW_AXIOM_H_ */

--- a/mcpwm_foc.c
+++ b/mcpwm_foc.c
@@ -193,6 +193,7 @@ static float correct_encoder(float obs_angle, float enc_angle, float speed, floa
 static float correct_hall(float angle, float dt, volatile motor_all_state_t *motor);
 static void terminal_plot_hfi(int argc, const char **argv);
 static void timer_update(volatile motor_all_state_t *motor, float dt);
+static void input_current_offset_measurement( void );
 static void hfi_update(volatile motor_all_state_t *motor);
 
 // Threads
@@ -2570,6 +2571,9 @@ void mcpwm_foc_adc_int_handler(void *p, uint32_t flags) {
 		motor_now->m_motor_state.iq = 0.0;
 		motor_now->m_motor_state.id_filter = 0.0;
 		motor_now->m_motor_state.iq_filter = 0.0;
+	#ifdef HW_HAS_INPUT_CURRENT_SENSOR
+		GET_INPUT_CURRENT_OFFSET();
+	#endif
 		motor_now->m_motor_state.i_bus = 0.0;
 		motor_now->m_motor_state.i_abs = 0.0;
 		motor_now->m_motor_state.i_abs_filter = 0.0;
@@ -2795,7 +2799,6 @@ static void timer_update(volatile motor_all_state_t *motor, float dt) {
 	utils_truncate_number_abs(&openloop_rpm, motor->m_conf->foc_openloop_rpm);
 
 	const float min_rads = (openloop_rpm * 2.0 * M_PI) / 60.0;
-
 	float add_min_speed = 0.0;
 	if (motor->m_motor_state.duty_now > 0.0) {
 		add_min_speed = min_rads * dt;
@@ -2880,6 +2883,24 @@ static void timer_update(volatile motor_all_state_t *motor, float dt) {
 	motor->m_gamma_now = gamma_tmp * 4.0;
 }
 
+static void input_current_offset_measurement( void ){
+
+#ifdef HW_HAS_INPUT_CURRENT_SENSOR
+	static uint16_t delay_current_offset_measurement = 0;
+
+	if( delay_current_offset_measurement < 1000){
+		delay_current_offset_measurement++;
+	}else{
+		if( delay_current_offset_measurement == 1000)
+		{
+			delay_current_offset_measurement++;
+			MEASURE_INPUT_CURRENT_OFFSET();
+		}
+	}
+#endif
+}
+
+
 static THD_FUNCTION(timer_thread, arg) {
 	(void)arg;
 
@@ -2897,6 +2918,8 @@ static THD_FUNCTION(timer_thread, arg) {
 #ifdef HW_HAS_DUAL_MOTORS
 		timer_update(&m_motor_2, dt);
 #endif
+
+		input_current_offset_measurement();
 
 		run_pid_control_speed(dt, &m_motor_1);
 #ifdef HW_HAS_DUAL_MOTORS
@@ -3313,8 +3336,12 @@ static void control_current(volatile motor_all_state_t *motor, float dt) {
 //	utils_truncate_number((float*)&state_m->vq_int, -max_v_mag, max_v_mag);
 
 	// TODO: Have a look at this?
+#ifdef HW_HAS_INPUT_CURRENT_SENSOR
+	state_m->i_bus = GET_INPUT_CURRENT();
+#else
 	state_m->i_bus = state_m->mod_d * state_m->id + state_m->mod_q * state_m->iq;
-	state_m->i_abs = sqrtf(SQ(state_m->id) + SQ(state_m->iq));
+#endif
+    state_m->i_abs = sqrtf(SQ(state_m->id) + SQ(state_m->iq));
 	state_m->i_abs_filter = sqrtf(SQ(state_m->id_filter) + SQ(state_m->iq_filter));
 
 	float mod_alpha = c * state_m->mod_d - s * state_m->mod_q;


### PR DESCRIPTION
use HW_HAS_INPUT_CURRENT_SENSOR in hw_axiom.h to enable it, it is commented by default

We added the possibility of using an external DC current sensor for measuring the input current, instead of calculating it indirectly. Our goal is to achieve better global system efficiency estimation.

Signed-off-by: Maximiliano Cordoba <mcordoba@powerdesigns.ca>