### PR TITLE
MTPA hall detection

### DIFF
--- a/mcpwm_foc.c
+++ b/mcpwm_foc.c
@@ -2000,6 +2000,10 @@ bool mcpwm_foc_hall_detect(float current, uint8_t *hall_table) {
 	motor->m_control_mode = CONTROL_MODE_CURRENT;
 	motor->m_state = MC_STATE_RUNNING;
 
+	// MTPA overrides id target
+	float ldiff_old = motor->m_conf->foc_motor_ld_lq_diff;
+	motor->m_conf->foc_motor_ld_lq_diff = 0.0;
+
 	// Disable timeout
 	systime_t tout = timeout_get_timeout_msec();
 	float tout_c = timeout_get_brake_current();
@@ -2057,6 +2061,8 @@ bool mcpwm_foc_hall_detect(float current, uint8_t *hall_table) {
 	motor->m_control_mode = CONTROL_MODE_NONE;
 	motor->m_state = MC_STATE_OFF;
 	stop_pwm_hw(motor);
+
+	motor->m_conf->foc_motor_ld_lq_diff = ldiff_old;
 
 	// Enable timeout
 	timeout_configure(tout, tout_c);

--- a/mcpwm_foc.c
+++ b/mcpwm_foc.c
@@ -2562,9 +2562,9 @@ void mcpwm_foc_adc_int_handler(void *p, uint32_t flags) {
 		}
 
 		// Apply MTPA. See: https://github.com/vedderb/bldc/pull/179
-		float ld_lq_diff = conf_now->foc_motor_ld_lq_diff;
+		const float ld_lq_diff = conf_now->foc_motor_ld_lq_diff;
 		if (ld_lq_diff != 0.0) {
-			float lambda = conf_now->foc_motor_flux_linkage;
+			const float lambda = conf_now->foc_motor_flux_linkage;
 
 			id_set_tmp = (lambda - sqrtf(SQ(lambda) + 8.0 * SQ(ld_lq_diff) * SQ(iq_set_tmp))) / (4.0 * ld_lq_diff);
 			iq_set_tmp = SIGN(iq_set_tmp) * sqrtf(SQ(iq_set_tmp) - SQ(id_set_tmp));


### PR DESCRIPTION
I found that MTPA code overrides the current set by the hall_detect function, so hall table detection doesn't work if MTPA is enabled
The MTPA code had a workaround in place for encoder detection which presented the same issue, I didn't realize hall_detect needed it as well.