### PR TITLE
Balance-app: allow jump-dismount at low speed, using half_fault delay

### DIFF
--- a/applications/app_balance.c
+++ b/applications/app_balance.c
@@ -197,8 +197,9 @@ bool check_faults(bool ignoreTimers){
 			state = FAULT_SWITCH_FULL;
 			return true;
 		}
-		// at low speed (below half-fault threshold speed), also check half_fault delay:
+		// at low speed (below half-fault threshold speed), also check half_fault delay (if non-zero):
 		else if ((abs_erpm < balance_conf.fault_adc_half_erpm)
+				 && (balance_conf.fault_delay_switch_half > 0)
 				 && (ST2MS(current_time - fault_switch_timer) > balance_conf.fault_delay_switch_half)){
 			state = FAULT_SWITCH_FULL;
 			return true;

--- a/applications/app_balance.c
+++ b/applications/app_balance.c
@@ -192,7 +192,14 @@ bool check_faults(bool ignoreTimers){
 	// Check switch
 	// Switch fully open
 	if(switch_state == OFF){
+		// at any speed, always check full_fault delay:
 		if(ST2MS(current_time - fault_switch_timer) > balance_conf.fault_delay_switch_full || ignoreTimers){
+			state = FAULT_SWITCH_FULL;
+			return true;
+		}
+		// at low speed (below half-fault threshold speed), also check half_fault delay:
+		else if ((abs_erpm < balance_conf.fault_adc_half_erpm)
+				 && (ST2MS(current_time - fault_switch_timer) > balance_conf.fault_delay_switch_half)){
 			state = FAULT_SWITCH_FULL;
 			return true;
 		}


### PR DESCRIPTION
When below the half-fault erpm, we check the full-fault ADC switch timer
also against the half_fault delay value

Before this change, a long full_fault delay could lead to undesired wheel
spinning after jumping off the board, even when stationary.

The other advantage of this change, is that users with only a single sensor
now have the ability to set different delays for speeds above half_fault erpm
and below half_fault erpm.

If "Half Switch Fault Delay" is 0 (=default) then this new behavior is disabled.

Signed-off-by: Dado Mista <dadomista@gmail.com>