### PR TITLE
Allow read-only motor config and app config

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -452,6 +452,7 @@ void commands_process_packet(unsigned char *data, unsigned int len,
 	} break;
 
 	case COMM_SET_MCCONF: {
+#ifndef	HW_MCCONF_READ_ONLY 
 		mc_configuration *mcconf = mempools_alloc_mcconf();
 		*mcconf = *mc_interface_get_configuration();
 
@@ -484,6 +485,7 @@ void commands_process_packet(unsigned char *data, unsigned int len,
 		}
 
 		mempools_free_mcconf(mcconf);
+#endif
 	} break;
 
 	case COMM_GET_MCCONF:
@@ -501,6 +503,7 @@ void commands_process_packet(unsigned char *data, unsigned int len,
 	} break;
 
 	case COMM_SET_APPCONF: {
+#ifndef	HW_APPCONF_READ_ONLY 
 		app_configuration *appconf = mempools_alloc_appconf();
 		*appconf = *app_get_configuration();
 
@@ -526,6 +529,7 @@ void commands_process_packet(unsigned char *data, unsigned int len,
 		}
 
 		mempools_free_appconf(appconf);
+#endif
 	} break;
 
 	case COMM_GET_APPCONF:


### PR DESCRIPTION
Defining HW_MCCONF_READ_ONLY and HW_APPCONF_READ_ONLY in the hardware settings turns the configs in read-only mode.

In some applications its better to block the user from playing with critical settings. With these switches the vesc can be flashed
with a hardcoded config which the user can only change with a full firmware update.

Signed-off-by: Marcos Chaparro <mchaparro@powerdesigns.ca>