### PR TITLE
Added play music tune function

### DIFF
--- a/applications/app_play_tune.c
+++ b/applications/app_play_tune.c
@@ -68,7 +68,7 @@ static THD_FUNCTION(custom_script_thread, arg)
                 //play the startup tune
                 for( int a = 3000; a < 5000; a = a + 500 ) {
                      change_sw(a);
-                     mc_interface_set_pid_speed(300.0);
+                     mc_interface_set_pid_speed(10.0);
                      chThdSleepMilliseconds(300);
                      timeout_reset();
                 }
@@ -82,7 +82,7 @@ static THD_FUNCTION(custom_script_thread, arg)
                 for( int i = 0; i < 3; i++ ) {
                      change_sw(5000);
                      chThdSleepMilliseconds(300);
-                     mc_interface_set_pid_speed(300.0);
+                     mc_interface_set_pid_speed(10.0);
                      chThdSleepMilliseconds(500);
                      timeout_reset();
                 }

--- a/applications/app_play_tune.c
+++ b/applications/app_play_tune.c
@@ -60,7 +60,7 @@ static THD_FUNCTION(custom_script_thread, arg)
 		is_running = true;
 		(void)arg;
 	 
-		chRegSetThreadName("APP_CUSTOM_SCRIPT");
+		chRegSetThreadName("APP_PLAY_TUNES");
  
                 //save original switching frequency
                 float original_sw = mc_interface_get_configuration()->foc_f_sw;

--- a/applications/app_play_tune.c
+++ b/applications/app_play_tune.c
@@ -1,0 +1,101 @@
+/*
+	Copyright 2017 Benjamin Vedder	benjamin@vedder.se
+        Copyright 2021 Sam Shum         cshum@andrew.cmu.edu
+
+	This file is part of the VESC firmware.
+
+	The VESC firmware is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    The VESC firmware is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    */
+
+#include "ch.h" // ChibiOS
+#include "hal.h" // ChibiOS HAL
+#include "mc_interface.h" // Motor control functions
+#include "hw.h" // Pin mapping on this hardware
+#include "timeout.h" // To reset the timeout
+
+#include "mcpwm_foc.h" // Motor control functions
+#include "timer.h" // Motor control functions
+
+static volatile bool stop_now = true;
+static volatile bool is_running = false;
+// custom script thread
+static THD_FUNCTION(custom_script_thread, arg);
+static THD_WORKING_AREA(custom_script_thread_wa, 2048); // 2kb stack for this thread
+
+
+void app_custom_start(void) {
+        if (!is_running)
+        {
+                stop_now = false;
+                is_running = true;
+		chThdCreateStatic(custom_script_thread_wa, sizeof(custom_script_thread_wa), NORMALPRIO, custom_script_thread, NULL);
+        }
+}
+
+void app_custom_stop(void) {
+
+     stop_now = true;
+     is_running = false;
+     mc_interface_release_motor(); 
+	
+}
+
+void app_custom_configure(app_configuration *conf) {
+	(void)conf;
+}
+ 
+static THD_FUNCTION(custom_script_thread, arg) 
+{
+		is_running = true;
+		(void)arg;
+	 
+		chRegSetThreadName("APP_CUSTOM_SCRIPT");
+ 
+                //save original switching frequency
+                float original_sw = mc_interface_get_configuration()->foc_f_sw;
+
+                //play the startup tune
+                for( int a = 3000; a < 5000; a = a + 500 ) {
+                     change_sw(a);
+                     mc_interface_set_pid_speed(1000.0);
+                     chThdSleepMilliseconds(300);
+                     timeout_reset();
+                }
+                    
+                //stop playing
+                mc_interface_set_pid_speed(0.0);
+                chThdSleepMilliseconds(2000);
+                timeout_reset();
+
+                //play the error/fault tune
+                for( int i = 0; i < 3; i++ ) {
+                     change_sw(5000);
+                     chThdSleepMilliseconds(300);
+                     mc_interface_set_pid_speed(1000.0);
+                     chThdSleepMilliseconds(700);
+                     timeout_reset();
+                }
+
+                //stop playing
+                change_sw((int)original_sw);
+                mc_interface_set_pid_speed(0.0);
+                chThdSleepMilliseconds(500);
+                timeout_reset();
+
+         
+                is_running = false;
+                chThdExit(0);   // terminate the thread, all scripted behavior completed
+		
+}
+

