### PR TITLE
Firmware odometer & verify MC/APP config via CRC

### DIFF
--- a/applications/app.c
+++ b/applications/app.c
@@ -25,6 +25,7 @@
 #include "rfhelp.h"
 #include "comm_can.h"
 #include "imu.h"
+#include "crc.h"
 
 // Private variables
 static app_configuration appconf;
@@ -172,4 +173,12 @@ bool app_is_output_disabled(void) {
 static void output_vt_cb(void *arg) {
 	(void)arg;
 	output_disabled_now = false;
+}
+
+unsigned app_calc_crc(void) {
+	unsigned crc_old = appconf.crc;
+	appconf.crc = 0;
+	unsigned crc_new = crc16((uint8_t*)&(appconf), sizeof(app_configuration));
+	appconf.crc = crc_old;
+	return crc_new;
 }

--- a/applications/app.h
+++ b/applications/app.h
@@ -27,6 +27,7 @@ const app_configuration* app_get_configuration(void);
 void app_set_configuration(app_configuration *conf);
 void app_disable_output(int time_ms);
 bool app_is_output_disabled(void);
+unsigned app_calc_crc(void);
 
 // Standard apps
 void app_ppm_start(void);

--- a/commands.c
+++ b/commands.c
@@ -774,9 +774,18 @@ void commands_process_packet(unsigned char *data, unsigned int len,
 		if (mask & ((uint32_t)1 << 19)) {
 			buffer_append_float32(send_buffer, wh_batt_left, 1e3, &ind);
 		}
+		if (mask & ((uint32_t)1 << 20)) {
+			buffer_append_uint32(send_buffer, mc_interface_get_odometer(), &ind);
+		}
 
 		reply_func(send_buffer, ind);
 		chMtxUnlock(&send_buffer_mutex);
+	    } break;
+
+	case COMM_SET_ODOMETER: {
+		int32_t ind = 0;
+		mc_interface_set_odometer(buffer_get_uint32(data, &ind));
+		timeout_reset();
 	} break;
 
 	case COMM_SET_MCCONF_TEMP:

--- a/conf_general.c
+++ b/conf_general.c
@@ -33,9 +33,14 @@
 #include "confgenerator.h"
 #include "mempools.h"
 #include "worker.h"
+#include "crc.h"
+#include "terminal.h"
 
 #include <string.h>
 #include <math.h>
+
+//#define TEST_BAD_MC_CRC
+//#define TEST_BAD_APP_CRC
 
 // EEPROM settings
 #define EEPROM_BASE_MCCONF		1000
@@ -210,6 +215,22 @@ void conf_general_read_app_configuration(app_configuration *conf) {
 		}
 	}
 
