### PR TITLE
solved bug in speed command ramp.

### DIFF
--- a/mcpwm_foc.c
+++ b/mcpwm_foc.c
@@ -812,7 +812,6 @@ void mcpwm_foc_set_pid_speed(float rpm) {
 	}
 
 	motor_now()->m_control_mode = CONTROL_MODE_SPEED;
-	motor_now()->m_speed_pid_set_rpm = rpm;
 
 	if (motor_now()->m_state != MC_STATE_RUNNING) {
 		motor_now()->m_state = MC_STATE_RUNNING;


### PR DESCRIPTION
The input to the speed PID was being overwritten by the rpm command, so the ramp was never working.

Signed-off-by: Maximiliano Cordoba <mcordoba@powerdesigns.ca>