### PR TITLE
app adc: allow hardwares to override the brake input

### DIFF
--- a/applications/app_adc.c
+++ b/applications/app_adc.c
@@ -186,6 +186,9 @@ static THD_FUNCTION(adc_thread, arg) {
 		float brake = 0.0;
 #endif
 
+#ifdef HW_HAS_BRAKE_OVERRIDE
+		hw_brake_override(&brake);
+#endif
 		read_voltage2 = brake;
 
 		// Optionally apply a mean value filter


### PR DESCRIPTION
With this hook the brake can be overriden from the hw_*.c file without polluting the app configuration UI.

Some examples of commanded braking:
* Tilt/crash sensor
* Gear shift sensor
* Emergency stop
* Kill switch

I'm using this for an e-bike gear shift sensor that pauses torque for a moment during shifts. It will be part of a future pull request to update luna hw.

If there is a better way please let me know and I'll change this.