### PR TITLE
App PPM rework

### DIFF
--- a/applications/app_ppm.c
+++ b/applications/app_ppm.c
@@ -405,7 +405,7 @@ static THD_FUNCTION(ppm_thread, arg) {
 		}
 
 		if ((send_current || send_duty) && config.multi_esc) {
-			float current_filtered = mc_interface_get_tot_current_directional_filtered();
+
 			float duty = mc_interface_get_duty_cycle_now();
 
 			for (int i = 0;i < CAN_STATUS_MSGS_TO_STORE;i++) {
@@ -413,7 +413,7 @@ static THD_FUNCTION(ppm_thread, arg) {
 
 				if (msg->id >= 0 && UTILS_AGE_S(msg->rx_time) < MAX_CAN_AGE) {
 					if (send_current) {
-						comm_can_set_current(msg->id, current_filtered);
+						comm_can_set_current(msg->id, current);
 					} else if (send_duty) {
 						comm_can_set_duty(msg->id, duty);
 					}

--- a/applications/app_ppm.c
+++ b/applications/app_ppm.c
@@ -136,6 +136,7 @@ static THD_FUNCTION(ppm_thread, arg) {
 		const float rpm_now = mc_interface_get_rpm();
 		float servo_val = servodec_get_servo(0);
 		float servo_ms = utils_map(servo_val, -1.0, 1.0, config.pulse_start, config.pulse_end);
+		static bool servoError = false;
 
 		switch (config.ctrl_type) {
 		case PPM_CTRL_TYPE_CURRENT_NOREV:
@@ -165,10 +166,23 @@ static THD_FUNCTION(ppm_thread, arg) {
 			continue;
 		}
 
-		if (timeout_has_timeout() || servodec_get_time_since_update() > timeout_get_timeout_msec() ||
-				mc_interface_get_fault() != FAULT_CODE_NONE) {
+		if (timeout_has_timeout() || servodec_get_time_since_update() > timeout_get_timeout_msec()) {
 			pulses_without_power = 0;
+			servoError = true;
+			float timeoutCurrent = timeout_get_brake_current();
+			mc_interface_set_brake_current(timeoutCurrent);
+			if(config.multi_esc){
+				for (int i = 0;i < CAN_STATUS_MSGS_TO_STORE;i++) {
+					can_status_msg *msg = comm_can_get_status_msg_index(i);
+
+					if (msg->id >= 0 && UTILS_AGE_S(msg->rx_time) < MAX_CAN_AGE) {
+						comm_can_set_current_brake(msg->id, timeoutCurrent);
+					}
+				}
+			}
 			continue;
+		} else if (mc_interface_get_fault() != FAULT_CODE_NONE){
+			pulses_without_power = 0;
 		}
 
 		// Apply deadband
@@ -202,9 +216,10 @@ static THD_FUNCTION(ppm_thread, arg) {
 		bool send_current = false;
 		bool send_duty = false;
 		static bool force_brake = true;
-		static int8_t did_idle_once = 0;
+		static int8_t did_idle_once = 0; //0 = haven't idle ;1 = idle once ; 2 = idle twice
 		float rpm_local = mc_interface_get_rpm();
 		float rpm_lowest = rpm_local;
+		float rpm_highest = rpm_local;
 
 		switch (config.ctrl_type) {
 		case PPM_CTRL_TYPE_CURRENT_BRAKE_REV_HYST:
@@ -241,7 +256,7 @@ static THD_FUNCTION(ppm_thread, arg) {
 				// too fast
 				if (force_brake){
 					current_mode_brake = true;
-				} else{
+				} else {
 					// not too fast backwards
 					if (rpm_local > -config.max_erpm_for_dir) { // for 2500 it's -2500
 						// first time that we brake and we are not too fast
@@ -278,9 +293,10 @@ static THD_FUNCTION(ppm_thread, arg) {
 		case PPM_CTRL_TYPE_CURRENT:
 		case PPM_CTRL_TYPE_CURRENT_NOREV:
 			current_mode = true;
-			if ((servo_val >= 0.0 && rpm_now > 0.0) || (servo_val < 0.0 && rpm_now < 0.0)) {
+			if ((servo_val >= 0.0 && rpm_now >= 0.0) || (servo_val < 0.0 && rpm_now <= 0.0)) { //Accelerate
 				current = servo_val * mcconf->lo_current_motor_max_now;
-			} else {
+
+			} else { //Brake
 				current = servo_val * fabsf(mcconf->lo_current_motor_min_now);
 			}
 
@@ -294,9 +310,9 @@ static THD_FUNCTION(ppm_thread, arg) {
 			current_mode = true;
 			current_mode_brake = servo_val < 0.0;
 
-			if (servo_val >= 0.0 && rpm_now > 0.0) {
+			if (servo_val >= 0.0 && rpm_now > 0.0) { //Positive input AND going forward = accelerating
 				current = servo_val * mcconf->lo_current_motor_max_now;
-			} else {
+			} else { //Negative input OR going backwards = brake (no reverse allowed in those control types)
 				current = fabsf(servo_val * mcconf->lo_current_motor_min_now);
 			}
 
@@ -332,21 +348,29 @@ static THD_FUNCTION(ppm_thread, arg) {
 		default:
 			continue;
 		}
-
+		//Safe start : If startup, servo timeout or fault, check if idle has been verified for some pulses before driving the motor
 		if (pulses_without_power < MIN_PULSES_WITHOUT_POWER && config.safe_start) {
 			static int pulses_without_power_before = 0;
 			if (pulses_without_power == pulses_without_power_before) {
 				pulses_without_power = 0;
 			}
 			pulses_without_power_before = pulses_without_power;
-			mc_interface_set_brake_current(timeout_get_brake_current());
-			continue;
+
+			if (servoError){
+				continue;
+			}
+			if (current_mode) {
+				current = 0.0;
+			}
+		} else {
+			servoError = false;
 		}
 
 		const float duty_now = mc_interface_get_duty_cycle_now();
 		float current_highest_abs = fabsf(mc_interface_get_tot_current_directional_filtered());
 		float duty_highest_abs = fabsf(duty_now);
 
+		//If multiple VESCs over CAN, store highest/lowest running values of the whole setup
 		if (config.multi_esc) {
 			for (int i = 0;i < CAN_STATUS_MSGS_TO_STORE;i++) {
 				can_status_msg *msg = comm_can_get_status_msg_index(i);
@@ -354,6 +378,10 @@ static THD_FUNCTION(ppm_thread, arg) {
 				if (msg->id >= 0 && UTILS_AGE_S(msg->rx_time) < MAX_CAN_AGE) {
 					if (fabsf(msg->rpm) < fabsf(rpm_lowest)) {
 						rpm_lowest = msg->rpm;
+					}
+
+					if (fabsf(msg->rpm) > fabsf(rpm_highest)) {
+						rpm_highest = msg->rpm;
 					}
 
 					if (fabsf(msg->current) > current_highest_abs) {
@@ -403,9 +431,9 @@ static THD_FUNCTION(ppm_thread, arg) {
 				was_duty_control = false;
 			}
 		}
-
+		//CTRL TYPE PID_NOREV & DUTY_NOREV : Acting as master, send motor control command to all slave VESCs detected on the CANbus
 		if ((send_current || send_duty) && config.multi_esc) {
-
+			float current_filtered = mc_interface_get_tot_current_directional_filtered();
 			float duty = mc_interface_get_duty_cycle_now();
 
 			for (int i = 0;i < CAN_STATUS_MSGS_TO_STORE;i++) {
@@ -413,64 +441,74 @@ static THD_FUNCTION(ppm_thread, arg) {
 
 				if (msg->id >= 0 && UTILS_AGE_S(msg->rx_time) < MAX_CAN_AGE) {
 					if (send_current) {
-						comm_can_set_current(msg->id, current);
+						comm_can_set_current(msg->id, current_filtered);
 					} else if (send_duty) {
 						comm_can_set_duty(msg->id, duty);
 					}
 				}
 			}
 		}
-
+//CTRL TYPE CURRENT
 		if (current_mode) {
-			if (current_mode_brake) {
-				mc_interface_set_brake_current(current);
+			if (current_mode_brake) { //If braking applied
+				mc_interface_set_brake_current(fabsf(current));
 
 				// Send brake command to all ESCs seen recently on the CAN bus
-				for (int i = 0;i < CAN_STATUS_MSGS_TO_STORE;i++) {
-					can_status_msg *msg = comm_can_get_status_msg_index(i);
-
-					if (msg->id >= 0 && UTILS_AGE_S(msg->rx_time) < MAX_CAN_AGE) {
-						comm_can_set_current_brake(msg->id, current);
-					}
-				}
-			} else {
-				float current_out = current;
-				bool is_reverse = false;
-				if (current_out < 0.0) {
-					is_reverse = true;
-					current_out = -current_out;
-					current = -current;
-					rpm_local = -rpm_local;
-					rpm_lowest = -rpm_lowest;
-				}
-
-				// Traction control
 				if (config.multi_esc) {
 					for (int i = 0;i < CAN_STATUS_MSGS_TO_STORE;i++) {
 						can_status_msg *msg = comm_can_get_status_msg_index(i);
 
 						if (msg->id >= 0 && UTILS_AGE_S(msg->rx_time) < MAX_CAN_AGE) {
-							if (config.tc) {
+							comm_can_set_current_brake_rel(msg->id, fabsf(servo_val));
+						}
+					}
+				}
+			} else {
+				float current_out = current;
+				bool is_reverse = false;
+				static bool autoTCdisengaged = false;
+				if (current_out < 0.0) { // Not braking AND negative current = reverse engaged
+					is_reverse = true;
+					current_out = -current_out;
+					current = -current;
+					rpm_local = -rpm_local;
+					rpm_lowest = -rpm_lowest;
+					rpm_highest = -rpm_highest;
+					servo_val = -servo_val;
+				}
+
+				// Send acceleration command to all ESCs seen recently on the CAN bus
+				if (config.multi_esc) {
+					if (config.tc) {
+						if(mc_interface_get_fault() != FAULT_CODE_NONE) {
+							autoTCdisengaged = true;
+						} else if (autoTCdisengaged && rpm_highest < rpm_local + config.tc_max_diff && rpm_lowest > rpm_local - config.tc_max_diff) { //No Fault anymore and no traction control action needed = re-enable traction control
+							autoTCdisengaged = false;
+						}
+					}
+					for (int i = 0;i < CAN_STATUS_MSGS_TO_STORE;i++) {
+						can_status_msg *msg = comm_can_get_status_msg_index(i);
+
+						if (msg->id >= 0 && UTILS_AGE_S(msg->rx_time) < MAX_CAN_AGE) {
+							//Traction Control - Applied to slaves except if a fault has occured on the local VESC (undriven wheel may generate fake RPM)
+							if (config.tc && !autoTCdisengaged) {
 								float rpm_tmp = msg->rpm;
 								if (is_reverse) {
 									rpm_tmp = -rpm_tmp;
 								}
 
 								float diff = rpm_tmp - rpm_lowest;
-								current_out = utils_map(diff, 0.0, config.tc_max_diff, current, 0.0);
-								if (current_out < mcconf->cc_min_current) {
-									current_out = 0.0;
-								}
+								servo_val = utils_map(diff, 0.0, config.tc_max_diff, servo_val, 0.0);
 							}
-
+							//Send motor drive command to slaves
 							if (is_reverse) {
-								comm_can_set_current(msg->id, -current_out);
+								comm_can_set_current_rel(msg->id, -servo_val);
 							} else {
-								comm_can_set_current(msg->id, current_out);
+								comm_can_set_current_rel(msg->id, servo_val);
 							}
 						}
 					}
-
+					//Traction Control - Applying locally
 					if (config.tc) {
 						float diff = rpm_local - rpm_lowest;
 						current_out = utils_map(diff, 0.0, config.tc_max_diff, current, 0.0);
@@ -479,7 +517,7 @@ static THD_FUNCTION(ppm_thread, arg) {
 						}
 					}
 				}
-
+				//Drive local motor
 				if (is_reverse) {
 					mc_interface_set_current(-current_out);
 				} else {

--- a/conf_general.h
+++ b/conf_general.h
@@ -24,7 +24,7 @@
 #define FW_VERSION_MAJOR			5
 #define FW_VERSION_MINOR			02
 // Set to 0 for building a release and iterate during beta test builds
-#define FW_TEST_VERSION_NUMBER		4
+#define FW_TEST_VERSION_NUMBER		5
 
 #include "datatypes.h"
 


### PR DESCRIPTION
- **CHANGED** : Master keeps the slave(s) running even if a local fault occurs
- **CHANGED** : Master now sends relative value instead (%) instead of absolute value (A) (great for multiple VESC with different currents settings)
- **FIXED** : Timeout current brake feature not working
- **FIXED** : brake command sent over CANbus even if Multiple VESC over CAN disabled
- **FIXED** : delay before switching slave off in case of RX timeout
- **ADDED** : Traction control auto-disabling in case of fault on master, re-enable only if no effect on motors will happen (avoid weird behaviour exiting fault state on master). 