### PR TITLE
Lower default fault stop time

### DIFF
--- a/mcconf/mcconf_default.h
+++ b/mcconf/mcconf_default.h
@@ -385,7 +385,7 @@
 
 // Misc
 #ifndef MCCONF_M_FAULT_STOP_TIME
-#define MCCONF_M_FAULT_STOP_TIME		500	// Ignore commands for this duration in msec when faults occur
+#define MCCONF_M_FAULT_STOP_TIME		85	// Ignore commands for this duration in msec when faults occur
 #endif
 #ifndef MCCONF_M_RAMP_STEP
 #define MCCONF_M_RAMP_STEP				0.02	// Duty cycle ramping step (1000 times/sec) at maximum duty cycle


### PR DESCRIPTION
The high default of 500ms can easily knock folks off their electric longboards --- and after lots of experience, I feel like sub-100ms values work better. It could be more risky for some hardware but I feel like it's safer for most humans. Given the choice between body or ESC I will choose body every time.

I'd like to propose changing this default.

This updates the default Fault Stop Time in the Motor > General > Advanced tab, for hardware that hasn't provided its own value.

In combination with https://github.com/vedderb/vesc_tool/pull/95