### PR TITLE
[COMM_GET_VALUES] Unity should return second motor controller ID if that is the selected thread

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -345,7 +345,13 @@ void commands_process_packet(unsigned char *data, unsigned int len,
 			buffer_append_float32(send_buffer, mc_interface_get_pid_pos_now(), 1e6, &ind);
 		}
 		if (mask & ((uint32_t)1 << 17)) {
-			send_buffer[ind++] = app_get_configuration()->controller_id;
+			uint8_t current_controller_id = app_get_configuration()->controller_id;
+			#ifdef HW_HAS_DUAL_MOTORS
+				if (mc_interface_get_motor_thread() == 2) {
+					current_controller_id = utils_second_motor_id();
+				}
+			#endif
+			send_buffer[ind++] = current_controller_id;
 		}
 		if (mask & ((uint32_t)1 << 18)) {
 			buffer_append_float16(send_buffer, NTC_TEMP_MOS1(), 1e1, &ind);


### PR DESCRIPTION
This addresses: https://github.com/vedderb/bldc/issues/231