### PR TITLE
Lower default duty cycle current limit start

### DIFF
--- a/mcconf/mcconf_default.h
+++ b/mcconf/mcconf_default.h
@@ -114,7 +114,7 @@
 #define MCCONF_L_CURRENT_MIN_SCALE		1.0	// Minimum current scale
 #endif
 #ifndef MCCONF_L_DUTY_START
-#define MCCONF_L_DUTY_START				1.0 // Start limiting current at this duty cycle
+#define MCCONF_L_DUTY_START				0.85 // Start limiting current at this duty cycle
 #endif
 
 // Speed PID parameters


### PR DESCRIPTION
This needs to default less than Maximum Duty Cycle which defaults to 95%.

This updates the default Duty Cycle Current Limit Start in the Motor > General > Advanced tab, for hardware that hasn't provided its own value.

In combination with https://github.com/vedderb/vesc_tool/pull/94