+	// check CRC
+#ifdef TEST_BAD_APP_CRC
+	conf->crc++;
+#endif
+	unsigned crc_stored = conf->crc;
+	conf->crc = 0;
+	if(crc_stored != crc16((uint8_t*)conf, sizeof(app_configuration))) {
+		is_ok = false;
+		mc_interface_fault_stop(FAULT_CODE_FLASH_CORRUPTION_APP_CFG, false, false);
+		fault_data f;
+		f.fault = FAULT_CODE_FLASH_CORRUPTION_APP_CFG;
+		terminal_add_fault_data(&f);
+	} else {
+		conf->crc = crc_stored;
+	}
+
 	// Set the default configuration
 	if (!is_ok) {
 		confgenerator_set_defaults_appconf(conf);
@@ -242,6 +263,10 @@ bool conf_general_store_app_configuration(app_configuration *conf) {
 	bool is_ok = true;
 	uint8_t *conf_addr = (uint8_t*)conf;
 	uint16_t var;
+
+	//compute CRC
+	conf->crc = 0;
+	conf->crc = crc16((uint8_t*)conf, sizeof(app_configuration));
 
 	FLASH_Unlock();
 	FLASH_ClearFlag(FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR |
@@ -296,6 +321,23 @@ void conf_general_read_mc_configuration(mc_configuration *conf, bool is_motor_2)
 		}
 	}
 
+	// check CRC
+#ifdef TEST_BAD_MC_CRC
+	conf->crc++;
+#endif
+	unsigned crc_stored = conf->crc;
+
+	conf->crc = 0;
+	if(crc_stored != crc16((uint8_t*)conf, sizeof(mc_configuration))) {
+		is_ok = false;
+		mc_interface_fault_stop(FAULT_CODE_FLASH_CORRUPTION_MC_CFG, is_motor_2, false);
+		fault_data f;
+		f.fault = FAULT_CODE_FLASH_CORRUPTION_MC_CFG;
+		terminal_add_fault_data(&f);
+	} else {
+		conf->crc = crc_stored;
+	}
+
 	if (!is_ok) {
 		confgenerator_set_defaults_mcconf(conf);
 	}
@@ -327,6 +369,10 @@ bool conf_general_store_mc_configuration(mc_configuration *conf, bool is_motor_2
 	bool is_ok = true;
 	uint8_t *conf_addr = (uint8_t*)conf;
 	unsigned int base = is_motor_2 ? EEPROM_BASE_MCCONF_2 : EEPROM_BASE_MCCONF;
+
+	//compute CRC
+	conf->crc = 0;
+	conf->crc = crc16((uint8_t*)conf, sizeof(mc_configuration));
 
 	FLASH_Unlock();
 	FLASH_ClearFlag(FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR |

--- a/datatypes.h
+++ b/datatypes.h
@@ -116,6 +116,8 @@ typedef enum {
 	FAULT_CODE_ENCODER_SINCOS_BELOW_MIN_AMPLITUDE,
 	FAULT_CODE_ENCODER_SINCOS_ABOVE_MAX_AMPLITUDE,
 	FAULT_CODE_FLASH_CORRUPTION,
+	FAULT_CODE_FLASH_CORRUPTION_APP_CFG,
+	FAULT_CODE_FLASH_CORRUPTION_MC_CFG,
 	FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_1,
 	FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_2,
 	FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_3,
@@ -355,6 +357,8 @@ typedef struct {
 	BATTERY_TYPE si_battery_type;
 	int si_battery_cells;
 	float si_battery_ah;
+	// Protect from flash corruption.
+	uint16_t crc;
 } mc_configuration;
 
 // Applications to use
@@ -674,6 +678,9 @@ typedef struct {
 
 	// IMU Settings
 	imu_config imu_conf;
+
+	// Protect from flash corruption
+	uint16_t crc;
 } app_configuration;
 
 // Communication commands

--- a/datatypes.h
+++ b/datatypes.h
@@ -775,7 +775,8 @@ typedef enum {
 	COMM_SET_BLE_NAME,
 	COMM_SET_BLE_PIN,
 	COMM_SET_CAN_MODE,
-	COMM_GET_IMU_CALIBRATION
+    	COMM_GET_IMU_CALIBRATION,
+	COMM_SET_ODOMETER
 } COMM_PACKET_ID;
 
 // CAN commands
@@ -972,6 +973,8 @@ typedef union {
 
 #define EEPROM_VARS_HW			64
 #define EEPROM_VARS_CUSTOM		64
+
+#define EEPROM_ADDR_ODOMETER    1
 
 typedef struct {
 	float ah_tot;

--- a/mc_interface.c
+++ b/mc_interface.c
@@ -39,6 +39,7 @@
 #include "app.h"
 #include "utils.h"
 #include "mempools.h"
+#include "crc.h"
 
 #include <math.h>
 #include <stdlib.h>
@@ -527,6 +528,8 @@ const char* mc_interface_fault_to_string(mc_fault_code fault) {
 	case FAULT_CODE_ENCODER_SINCOS_BELOW_MIN_AMPLITUDE: return "FAULT_CODE_ENCODER_SINCOS_BELOW_MIN_AMPLITUDE"; break;
 	case FAULT_CODE_ENCODER_SINCOS_ABOVE_MAX_AMPLITUDE: return "FAULT_CODE_ENCODER_SINCOS_ABOVE_MAX_AMPLITUDE"; break;
     case FAULT_CODE_FLASH_CORRUPTION: return "FAULT_CODE_FLASH_CORRUPTION";
+    case FAULT_CODE_FLASH_CORRUPTION_APP_CFG: return "FAULT_CODE_FLASH_CORRUPTION_APP_CFG";
+    case FAULT_CODE_FLASH_CORRUPTION_MC_CFG: return "FAULT_CODE_FLASH_CORRUPTION_MC_CFG";
     case FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_1: return "FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_1";
     case FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_2: return "FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_2";
     case FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_3: return "FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_3";
@@ -2355,4 +2358,12 @@ static THD_FUNCTION(fault_stop_thread, arg) {
 
 		motor->m_fault_now = m_fault_stop_fault;
 	}
+}
+
+unsigned mc_interface_calc_crc(void) {
+	unsigned crc_old = m_motor_1.m_conf.crc;
+	m_motor_1.m_conf.crc = 0;
+	unsigned crc_new = crc16((uint8_t*)&(m_motor_1.m_conf), sizeof(mc_configuration));
+	m_motor_1.m_conf.crc = crc_old;
+	return crc_new;
 }

--- a/mc_interface.c
+++ b/mc_interface.c
@@ -114,6 +114,8 @@ static volatile bool m_sample_is_second_motor;
 static volatile mc_fault_code m_fault_stop_fault;
 static volatile bool m_fault_stop_is_second_motor;
 
+static volatile uint32_t m_odometer_meters;
+
 // Private functions
 static void update_override_limits(volatile motor_if_state_t *motor, volatile mc_configuration *conf);
 static void run_timer_tasks(volatile motor_if_state_t *motor);
@@ -156,6 +158,12 @@ void mc_interface_init(void) {
 	m_sample_mode = DEBUG_SAMPLING_OFF;
 	m_sample_mode_last = DEBUG_SAMPLING_OFF;
 	m_sample_is_second_motor = false;
+	//initialize odometer to EEPROM value
+	m_odometer_meters = 0;
+	eeprom_var v;
+	if(conf_general_read_eeprom_var_custom(&v, EEPROM_ADDR_ODOMETER)) {
+		m_odometer_meters = v.as_u32;
+	}
 
 	// Start threads
 	chThdCreateStatic(timer_thread_wa, sizeof(timer_thread_wa), NORMALPRIO, timer_thread, NULL);
@@ -2366,4 +2374,36 @@ unsigned mc_interface_calc_crc(void) {
 	unsigned crc_new = crc16((uint8_t*)&(m_motor_1.m_conf), sizeof(mc_configuration));
 	m_motor_1.m_conf.crc = crc_old;
 	return crc_new;
+}
+
+/**
+ * Set odometer value in meters.
+ *
+ * @param new_odometer_meters
+ * new odometer value in meters
+ */
+void mc_interface_set_odometer(uint32_t new_odometer_meters) {
+	m_odometer_meters = new_odometer_meters - roundf(mc_interface_get_distance_abs());
+}
+
+/**
+ * Return current odometer value in meters.
+ *
+ * @return
+ * Odometer value in meters, including current trip
+ */
+uint32_t mc_interface_get_odometer(void) {
+	return m_odometer_meters + roundf(mc_interface_get_distance_abs());
+}
+
+/**
+ * Save current odometer value to persistent memory
+ *
+ * @return
+ * success
+ */
+bool mc_interface_save_odometer(void) {
+	eeprom_var v;
+	v.as_u32 = mc_interface_get_odometer();
+	return conf_general_store_eeprom_var_custom(&v, EEPROM_ADDR_ODOMETER);
 }

--- a/mc_interface.h
+++ b/mc_interface.h
@@ -30,6 +30,7 @@ void mc_interface_select_motor_thread(int motor);
 int mc_interface_get_motor_thread(void);
 const volatile mc_configuration* mc_interface_get_configuration(void);
 void mc_interface_set_configuration(mc_configuration *configuration);
+unsigned mc_interface_calc_crc(void);
 void mc_interface_set_pwm_callback(void (*p_func)(void));
 void mc_interface_lock(void);
 void mc_interface_unlock(void);

--- a/mc_interface.h
+++ b/mc_interface.h
@@ -84,6 +84,12 @@ float mc_interface_get_battery_level(float *wh_left);
 float mc_interface_get_speed(void);
 float mc_interface_get_distance(void);
 float mc_interface_get_distance_abs(void);
+
+// odometer
+uint32_t mc_interface_get_odometer(void);
+void mc_interface_set_odometer(uint32_t new_odometer_meters);
+bool mc_interface_save_odometer(void);
+
 setup_values mc_interface_get_setup_values(void);
 
 // MC implementation functions

--- a/terminal.c
+++ b/terminal.c
@@ -162,6 +162,10 @@ void terminal_process_string(char *str) {
 		commands_printf("Electrical RPM: %.2f rpm\n", (double)mc_interface_get_rpm());
 	} else if (strcmp(argv[0], "tacho") == 0) {
 		commands_printf("Tachometer counts: %i\n", mc_interface_get_tachometer_value(0));
+	} else if (strcmp(argv[0], "dist") == 0) {
+		commands_printf("Trip dist.      : %.2f m", (double)mc_interface_get_distance());
+		commands_printf("Trip dist. (ABS): %.2f m", (double)mc_interface_get_distance_abs());
+		commands_printf("Odometer        : %u   m\n", mc_interface_get_odometer());
 	} else if (strcmp(argv[0], "tim") == 0) {
 		chSysLock();
 		volatile int t1_cnt = TIM1->CNT;

--- a/terminal.c
+++ b/terminal.c
@@ -37,6 +37,7 @@
 #include "comm_usb.h"
 #include "comm_usb_serial.h"
 #include "mempools.h"
+#include "crc.h"
 
 #include <string.h>
 #include <stdio.h>
@@ -959,7 +960,17 @@ void terminal_process_string(char *str) {
 			commands_printf("This command requires one argument.\n");
 		}
 	}
+	else if (strcmp(argv[0], "build_date") == 0) {
+		    commands_printf("Build date and time: %s at %s\n", __DATE__, __TIME__);
+	} else if (strcmp(argv[0], "crc") == 0) {
+	            unsigned mc_crc0 = mc_interface_get_configuration()->crc;
+                    unsigned mc_crc1 = mc_interface_calc_crc();
+                    commands_printf(" MC CFG crc: 0x%04X (stored)  0x%04X (recalc)", mc_crc0, mc_crc1);
 
+                    unsigned app_crc0 = app_get_configuration()->crc;
+                    unsigned app_crc1 = app_calc_crc();
+                    commands_printf("APP CFG crc: 0x%04X (stored)  0x%04X (recalc)\n", app_crc0, app_crc1);
+        }
 	// The help command
 	else if (strcmp(argv[0], "help") == 0) {
 		commands_printf("Valid commands are:");
@@ -1084,6 +1095,9 @@ void terminal_process_string(char *str) {
 
 		commands_printf("hall_analyze [current]");
 		commands_printf("  Rotate motor in open loop and analyze hall sensors.");
+
+		commands_printf("crc");
+		commands_printf("  Print CRC values.");
 
 		for (int i = 0;i < callback_write;i++) {
 			if (callbacks[i].cbf == 0) {


### PR DESCRIPTION
Store odometer in emulated EEPROM (update at shutdown).
   * New "dist" terminal command shows odometer and trip distances.
   * Odometer value is sent to UI via COMM_GET_VALUES_SETUP.
   * UI can set the odometer via COMM_SET_ODOMETER.
   * Unfortunately, the bootloader clears the odometer to 0 when FW is reprogrammed.

FLASH will be written a little more, so verify integrity of MC and APP config with CRC.
   * Currently the FW code has CRC checks, but configs are also important!
   * This helps maintain FLASH integrity when the config pages are occasionally
      re-written due to odometer updates.
   * If the config CRC checks fail, store the fault and fall back to default config.
   * New 'crc' terminal command displays CRC values.

[Pull request to display the odometer in VESC Tool.](https://github.com/vedderb/vesc_tool/pull/93#issue-493626958)