--- a/applications/app_play_tune.c
+++ b/applications/app_play_tune.c
@@ -35,20 +35,18 @@ static THD_WORKING_AREA(custom_script_thread_wa, 2048); // 2kb stack for this th
 
 
 void app_custom_start(void) {
-        if (!is_running)
+	if (!is_running)
         {
-                stop_now = false;
+		stop_now = false;
                 is_running = true;
 		chThdCreateStatic(custom_script_thread_wa, sizeof(custom_script_thread_wa), NORMALPRIO, custom_script_thread, NULL);
         }
 }
 
 void app_custom_stop(void) {
-
-     stop_now = true;
-     is_running = false;
-     mc_interface_release_motor(); 
-	
+	stop_now = true;
+	is_running = false;
+	mc_interface_release_motor();	
 }
 
 void app_custom_configure(app_configuration *conf) {
@@ -57,45 +55,43 @@ void app_custom_configure(app_configuration *conf) {
  
 static THD_FUNCTION(custom_script_thread, arg) 
 {
-		is_running = true;
-		(void)arg;
+	is_running = true;
+	(void)arg;
 	 
-		chRegSetThreadName("APP_PLAY_TUNES");
+	chRegSetThreadName("APP_PLAY_TUNES");
  
-                //save original switching frequency
-                float original_sw = mc_interface_get_configuration()->foc_f_sw;
+	//save original switching frequency
+	float original_sw = mc_interface_get_configuration()->foc_f_sw;
 
-                //play the startup tune
-                for( int a = 3000; a < 5000; a = a + 500 ) {
-                     change_sw(a);
-                     mc_interface_set_pid_speed(10.0);
-                     chThdSleepMilliseconds(300);
-                     timeout_reset();
-                }
+	//play the startup tune
+	for( int a = 3000; a < 5000; a = a + 500 ) {
+		mcpwm_foc_change_sw(a);
+		mc_interface_set_pid_speed(10.0);
+		chThdSleepMilliseconds(300);
+		timeout_reset();
+	}
                     
-                //stop playing
-                mc_interface_set_pid_speed(0.0);
-                chThdSleepMilliseconds(2000);
-                timeout_reset();
+	//stop playing
+	mc_interface_set_pid_speed(0.0);
+ 	chThdSleepMilliseconds(2000);
+	timeout_reset();
 
-                //play the error/fault tune
-                for( int i = 0; i < 3; i++ ) {
-                     change_sw(5000);
-                     chThdSleepMilliseconds(300);
-                     mc_interface_set_pid_speed(10.0);
-                     chThdSleepMilliseconds(500);
-                     timeout_reset();
-                }
+	//play the error/fault tune
+	for( int i = 0; i < 3; i++ ) {
+		mcpwm_foc_change_sw(5000);
+		chThdSleepMilliseconds(300);
+		mc_interface_set_pid_speed(10.0);
+		chThdSleepMilliseconds(500);
+		timeout_reset();
+	}
 
-                //stop playing
-                change_sw((int)original_sw);
-                mc_interface_set_pid_speed(0.0);
-                chThdSleepMilliseconds(500);
-                timeout_reset();
+	//stop playing
+	mcpwm_foc_change_sw((int)original_sw);
+	mc_interface_set_pid_speed(0.0);
+	chThdSleepMilliseconds(500);
+	timeout_reset();
 
-         
-                is_running = false;
-                chThdExit(0);   // terminate the thread, all scripted behavior completed
-		
+	is_running = false;
+	chThdExit(0);   // terminate the thread, all scripted behavior completed	
 }
 

--- a/applications/app_play_tune.c
+++ b/applications/app_play_tune.c
@@ -68,7 +68,7 @@ static THD_FUNCTION(custom_script_thread, arg)
                 //play the startup tune
                 for( int a = 3000; a < 5000; a = a + 500 ) {
                      change_sw(a);
-                     mc_interface_set_pid_speed(1000.0);
+                     mc_interface_set_pid_speed(300.0);
                      chThdSleepMilliseconds(300);
                      timeout_reset();
                 }
@@ -82,8 +82,8 @@ static THD_FUNCTION(custom_script_thread, arg)
                 for( int i = 0; i < 3; i++ ) {
                      change_sw(5000);
                      chThdSleepMilliseconds(300);
-                     mc_interface_set_pid_speed(1000.0);
-                     chThdSleepMilliseconds(700);
+                     mc_interface_set_pid_speed(300.0);
+                     chThdSleepMilliseconds(500);
                      timeout_reset();
                 }
 

--- a/mcpwm_foc.c
+++ b/mcpwm_foc.c
@@ -687,8 +687,8 @@ void mcpwm_foc_init(volatile mc_configuration *conf_m1, volatile mc_configuratio
 	m_init_done = true;
 }
 
-void change_sw(int f_sw) {
-        timer_reinit(f_sw);
+void mcpwm_foc_change_sw(int f_sw) {
+		timer_reinit(f_sw);
         }
 
 void mcpwm_foc_deinit(void) {

--- a/mcpwm_foc.c
+++ b/mcpwm_foc.c
@@ -687,6 +687,10 @@ void mcpwm_foc_init(volatile mc_configuration *conf_m1, volatile mc_configuratio
 	m_init_done = true;
 }
 
+void change_sw(int f_sw) {
+        timer_reinit(f_sw);
+        }
+
 void mcpwm_foc_deinit(void) {
 	if (!m_init_done) {
 		return;

--- a/mcpwm_foc.h
+++ b/mcpwm_foc.h
@@ -120,7 +120,7 @@ void mcpwm_foc_tim_sample_int_handler(void);
 void mcpwm_foc_adc_int_handler(void *p, uint32_t flags);
 
 //play tune by changing switching frequency
-void change_sw(int f_sw);
+void mcpwm_foc_change_sw(int f_sw);
 
 // Defines
 #define MCPWM_FOC_CURRENT_SAMP_OFFSET				(2) // Offset from timer top for ADC samples

--- a/mcpwm_foc.h
+++ b/mcpwm_foc.h
@@ -119,6 +119,9 @@ mc_state mcpwm_foc_get_state_motor(bool is_second_motor);
 void mcpwm_foc_tim_sample_int_handler(void);
 void mcpwm_foc_adc_int_handler(void *p, uint32_t flags);
 
+//play tune by changing switching frequency
+void change_sw(int f_sw);
+
 // Defines
 #define MCPWM_FOC_CURRENT_SAMP_OFFSET				(2) // Offset from timer top for ADC samples
 


### PR DESCRIPTION
**Motivation:**  

Most of the commercial ESCs on the market, especially drone ESCs, have the ability to produce a tune when powered or in fault state. This is achieved by running the motor in different switching frequencies that is audible to human ears, basically using the motor as a speaker.

This pull request is an simple inital attempt to re-create the same effect in VESC, producing tunes by running the motor in different switching frequencies.

==========
**Mechanics:**  

This pull request contains an example for playing tunes, it uses custom application that plays two tunes, one after another. The first one is a startup tune sequence, the second is a error/warning tune sequence tune.


In the next version, the function will be added to the startup function, to play the startup tune when powered on.

Update:
Tested on 6" inch scooter direct drive hub motor and a small drone motor, with new parameters.

==========
**Video Demos:**  

Demo Video (small drone motor - running 3S):
[![Demo here](http://img.youtube.com/vi/LB0OpRd8YMk/0.jpg)](http://www.youtube.com/watch?v=LB0OpRd8YMk "Demo Here")    

Demo Video (6" inch direct drive scooter motor - runnning 13S):
[![Demo here](http://img.youtube.com/vi/zjQ2rIybZyA/0.jpg)](http://www.youtube.com/watch?v=zjQ2rIybZyA "Demo Here")

=====
Old version demos:  

More explaination [ old version was used in this video, still moves a bit, please refer to new version video above] :  

[![Demo here](http://img.youtube.com/vi/RGsPfEyQ-WU/0.jpg)](http://www.youtube.com/watch?v=RGsPfEyQ-WU "Demo Here")  

[Old version, still moves a bit, please refer to new version video above] <del>Demo Video :</del>
[![Demo here](http://img.youtube.com/vi/pQnYOhD0_OI/0.jpg)](http://www.youtube.com/watch?v=pQnYOhD0_OI "Demo Here")    


==========
**Related issue:**  

#324 
https://vesc-project.com/node/647

Sam