### PR TITLE
Match Focer hardware names to firmware directories

### DIFF
--- a/hwconf/hw_Cheap_FOCer_2.h
+++ b/hwconf/hw_Cheap_FOCer_2.h
@@ -20,7 +20,7 @@
 #ifndef HW_Cheap_FOCer_2
 #define HW_Cheap_FOCer_2
 
-#define HW_NAME					"Cheap FOCer 2"
+#define HW_NAME					"Cheap_FOCer_2"
 
 // HW properties
 #define HW_HAS_DRV8301

--- a/hwconf/hw_Little_FOCer.h
+++ b/hwconf/hw_Little_FOCer.h
@@ -22,7 +22,7 @@
 
 #include "drv8323s.h"
 
-#define HW_NAME                 "Little FOCer"
+#define HW_NAME                 "Little_FOCer"
 
 // HW properties
 #define HW_HAS_DRV8323S


### PR DESCRIPTION
Trying to get the firmwares into the tool, not sure if anything else is wrong.