### PR TITLE
NTC100k Motor Temperature Sensor support

### DIFF
--- a/confgenerator.h
+++ b/confgenerator.h
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 
 // Constants
-#define MCCONF_SIGNATURE		1050464887
+#define MCCONF_SIGNATURE		2211848314
 #define APPCONF_SIGNATURE		3264926020
 
 // Functions

--- a/datatypes.h
+++ b/datatypes.h
@@ -76,6 +76,7 @@ typedef enum {
 	TEMP_SENSOR_NTC_10K_25C = 0,
 	TEMP_SENSOR_PTC_1K_100C,
 	TEMP_SENSOR_KTY83_122,
+	TEMP_SENSOR_NTC_100K_25C,
 } temp_sensor_type;
 
 // General purpose drive output mode

--- a/hwconf/hw.h
+++ b/hwconf/hw.h
@@ -419,6 +419,14 @@
 #endif
 #endif
 
+#ifndef NTC100K_TEMP_MOTOR
+#if defined(NTC_RES_MOTOR) && defined(ADC_IND_TEMP_MOTOR)
+#define NTC100K_TEMP_MOTOR(beta)	(1.0 / ((logf(NTC_RES_MOTOR(ADC_Value[ADC_IND_TEMP_MOTOR]) / 100000.0) / beta) + (1.0 / 298.15)) - 273.15)
+#else
+#define NTC100K_TEMP_MOTOR(beta)			0.0
+#endif
+#endif
+
 // Default second motor defines
 #ifndef READ_HALL1_2
 #define READ_HALL1_2()			READ_HALL1()
@@ -434,6 +442,9 @@
 #endif
 #ifndef NTC_TEMP_MOTOR_2
 #define NTC_TEMP_MOTOR_2(beta)	NTC_TEMP_MOTOR(beta)
+#endif
+#ifndef NTC100K_TEMP_MOTOR_2
+#define NTC100K_TEMP_MOTOR_2(beta)	NTC100K_TEMP_MOTOR(beta)
 #endif
 #ifndef ADC_IND_TEMP_MOTOR_2
 #define ADC_IND_TEMP_MOTOR_2	ADC_IND_TEMP_MOTOR

--- a/mc_interface.c
+++ b/mc_interface.c
@@ -1885,6 +1885,10 @@ static void update_override_limits(volatile motor_if_state_t *motor, volatile mc
 		temp_motor = is_motor_1 ? NTC_TEMP_MOTOR(conf->m_ntc_motor_beta) : NTC_TEMP_MOTOR_2(conf->m_ntc_motor_beta);
 		break;
 
+	case TEMP_SENSOR_NTC_100K_25C:
+		temp_motor = is_motor_1 ? NTC100K_TEMP_MOTOR(conf->m_ntc_motor_beta) : NTC100K_TEMP_MOTOR_2(conf->m_ntc_motor_beta);
+		break;
+
 	case TEMP_SENSOR_PTC_1K_100C:
 		temp_motor = is_motor_1 ? PTC_TEMP_MOTOR(1000.0, conf->m_ptc_motor_coeff, 100) : PTC_TEMP_MOTOR_2(1000.0, conf->m_ptc_motor_coeff, 100);
 		break;


### PR DESCRIPTION
Many earlier PHUB188 hubs (used by Fungineers balance vehicles and others) still have 100kOhm thermistors - this commit adds the support for it.