### PR TITLE
Feature app io default hw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ build
 .project
 .cproject
 .settings/language.settings.xml
+bldc.config
+bldc.creator
+bldc.creator.user
+bldc.files
+bldc.includes

--- a/applications/app.c
+++ b/applications/app.c
@@ -53,6 +53,7 @@ void app_set_configuration(app_configuration *conf) {
 	app_uartcomm_stop();
 	app_nunchuk_stop();
 	app_balance_stop();
+	app_io_stop();
 
 	if (!conf_general_permanent_nrf_found) {
 		nrf_driver_stop();
@@ -135,6 +136,9 @@ void app_set_configuration(app_configuration *conf) {
 #ifdef APP_CUSTOM_TO_USE
 	app_custom_configure(&appconf);
 #endif
+
+	app_io_start();
+	app_io_configure(&appconf);
 
 	rfhelp_update_conf(&appconf.app_nrf_conf);
 }

--- a/applications/app.h
+++ b/applications/app.h
@@ -69,6 +69,10 @@ uint16_t app_balance_get_switch_state(void);
 float app_balance_get_adc1(void);
 float app_balance_get_adc2(void);
 
+void app_io_start(void);
+void app_io_stop(void);
+void app_io_configure(app_configuration *conf);
+
 // Custom apps
 void app_custom_start(void);
 void app_custom_stop(void);

--- a/applications/app_io.c
+++ b/applications/app_io.c
@@ -1,0 +1,150 @@
+/*
+	Copyright 2019 Benjamin Vedder	benjamin@vedder.se
+
+	This file is part of the VESC firmware.
+
+	The VESC firmware is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    The VESC firmware is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    */
+
+#include "app.h"
+#include "ch.h"
+#include "hal.h"
+
+// Some useful includes
+#include "mc_interface.h"
+#include "utils.h"
+#include "encoder.h"
+#include "terminal.h"
+#include "comm_can.h"
+#include "hw.h"
+#include "commands.h"
+#include "timeout.h"
+
+#include <math.h>
+#include <string.h>
+#include <stdio.h>
+
+typedef enum tag_IO_PAD {
+	TX_PAD = 0,
+	RX_PAD = 1,
+} IO_PAD;
+
+// Threads
+static THD_FUNCTION(io_thread, arg);
+static THD_WORKING_AREA(io_thread_wa, 2048);
+
+// Private functions
+static void control_io(int argc, const char **argv);
+
+// Private variables
+static volatile bool stop_now = true;
+static volatile bool is_running = false;
+static bool b_isInit = false;
+
+// Called when the io application is started. Start our
+// threads here and set up callbacks.
+void app_io_start(void) {
+
+	stop_now = false;
+	chThdCreateStatic(io_thread_wa, sizeof(io_thread_wa),
+			NORMALPRIO, io_thread, NULL);
+
+	// Terminal commands for the VESC Tool terminal can be registered.
+	terminal_register_command_callback(
+			"io",
+			"Use tx(0) and rx(1) pins as digital output",
+			"[pin] [state]",
+			control_io);
+}
+
+// Called when the custom application is stopped. Stop our threads
+// and release callbacks.
+void app_io_stop(void) {
+	terminal_unregister_callback(control_io);
+
+	stop_now = true;
+	while (is_running) {
+		chThdSleepMilliseconds(1);
+	}
+}
+
+void app_io_configure(app_configuration *conf) {
+	(void)conf;
+}
+
+static THD_FUNCTION(io_thread, arg) {
+	(void)arg;
+
+	chRegSetThreadName("App IO");
+
+	is_running = true;
+
+	for(;;) {
+		// Check if it is time to stop.
+		if (stop_now) {
+			is_running = false;
+			return;
+		}
+
+		timeout_reset(); // Reset timeout if everything is OK.
+
+		// Run your logic here. A lot of functionality is available in mc_interface.h.
+
+		chThdSleepMilliseconds(10);
+	}
+}
+
+// Callback function for the terminal command with arguments.
+static void control_io(int argc, const char **argv) {
+
+	if (b_isInit != true) {
+		palSetPadMode(HW_UART_TX_PORT, HW_UART_TX_PIN, PAL_MODE_OUTPUT_PUSHPULL);
+		palSetPadMode(HW_UART_RX_PORT, HW_UART_RX_PIN, PAL_MODE_OUTPUT_PUSHPULL);
+		palClearPad(HW_UART_TX_PORT, HW_UART_TX_PIN);
+		palClearPad(HW_UART_RX_PORT, HW_UART_RX_PIN);
+		b_isInit = true;
+	}
+
+	if (argc == 3) {
+		int pad = -1;
+		int state = -1;
+		sscanf(argv[1], "%d", &pad);
+		sscanf(argv[2], "%d", &state);
+
+		switch (pad) {
+			case TX_PAD:
+				if (state) {
+					palSetPad(HW_UART_TX_PORT, HW_UART_TX_PIN);
+				} else {
+					palClearPad(HW_UART_TX_PORT, HW_UART_TX_PIN);
+				}
+				break;
+
+			case RX_PAD:
+				if (state) {
+					palSetPad(HW_UART_RX_PORT, HW_UART_RX_PIN);
+				} else {
+					palClearPad(HW_UART_RX_PORT, HW_UART_RX_PIN);
+				}
+				break;
+
+			default:
+				commands_printf("Unsuported PAD index.\n");
+				break;
+		}
+	}
+	commands_printf("IO TX %d RX %d\n",
+									palReadPad(HW_UART_TX_PORT, HW_UART_TX_PIN),
+									palReadPad(HW_UART_RX_PORT, HW_UART_RX_PIN) );
+}

--- a/applications/applications.mk
+++ b/applications/applications.mk
@@ -5,7 +5,7 @@ APPSRC =	applications/app.c \
 			applications/app_uartcomm.c \
 			applications/app_nunchuk.c \
 			applications/app_balance.c \
-      applications/app_custom.c \
-      applications/app_io.c
+			applications/app_custom.c \
+			applications/app_io.c
 
 APPINC = applications

--- a/applications/applications.mk
+++ b/applications/applications.mk
@@ -5,6 +5,7 @@ APPSRC =	applications/app.c \
 			applications/app_uartcomm.c \
 			applications/app_nunchuk.c \
 			applications/app_balance.c \
-			applications/app_custom.c
+      applications/app_custom.c \
+      applications/app_io.c
 
 APPINC = applications

--- a/conf_general.h
+++ b/conf_general.h
@@ -63,18 +63,18 @@
 //#define HW_SOURCE "hw_49.c"
 //#define HW_HEADER "hw_49.h"
 
-//#define HW_SOURCE "hw_410.c" // Also for 4.11 and 4.12
-//#define HW_HEADER "hw_410.h" // Also for 4.11 and 4.12
+#define HW_SOURCE "hw_410.c" // Also for 4.11 and 4.12
+#define HW_HEADER "hw_410.h" // Also for 4.11 and 4.12
 
 // Benjamins first HW60 PCB with PB5 and PB6 swapped
 //#define HW60_VEDDER_FIRST_PCB
 
 // Mark3 version of HW60 with power switch and separate NRF UART.
 //#define HW60_IS_MK3
-#define HW60_IS_MK4
+//#define HW60_IS_MK4
 
-#define HW_SOURCE "hw_60.c"
-#define HW_HEADER "hw_60.h"
+//#define HW_SOURCE "hw_60.c"
+//#define HW_HEADER "hw_60.h"
 
 //#define HW_SOURCE "hw_r2.c"
 //#define HW_HEADER "hw_r2.h"

--- a/conf_general.h
+++ b/conf_general.h
@@ -63,18 +63,18 @@
 //#define HW_SOURCE "hw_49.c"
 //#define HW_HEADER "hw_49.h"
 
-#define HW_SOURCE "hw_410.c" // Also for 4.11 and 4.12
-#define HW_HEADER "hw_410.h" // Also for 4.11 and 4.12
+//#define HW_SOURCE "hw_410.c" // Also for 4.11 and 4.12
+//#define HW_HEADER "hw_410.h" // Also for 4.11 and 4.12
 
 // Benjamins first HW60 PCB with PB5 and PB6 swapped
 //#define HW60_VEDDER_FIRST_PCB
 
 // Mark3 version of HW60 with power switch and separate NRF UART.
 //#define HW60_IS_MK3
-//#define HW60_IS_MK4
+#define HW60_IS_MK4
 
-//#define HW_SOURCE "hw_60.c"
-//#define HW_HEADER "hw_60.h"
+#define HW_SOURCE "hw_60.c"
+#define HW_HEADER "hw_60.h"
 
 //#define HW_SOURCE "hw_r2.c"
 //#define HW_HEADER "hw_r2.h"


### PR DESCRIPTION
Added io app to reconfigure UART pins as output digital pins. 
Control of pins is done using VESC terminal messages.
App is always started by default, but pins are only configured after a call to the io app.