### PR TITLE
Introduce adjusted input voltage to componensate for R tolerances

### DIFF
--- a/applications/app_balance.c
+++ b/applications/app_balance.c
@@ -255,7 +255,7 @@ void calculate_setpoint_target(void){
 		}
 		setpointAdjustmentType = TILTBACK;
 		state = RUNNING_TILTBACK_DUTY;
-	}else if(abs_duty_cycle > 0.05 && GET_INPUT_VOLTAGE() > balance_conf.tiltback_high_voltage){
+	}else if(abs_duty_cycle > 0.05 && mc_interface_get_adjusted_input_voltage() > balance_conf.tiltback_high_voltage){
 		if(erpm > 0){
 			setpoint_target = balance_conf.tiltback_angle;
 		} else {
@@ -263,7 +263,7 @@ void calculate_setpoint_target(void){
 		}
 		setpointAdjustmentType = TILTBACK;
 		state = RUNNING_TILTBACK_HIGH_VOLTAGE;
-	}else if(abs_duty_cycle > 0.05 && GET_INPUT_VOLTAGE() < balance_conf.tiltback_low_voltage){
+	}else if(abs_duty_cycle > 0.05 && mc_interface_get_adjusted_input_voltage() < balance_conf.tiltback_low_voltage){
 		if(erpm > 0){
 			setpoint_target = balance_conf.tiltback_angle;
 		} else {

--- a/comm_can.c
+++ b/comm_can.c
@@ -1705,7 +1705,7 @@ static void send_status5(uint8_t id, bool replace) {
 	int32_t send_index = 0;
 	uint8_t buffer[8];
 	buffer_append_int32(buffer, mc_interface_get_tachometer_value(false), &send_index);
-	buffer_append_int16(buffer, (int16_t)(GET_INPUT_VOLTAGE() * 1e1), &send_index);
+	buffer_append_int16(buffer, (int16_t)(mc_interface_get_adjusted_input_voltage() * 1e1), &send_index);
 	buffer_append_int16(buffer, 0, &send_index); // Reserved for now
 	comm_can_transmit_eid_replace(id | ((uint32_t)CAN_PACKET_STATUS_5 << 8),
 			buffer, send_index, replace);

--- a/commands.c
+++ b/commands.c
@@ -354,7 +354,7 @@ void commands_process_packet(unsigned char *data, unsigned int len,
 			buffer_append_float32(send_buffer, mc_interface_get_rpm(), 1e0, &ind);
 		}
 		if (mask & ((uint32_t)1 << 8)) {
-			buffer_append_float16(send_buffer, GET_INPUT_VOLTAGE(), 1e1, &ind);
+			buffer_append_float16(send_buffer, mc_interface_get_adjusted_input_voltage(), 1e1, &ind);
 		}
 		if (mask & ((uint32_t)1 << 9)) {
 			buffer_append_float32(send_buffer, mc_interface_get_amp_hours(false), 1e4, &ind);
@@ -795,7 +795,7 @@ void commands_process_packet(unsigned char *data, unsigned int len,
 			buffer_append_float32(send_buffer, mc_interface_get_speed(), 1e3, &ind);
 		}
 		if (mask & ((uint32_t)1 << 7)) {
-			buffer_append_float16(send_buffer, GET_INPUT_VOLTAGE(), 1e1, &ind);
+			buffer_append_float16(send_buffer, mc_interface_get_adjusted_input_voltage(), 1e1, &ind);
 		}
 		if (mask & ((uint32_t)1 << 8)) {
 			buffer_append_float16(send_buffer, battery_level, 1e3, &ind);

--- a/conf_general.c
+++ b/conf_general.c
@@ -824,7 +824,7 @@ bool conf_general_measure_flux_linkage(float current, float duty,
 	float avg_current = 0.0;
 	float samples = 0.0;
 	for (int i = 0;i < 2000;i++) {
-		avg_voltage += GET_INPUT_VOLTAGE() * mc_interface_get_duty_cycle_now();
+		avg_voltage += mc_interface_get_adjusted_input_voltage() * mc_interface_get_duty_cycle_now();
 		avg_rpm += mc_interface_get_rpm();
 		avg_current += mc_interface_get_tot_current();
 		samples += 1.0;

--- a/confgenerator.c
+++ b/confgenerator.c
@@ -25,6 +25,7 @@ int32_t confgenerator_serialize_mcconf(uint8_t *buffer, const mc_configuration *
 	buffer_append_float32_auto(buffer, conf->l_max_erpm_fbrake_cc, &ind);
 	buffer_append_float32_auto(buffer, conf->l_min_vin, &ind);
 	buffer_append_float32_auto(buffer, conf->l_max_vin, &ind);
+	buffer_append_float16(buffer, conf->l_vin_correction, 10000, &ind);
 	buffer_append_float32_auto(buffer, conf->l_battery_cut_start, &ind);
 	buffer_append_float32_auto(buffer, conf->l_battery_cut_end, &ind);
 	buffer[ind++] = conf->l_slow_abs_current;
@@ -373,6 +374,7 @@ bool confgenerator_deserialize_mcconf(const uint8_t *buffer, mc_configuration *c
 	conf->l_max_erpm_fbrake_cc = buffer_get_float32_auto(buffer, &ind);
 	conf->l_min_vin = buffer_get_float32_auto(buffer, &ind);
 	conf->l_max_vin = buffer_get_float32_auto(buffer, &ind);
+	conf->l_vin_correction = buffer_get_float16(buffer, 10000, &ind);
 	conf->l_battery_cut_start = buffer_get_float32_auto(buffer, &ind);
 	conf->l_battery_cut_end = buffer_get_float32_auto(buffer, &ind);
 	conf->l_slow_abs_current = buffer[ind++];
@@ -717,6 +719,7 @@ void confgenerator_set_defaults_mcconf(mc_configuration *conf) {
 	conf->l_max_erpm_fbrake_cc = MCCONF_L_CURR_MAX_RPM_FBRAKE_CC;
 	conf->l_min_vin = MCCONF_L_MIN_VOLTAGE;
 	conf->l_max_vin = MCCONF_L_MAX_VOLTAGE;
+	conf->l_vin_correction = MCCONF_L_VIN_CORRECTION;
 	conf->l_battery_cut_start = MCCONF_L_BATTERY_CUT_START;
 	conf->l_battery_cut_end = MCCONF_L_BATTERY_CUT_END;
 	conf->l_slow_abs_current = MCCONF_L_SLOW_ABS_OVERCURRENT;

--- a/confgenerator.h
+++ b/confgenerator.h
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 
 // Constants
-#define MCCONF_SIGNATURE		1125477401
+#define MCCONF_SIGNATURE		93547091
 #define APPCONF_SIGNATURE		3423413835
 
 // Functions

--- a/datatypes.h
+++ b/datatypes.h
@@ -298,6 +298,7 @@ typedef struct {
 	float l_max_erpm_fbrake_cc;
 	float l_min_vin;
 	float l_max_vin;
+	float l_vin_correction;
 	float l_battery_cut_start;
 	float l_battery_cut_end;
 	bool l_slow_abs_current;

--- a/gpdrive.c
+++ b/gpdrive.c
@@ -317,7 +317,7 @@ void gpdrive_output_sample(float sample) {
 		break;
 
 	case GPD_OUTPUT_MODE_VOLTAGE:
-		set_modulation(sample / GET_INPUT_VOLTAGE());
+		set_modulation(sample / mc_interface_get_adjusted_input_voltage());
 		break;
 
 	case GPD_OUTPUT_MODE_CURRENT:
@@ -538,7 +538,7 @@ static void adc_int_handler(void *p, uint32_t flags) {
 	// Check for most critical faults here, as doing it in mc_interface can be too slow
 	// for high switching frequencies.
 
-	const float input_voltage = GET_INPUT_VOLTAGE();
+	const float input_voltage = mc_interface_get_adjusted_input_voltage();
 
 	static int wrong_voltage_iterations = 0;
 	if (input_voltage < m_conf->l_min_vin ||
@@ -600,7 +600,7 @@ static void adc_int_handler(void *p, uint32_t flags) {
 		gpdrive_output_sample(m_output_now);
 
 		if (m_output_mode == GPD_OUTPUT_MODE_CURRENT) {
-			float v_in = GET_INPUT_VOLTAGE();
+			float v_in = mc_interface_get_adjusted_input_voltage();
 			float err = m_current_state.current_set - m_current_now_filtered;
 			m_current_state.voltage_now = m_current_state.voltage_int + err * m_conf->gpd_current_kp;
 			m_current_state.voltage_int += err * m_conf->gpd_current_ki * (1.0 / m_fsw_now);

--- a/hwconf/hw_stormcore_100d.c
+++ b/hwconf/hw_stormcore_100d.c
@@ -510,7 +510,7 @@ static THD_FUNCTION(smart_switch_thread, arg) {
 				cts++;
 			}
 			cts = 0;
-			while(((GET_BATT_VOLTAGE() - GET_INPUT_VOLTAGE()) > 8.0) && (cts < 50)){
+			while(((GET_BATT_VOLTAGE() - mc_interface_get_adjusted_input_voltage()) > 8.0) && (cts < 50)){
 				chThdSleepMilliseconds(100);
 				cts++;
 			}

--- a/hwconf/hw_stormcore_60d.c
+++ b/hwconf/hw_stormcore_60d.c
@@ -511,7 +511,7 @@ static THD_FUNCTION(smart_switch_thread, arg) {
 				cts++;
 			}
 			cts = 0;
-			while(((GET_BATT_VOLTAGE() - GET_INPUT_VOLTAGE()) > 8.0) && (cts < 50)){
+			while(((GET_BATT_VOLTAGE() - mc_interface_get_adjusted_input_voltage()) > 8.0) && (cts < 50)){
 				chThdSleepMilliseconds(100);
 				cts++;
 			}

--- a/led_external.c
+++ b/led_external.c
@@ -154,7 +154,8 @@ static THD_FUNCTION(led_thread, arg) {
 
 			case LED_EXT_BATT:
 				while (state == state_last && rev_last == reverse_leds && !HAS_FAULT()) {
-					batt_level = utils_map(GET_INPUT_VOLTAGE(), LED_EXT_BATT_LOW, LED_EXT_BATT_HIGH, 0.0, 1.0);
+					batt_level = utils_map(mc_interface_get_adjusted_input_voltage(),
+										   LED_EXT_BATT_LOW, LED_EXT_BATT_HIGH, 0.0, 1.0);
 					for (int i = 0;i < WS2811_LED_NUM / 2;i++) {
 						if (i < (WS2811_LED_NUM / 2) * batt_level) {
 							if (i < (WS2811_LED_NUM / 2) / 3) {

--- a/libcanard/canard_driver.c
+++ b/libcanard/canard_driver.c
@@ -336,7 +336,7 @@ void canard_driver_init(void) {
 static void calculateTotalCurrent(void) {
 	// Calculate total current being consumed by the ESCs on the system
 	float totalCurrent = mc_interface_get_tot_current();
-	float avgVoltage = GET_INPUT_VOLTAGE();
+	float avgVoltage = mc_interface_get_adjusted_input_voltage();
 	float totalSysCurrent = 0;
 
 	uint8_t escTotal = 1;
@@ -409,7 +409,7 @@ static void sendEscStatus(void) {
 			mc_interface_get_configuration()->l_current_max_scale) * 100.0;
 	status.rpm = mc_interface_get_rpm();
 	status.temperature = mc_interface_temp_fet_filtered() + 273.15;
-	status.voltage = GET_INPUT_VOLTAGE();
+	status.voltage = mc_interface_get_adjusted_input_voltage();
 
 	uavcan_equipment_esc_Status_encode(&status, buffer);
 

--- a/mc_interface.h
+++ b/mc_interface.h
@@ -84,6 +84,7 @@ float mc_interface_get_battery_level(float *wh_left);
 float mc_interface_get_speed(void);
 float mc_interface_get_distance(void);
 float mc_interface_get_distance_abs(void);
+float mc_interface_get_adjusted_input_voltage(void);
 
 // odometer
 uint64_t mc_interface_get_odometer(void);

--- a/mcconf/mcconf_default.h
+++ b/mcconf/mcconf_default.h
@@ -56,6 +56,9 @@
 #ifndef MCCONF_L_MAX_VOLTAGE
 #define MCCONF_L_MAX_VOLTAGE			57.0	// Maximum input voltage
 #endif
+#ifndef MCCONF_L_VIN_CORRECTION
+#define MCCONF_L_VIN_CORRECTION			0.0		// Correction factor for input voltage
+#endif
 #ifndef MCCONF_L_BATTERY_CUT_START
 #define MCCONF_L_BATTERY_CUT_START		10.0	// Start limiting the positive current at this voltage
 #endif

--- a/mcpwm.c
+++ b/mcpwm.c
@@ -746,7 +746,7 @@ mc_state mcpwm_get_state(void) {
  * The KV value.
  */
 float mcpwm_get_kv(void) {
-	return rpm_now / (GET_INPUT_VOLTAGE() * fabsf(dutycycle_now));
+	return rpm_now / (mc_interface_get_adjusted_input_voltage() * fabsf(dutycycle_now));
 }
 
 /**
@@ -1204,7 +1204,7 @@ static void run_pid_control_speed(void) {
 	}
 #else
 	// Compensation for supply voltage variations
-	float scale = 1.0 / GET_INPUT_VOLTAGE();
+	float scale = 1.0 / mc_interface_get_adjusted_input_voltage();
 
 	// Compute parameters
 	p_term = error * conf->s_pid_kp * scale;
@@ -1753,7 +1753,7 @@ void mcpwm_adc_int_handler(void *p, uint32_t flags) {
 	// Reset the watchdog
 	timeout_feed_WDT(THREAD_MCPWM);
 
-	const float input_voltage = GET_INPUT_VOLTAGE();
+	const float input_voltage = mc_interface_get_adjusted_input_voltage();
 	int ph1, ph2, ph3;
 
 	static int direction_before = 1;

--- a/mcpwm_foc.c
+++ b/mcpwm_foc.c
@@ -1750,9 +1750,9 @@ float mcpwm_foc_measure_inductance(float duty, int samples, float *curr, float *
 	stop_pwm_hw(motor);
 
 	motor->m_conf->foc_sensor_mode = FOC_SENSOR_MODE_HFI;
-	motor->m_conf->foc_hfi_voltage_start = duty * GET_INPUT_VOLTAGE() * (2.0 / 3.0);
-	motor->m_conf->foc_hfi_voltage_run = duty * GET_INPUT_VOLTAGE() * (2.0 / 3.0);
-	motor->m_conf->foc_hfi_voltage_max = duty * GET_INPUT_VOLTAGE() * (2.0 / 3.0);
+	motor->m_conf->foc_hfi_voltage_start = duty * mc_interface_get_adjusted_input_voltage() * (2.0 / 3.0);
+	motor->m_conf->foc_hfi_voltage_run = duty * mc_interface_get_adjusted_input_voltage() * (2.0 / 3.0);
+	motor->m_conf->foc_hfi_voltage_max = duty * mc_interface_get_adjusted_input_voltage() * (2.0 / 3.0);
 	motor->m_conf->foc_sl_erpm_hfi = 20000.0;
 	motor->m_conf->foc_sample_v0_v7 = false;
 	motor->m_conf->foc_hfi_samples = HFI_SAMPLES_32;
@@ -2519,7 +2519,7 @@ void mcpwm_foc_adc_int_handler(void *p, uint32_t flags) {
 	// TODO: Test this.
 	dt *= (float)FOC_CONTROL_LOOP_FREQ_DIVIDER;
 
-	UTILS_LP_FAST(motor_now->m_motor_state.v_bus, GET_INPUT_VOLTAGE(), 0.1);
+	UTILS_LP_FAST(motor_now->m_motor_state.v_bus, mc_interface_get_adjusted_input_voltage(), 0.1);
 
 	volatile float enc_ang = 0;
 	volatile bool encoder_is_being_used = false;
@@ -2611,7 +2611,7 @@ void mcpwm_foc_adc_int_handler(void *p, uint32_t flags) {
 				// Truncating the duty cycle here would be dangerous, so run a PID controller.
 
 				// Compensation for supply voltage variations
-				float scale = 1.0 / GET_INPUT_VOLTAGE();
+				float scale = 1.0 / mc_interface_get_adjusted_input_voltage();
 
 				// Compute error
 				float error = duty_set - motor_now->m_motor_state.duty_now;

--- a/terminal.c
+++ b/terminal.c
@@ -198,7 +198,7 @@ void terminal_process_string(char *str) {
 		commands_printf("Current 1 sample: %u", current1_samp);
 		commands_printf("Current 2 sample: %u\n", current2_samp);
 	} else if (strcmp(argv[0], "volt") == 0) {
-		commands_printf("Input voltage: %.2f\n", (double)GET_INPUT_VOLTAGE());
+		commands_printf("Input voltage: %.2f\n", (double)mc_interface_get_adjusted_input_voltage());
 #ifdef HW_HAS_GATE_DRIVER_SUPPLY_MONITOR
 		commands_printf("Gate driver power supply output voltage: %.2f\n", (double)GET_GATE_DRIVER_SUPPLY_VOLTAGE());
 #endif

--- a/virtual_motor.c
+++ b/virtual_motor.c
@@ -226,9 +226,9 @@ static void connect_virtual_motor(float ml , float J, float Vbus){
 	//we load 1 to get the transfer function indirectly
 	ADC_Value[ ADC_IND_VIN_SENS ] = 1;
 
-	float tempVoltage = GET_INPUT_VOLTAGE();
+	float tempVoltage = mc_interface_get_adjusted_input_voltage();
 	if(tempVoltage != 0.0){
-		ADC_Value[ ADC_IND_VIN_SENS ] = Vbus / GET_INPUT_VOLTAGE();
+		ADC_Value[ ADC_IND_VIN_SENS ] = Vbus / mc_interface_get_adjusted_input_voltage();
 	}
 
 	//initialize constants


### PR DESCRIPTION
On some VESCs the reported input voltage has a noticeable error.
A correction factor allows users to adjust the measured value.

This feature lets users specify a correction factor, expressed as a
percentage. Now the input voltage used everywhere is Vin * (1 + corr).

The correction factor is limited to values in the range of -10% .. +10%

There's a matching commit in vesc_tool