### PR TITLE
Added installation guide for recommended stable gcc version

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,18 +82,29 @@ There are also many other options that can be changed in conf_general.h
 
 ### On Ubuntu
 
-Install the gcc-arm-embedded toolchain
+Install the gcc-arm-embedded toolchain. Recommended version ```gcc-arm-none-eabi-7-2018-q2```  
 
+**Method 1 - Through Official GNU Arm Embedded Toolchain Downloads**
+1. Go to [GNU Arm Embedded Toolchain Downloads](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
+2. Locate and Download version **gcc-arm-none-eabi-7-2018-q2** for your machine  
+   ```GNU Arm Embedded Toolchain: 7-2018-q2-update     June 27, 2018```  
+   Linux 64-bit version can be downloaded from [here](https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2?revision=bc2c96c0-14b5-4bb4-9f18-bceb4050fee7?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,7-2018-q2-update)  
+3. Unpack the archive in the file manager by right-clicking on it and select "extract here"
+4. Change directory to the unpacked folder, unpack it in /usr/local by execute the following command
+   ```
+   cd gcc-arm-none-eabi-7-2018-q2-update-linux  
+   sudo cp -RT gcc-arm-none-eabi-7-2018-q2-update/ /usr/local  
+   ```
 
+**Method 2 - Through apt install**
 ```bash
 sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa
 sudo apt update
 sudo apt install gcc-arm-embedded
 ```
 
-Add udev rules to use the stlink v2 programmer without being root
 
-
+**Optional - Add udev rules to use the stlink v2 programmer without being root**
 ```bash
 wget vedder.se/Temp/49-stlinkv2.rules
 sudo mv 49-stlinkv2.rules /etc/udev/rules.d/


### PR DESCRIPTION
File changed: README.md

Added the installation guide for recommended gcc version. 
Established the suggested gcc version ```gcc-arm-none-eabi-7-2018-q2``` for firmware development, as recommended by Benjamin.

==========
Considering that there are already multiple reports of newer version of gcc not working properly. A tested stable working version of gcc should be explicitly stated in the setup section in README.md to help newcomers, alongside a guide to describe how install it.  

I tested the installation method mentioned in [#233](https://github.com/vedderb/bldc/issues/233#issuecomment-763453904)(Benjamin's method)  on a new machine, compiled the firmware (in both .hex and .bin) and it was successful.

==========
Reference: 
[#210](https://github.com/vedderb/bldc/issues/210#issuecomment-691923494) => People encountered problems when using newer gcc version.
[#210](https://github.com/vedderb/bldc/issues/210#issuecomment-692965616) => The last working version that is available for download was ```gcc-arm-none-eabi-7-2018-q2```
```GNU Arm Embedded Toolchain: 7-2018-q2-update June 27, 2018```

All version after this, starting with the "GNU Arm Embedded Toolchain: 8-2018-q4-major December 20, 2018" were not working. After compiling and flashing the firmware the VESC was in a rebooting loop that was noticeable when looking at the LEDs.  

[#233](https://github.com/vedderb/bldc/issues/233#issuecomment-763453904) => Instructions from Benjamin for setting up ```gcc-arm-none-eabi-7-2018-q2```
[#278](https://github.com/vedderb/bldc/issues/278#issuecomment-817429617) => The tested working version of gcc should be explicitly listed out for vesc fw development.

Sam  