### PR TITLE
Fix switching to the MT6816 encoder before reboot

### DIFF
--- a/mc_interface.c
+++ b/mc_interface.c
@@ -344,6 +344,10 @@ void mc_interface_set_configuration(mc_configuration *configuration) {
 			encoder_init_as5047p_spi();
 			break;
 
+		case SENSOR_PORT_MODE_MT6816_SPI:
+			encoder_init_mt6816_spi();
+			break;
+
 		case SENSOR_PORT_MODE_AD2S1205:
 			encoder_init_ad2s1205_spi();
 			break;


### PR DESCRIPTION
encoder_init_mt6816_spi only made it into the switch statement at
startup, so after changing the mc_conf it required a reboot of the VESC
before it worked.