### PR TITLE
Fixed two issues relating to libcanard and updated library

### DIFF
--- a/libcanard/canard.h
+++ b/libcanard/canard.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 UAVCAN Team
+ * Copyright (c) 2016-2019 UAVCAN Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,7 +30,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
-//#include <assert.h>
+#include <assert.h>
 
 /// Build configuration header. Use it to provide your overrides.
 #if defined(CANARD_ENABLE_CUSTOM_BUILD_CONFIG) && CANARD_ENABLE_CUSTOM_BUILD_CONFIG
@@ -47,8 +47,7 @@ extern "C" {
 
 /// By default this macro resolves to the standard assert(). The user can redefine this if necessary.
 #ifndef CANARD_ASSERT
-//# define CANARD_ASSERT(x)   assert(x)
-#define CANARD_ASSERT(x)
+# define CANARD_ASSERT(x)   assert(x)
 #endif
 
 #define CANARD_GLUE(a, b)           CANARD_GLUE_IMPL_(a, b)
@@ -66,12 +65,20 @@ extern "C" {
 #endif
 
 /// Error code definitions; inverse of these values may be returned from API calls.
-#define CANARD_OK                                   0
+#define CANARD_OK                                      0
 // Value 1 is omitted intentionally, since -1 is often used in 3rd party code
-#define CANARD_ERROR_INVALID_ARGUMENT               2
-#define CANARD_ERROR_OUT_OF_MEMORY                  3
-#define CANARD_ERROR_NODE_ID_NOT_SET                4
-#define CANARD_ERROR_INTERNAL                       9
+#define CANARD_ERROR_INVALID_ARGUMENT                  2
+#define CANARD_ERROR_OUT_OF_MEMORY                     3
+#define CANARD_ERROR_NODE_ID_NOT_SET                   4
+#define CANARD_ERROR_INTERNAL                          9
+#define CANARD_ERROR_RX_INCOMPATIBLE_PACKET            10
+#define CANARD_ERROR_RX_WRONG_ADDRESS                  11
+#define CANARD_ERROR_RX_NOT_WANTED                     12
+#define CANARD_ERROR_RX_MISSED_START                   13
+#define CANARD_ERROR_RX_WRONG_TOGGLE                   14
+#define CANARD_ERROR_RX_UNEXPECTED_TID                 15
+#define CANARD_ERROR_RX_SHORT_FRAME                    16
+#define CANARD_ERROR_RX_BAD_CRC                        17
 
 /// The size of a memory block in bytes.
 #define CANARD_MEM_BLOCK_SIZE                       32U
@@ -418,10 +425,12 @@ void canardPopTxQueue(CanardInstance* ins);
 /**
  * Processes a received CAN frame with a timestamp.
  * The application will call this function when it receives a new frame from the CAN bus.
+ *
+ * Return value will report any errors in decoding packets.
  */
-void canardHandleRxFrame(CanardInstance* ins,
-                         const CanardCANFrame* frame,
-                         uint64_t timestamp_usec);
+int16_t canardHandleRxFrame(CanardInstance* ins,
+                            const CanardCANFrame* frame,
+                            uint64_t timestamp_usec);
 
 /**
  * Traverses the list of transfers and removes those that were last updated more than timeout_usec microseconds ago.

--- a/libcanard/canard_driver.c
+++ b/libcanard/canard_driver.c
@@ -306,6 +306,7 @@ static THD_FUNCTION(canard_thread, arg) {
 
 	systime_t last_status_time = 0;
 	systime_t last_esc_status_time = 0;
+	bool idSet = false;
 
 	for (;;) {
 		const app_configuration *conf = app_get_configuration();
@@ -314,8 +315,13 @@ static THD_FUNCTION(canard_thread, arg) {
 			chThdSleepMilliseconds(100);
 			continue;
 		}
-
-		canardSetLocalNodeID(&canard, conf->controller_id);
+		
+		if (!idSet) {
+			// Setting id is only allowed to happen once 
+			// else assert is called
+			canardSetLocalNodeID(&canard, conf->controller_id);
+			idSet = true;
+		}
 
 		CANRxFrame *rxmsg;
 		while ((rxmsg = comm_can_get_rx_frame()) != 0) {

--- a/libcanard/canard_internals.h
+++ b/libcanard/canard_internals.h
@@ -70,8 +70,8 @@ CANARD_INTERNAL uint16_t extractDataType(uint32_t id);
 CANARD_INTERNAL void pushTxQueue(CanardInstance* ins,
                                  CanardTxQueueItem* item);
 
-CANARD_INTERNAL bool isPriorityHigher(uint32_t id,
-                                      uint32_t rhs);
+CANARD_INTERNAL bool isPriorityHigher(uint32_t self,
+                                      uint32_t other);
 
 CANARD_INTERNAL CanardTxQueueItem* createTxItem(CanardPoolAllocator* allocator);
 

--- a/main.c
+++ b/main.c
@@ -246,14 +246,16 @@ int main(void) {
 	comm_usb_init();
 #endif
 
-#if CAN_ENABLE
-	comm_can_init();
-#endif
-
 	app_configuration *appconf = mempools_alloc_appconf();
 	conf_general_read_app_configuration(appconf);
 	app_set_configuration(appconf);
 	app_uartcomm_start_permanent();
+
+//Can in uavcan mode needs app config to be valid before init to retrieve
+//the nodeId
+#if CAN_ENABLE
+	comm_can_init();
+#endif
 
 #ifdef HW_HAS_PERMANENT_NRF
 	conf_general_permanent_nrf_found = nrf_driver_init();


### PR DESCRIPTION
After updating libcanard (50c95ac) and enabling UAVCAN in appconfig the canard thread locked up due to setNodeId being called in every iteration (068f5ad). This happens now because the update put in the assertions again that were commented out. Was there a specific reason for this? A local fork runs the library with assertions without problems.

Also after looking through the code appconfig is loaded after the can thread is started 1321299 which needs config to be ready for nodeId. This might not be an issue because its unlikely that the main thread is preempted exactly before the loading is finished.