### PR TITLE
Handle negative values in current unbalance detection.

### DIFF
--- a/mc_interface.c
+++ b/mc_interface.c
@@ -2367,7 +2367,7 @@ static void run_timer_tasks(volatile motor_if_state_t *motor) {
 	if (!motor->m_conf.foc_sample_high_current) { // This won't work when high current sampling is used
 		motor->m_motor_current_unbalance = mc_interface_get_abs_motor_current_unbalance();
 
-		if (motor->m_motor_current_unbalance > MCCONF_MAX_CURRENT_UNBALANCE) {
+		if (fabsf(motor->m_motor_current_unbalance) > fabsf(MCCONF_MAX_CURRENT_UNBALANCE)) {
 			UTILS_LP_FAST(motor->m_motor_current_unbalance_error_rate, 1.0, (1 / 1000.0));
 		} else {
 			UTILS_LP_FAST(motor->m_motor_current_unbalance_error_rate, 0.0, (1 / 1000.0));


### PR DESCRIPTION
Current unbalance detection does not handle a negative MCCONF_MAX_CURRENT_UNBALANCE, which can be negative if FAC_CURRENT is negative in the case of inverted current sensors.


This PR adds absolute  number conversion to  `MCCONF_MAX_CURRENT_UNBALANCE` and `m_motor_current_unbalance` so that the magnitude of the two numbers is compered to determine the FAULT_CODE_UNBALANCED_CURRENTS error.

Discussion: 
- Is there a way to make this absolute conversion happen in the preprocessor?
- Is also making `motor->m_motor_current_unbalance` absolute acceptable? It seems like you really want an absolute magnitude as the sum of all currents.


### How this came about:
My current sensor signals are inverted, so my current factor derived from CURRENT_AMP_GAIN and CURRENT_SHUNT_RES is negative. (This is the correct way of handling inverted current signals, correct?)

It appears that MCCONF_MAX_CURRENT_UNBALANCE calculation does not take into account the possibility that FAC_CURRENT	could be negative. Which causes the unbalanced currents compare to fail when it shouldn't.

```
// Current ADC to amperes factor
#define FAC_CURRENT					((V_REG / 4095.0) / -0.01333)
```

```
#ifndef MCCONF_MAX_CURRENT_UNBALANCE
#define MCCONF_MAX_CURRENT_UNBALANCE		(FAC_CURRENT * 512)
#endif
```

```
if (motor->m_motor_current_unbalance > MCCONF_MAX_CURRENT_UNBALANCE) {
	UTILS_LP_FAST(motor->m_motor_current_unbalance_error_rate, 1.0, (1 / 1000.0));
} else {
	UTILS_LP_FAST(motor->m_motor_current_unbalance_error_rate, 0.0, (1 / 1000.0));
}
```

