### PR TITLE
Update virtual motor code to work with latest Vesc v5.

### DIFF
--- a/mcpwm_foc.c
+++ b/mcpwm_foc.c
@@ -529,7 +529,7 @@ void mcpwm_foc_init(volatile mc_configuration *conf_m1, volatile mc_configuratio
 	update_hfi_samples(m_motor_2.m_conf->foc_hfi_samples, &m_motor_2);
 #endif
 
-	virtual_motor_init();
+	virtual_motor_init(conf_m1);
 
 	TIM_DeInit(TIM1);
 	TIM_DeInit(TIM2);
@@ -723,6 +723,8 @@ void mcpwm_foc_set_configuration(volatile mc_configuration *configuration) {
 		stop_pwm_hw(motor_now());
 		update_hfi_samples(motor_now()->m_conf->foc_hfi_samples, motor_now());
 	}
+
+	virtual_motor_set_configuration(configuration);
 }
 
 mc_state mcpwm_foc_get_state(void) {
@@ -2329,14 +2331,22 @@ void mcpwm_foc_adc_int_handler(void *p, uint32_t flags) {
 
 	UTILS_LP_FAST(motor_now->m_motor_state.v_bus, GET_INPUT_VOLTAGE(), 0.1);
 
-	float enc_ang = 0;
-	if (encoder_is_configured()) {
-		if (virtual_motor_is_connected()){
-			enc_ang = virtual_motor_get_angle_deg();
-		} else {
-			enc_ang = encoder_read_deg();
-		}
+	volatile float enc_ang = 0;
+	volatile bool encoder_is_being_used = false;
 
+	if(virtual_motor_is_connected()){
+		if(conf_now->foc_sensor_mode == FOC_SENSOR_MODE_ENCODER ){
+			enc_ang = virtual_motor_get_angle_deg();
+			encoder_is_being_used = true;
+		}
+	}else{
+		if (encoder_is_configured()) {
+			enc_ang = encoder_read_deg();
+			encoder_is_being_used = true;
+		}
+	}
+
+	if(encoder_is_being_used){
 		float phase_tmp = enc_ang;
 		if (conf_now->foc_encoder_inverted) {
 			phase_tmp = 360.0 - phase_tmp;
@@ -2460,7 +2470,7 @@ void mcpwm_foc_adc_int_handler(void *p, uint32_t flags) {
 
 		switch (conf_now->foc_sensor_mode) {
 		case FOC_SENSOR_MODE_ENCODER:
-			if (encoder_index_found()) {
+			if (encoder_index_found() || virtual_motor_is_connected()) {
 				motor_now->m_motor_state.phase = correct_encoder(
 						motor_now->m_phase_now_observer,
 						motor_now->m_phase_now_encoder,

--- a/virtual_motor.h
+++ b/virtual_motor.h
@@ -23,7 +23,8 @@
 
 #include "datatypes.h"
 
-void virtual_motor_init(void);
+void virtual_motor_init(volatile mc_configuration *conf);
+void virtual_motor_set_configuration(volatile mc_configuration *conf);
 void virtual_motor_int_handler(float v_alpha, float v_beta);
 bool virtual_motor_is_connected(void);
 float virtual_motor_get_angle_deg(void);


### PR DESCRIPTION
We implemented some updates to the original virtual motor library to make it more practical to work with.

The "connect_virtual_motor" terminal command only requires 3 arguments now, load torque, load inertia and battery voltage. 

connect_virtual_motor [load_torque in Nm] [load_inertia in Nm /s^2] [battery voltage in Volts]

![image](https://user-images.githubusercontent.com/48726170/85207302-422e7680-b2fe-11ea-8aeb-535cda73f298.png)

The rest of the motor characteristics, are taken from already existant variables in VESC motor configuration.

We solved also some other issues with encoder sensor, fault gate driver undervoltage (in Axiom boards) and we improved hardware dependency defines in virtual motor.c

Something interesting to point out is that this code can also be run from a stm32f4 discovery board, or any board with same MCU. So you can play with VESC code, without having a VESC board yet. For instance, just testing this pull request I was able to find a tiny bug in speed ramp code (I will make another pull request with that).

The next snapshots are taken running from a STM32F407G-DISC1 and using latest vesc tool 2.07, showing some oscillations in motor startup.

![image](https://user-images.githubusercontent.com/48726170/85207730-385a4280-b301-11ea-898c-74e4ddb65897.png)

![image](https://user-images.githubusercontent.com/48726170/85207736-490ab880-b301-11ea-956d-b744403abe7e.png)

![image](https://user-images.githubusercontent.com/48726170/85207786-af8fd680-b301-11ea-866b-9d333fff0685.png)

I hope you find this useful, some guys were asking this update in the forum, but I could not find time to do it previously.




Signed-off-by: Maximiliano Cordoba <mcordoba@powerdesigns.ca>