### PR TITLE
App PPM rework

### DIFF
--- a/applications/app_ppm.c
+++ b/applications/app_ppm.c
@@ -405,7 +405,7 @@ static THD_FUNCTION(ppm_thread, arg) {
 		}
 
 		if ((send_current || send_duty) && config.multi_esc) {
-			float current_filtered = mc_interface_get_tot_current_directional_filtered();
+
 			float duty = mc_interface_get_duty_cycle_now();
 
 			for (int i = 0;i < CAN_STATUS_MSGS_TO_STORE;i++) {
@@ -413,7 +413,7 @@ static THD_FUNCTION(ppm_thread, arg) {
 
 				if (msg->id >= 0 && UTILS_AGE_S(msg->rx_time) < MAX_CAN_AGE) {
 					if (send_current) {
-						comm_can_set_current(msg->id, current_filtered);
+						comm_can_set_current(msg->id, current);
 					} else if (send_duty) {
 						comm_can_set_duty(msg->id, duty);
 					}

--- a/conf_general.h
+++ b/conf_general.h
@@ -24,7 +24,7 @@
 #define FW_VERSION_MAJOR			5
 #define FW_VERSION_MINOR			02
 // Set to 0 for building a release and iterate during beta test builds
-#define FW_TEST_VERSION_NUMBER		4
+#define FW_TEST_VERSION_NUMBER		5
 
 #include "datatypes.h"
 


### PR DESCRIPTION
- **CHANGED** : Master keeps the slave(s) running even if a local fault occurs
- **CHANGED** : Master now sends relative value instead (%) instead of absolute value (A) (great for multiple VESC with different currents settings)
- **FIXED** : Timeout current brake feature not working
- **FIXED** : brake command sent over CANbus even if Multiple VESC over CAN disabled
- **FIXED** : delay before switching slave off in case of RX timeout
- **ADDED** : Traction control auto-disabling in case of fault on master, re-enable only if no effect on motors will happen (avoid weird behaviour exiting fault state on master).