### PR TITLE
Added startup tune

### DIFF
--- a/conf_general.h
+++ b/conf_general.h
@@ -254,6 +254,11 @@
 #endif
 
 /*
+ * Enable startup tune 
+ */
+#define STATUP_TUNE_ENABLE				1    //comment to disable
+
+/*
  * Settings for the external LEDs (hardcoded for now)
  */
 #define LED_EXT_BATT_LOW			28.0

--- a/main.c
+++ b/main.c
@@ -226,7 +226,26 @@ int main(void) {
 
 	ledpwm_init();
 	mc_interface_init();
+#ifdef STATUP_TUNE_ENABLE
+        if (mc_interface_get_configuration()->motor_type==MOTOR_TYPE_FOC) {
+        float original_min_erpm = mc_interface_get_configuration()->s_pid_min_erpm;
+        float original_sw = mc_interface_get_configuration()->foc_f_sw;
 
+        mc_interface_set_min_erpm(1.0);
+
+        for( int a = 3000; a < 5000; a = a + 500 ) {
+              change_sw(a);
+              mc_interface_set_pid_speed(10.0);
+              chThdSleepMilliseconds(300);
+        }
+                    
+
+        change_sw((int)original_sw);
+        mc_interface_set_min_erpm(original_min_erpm);
+        mc_interface_release_motor();
+        chThdSleepMilliseconds(50);
+        }
+#endif
 	commands_init();
 
 #if COMM_USE_USB

--- a/main.c
+++ b/main.c
@@ -228,22 +228,21 @@ int main(void) {
 	mc_interface_init();
 #ifdef STATUP_TUNE_ENABLE
         if (mc_interface_get_configuration()->motor_type==MOTOR_TYPE_FOC) {
-        float original_min_erpm = mc_interface_get_configuration()->s_pid_min_erpm;
-        float original_sw = mc_interface_get_configuration()->foc_f_sw;
+		float original_min_erpm = mc_interface_get_configuration()->s_pid_min_erpm;
+		float original_sw = mc_interface_get_configuration()->foc_f_sw;
 
-        mc_interface_set_min_erpm(1.0);
+		mc_interface_set_min_erpm(1.0);
 
-        for( int a = 3000; a < 5000; a = a + 500 ) {
-              change_sw(a);
-              mc_interface_set_pid_speed(10.0);
-              chThdSleepMilliseconds(300);
-        }
+		for( int a = 3000; a < 5000; a = a + 500 ) {
+			mcpwm_foc_change_sw(a);
+			mc_interface_set_pid_speed(10.0);
+			chThdSleepMilliseconds(300);
+		}
                     
-
-        change_sw((int)original_sw);
-        mc_interface_set_min_erpm(original_min_erpm);
-        mc_interface_release_motor();
-        chThdSleepMilliseconds(50);
+		mcpwm_foc_change_sw((int)original_sw);
+		mc_interface_set_min_erpm(original_min_erpm);
+		mc_interface_release_motor();
+		chThdSleepMilliseconds(50);
         }
 #endif
 	commands_init();

--- a/mc_interface.c
+++ b/mc_interface.c
@@ -2698,3 +2698,7 @@ unsigned mc_interface_calc_crc(mc_configuration* conf_in, bool is_motor_2) {
 	conf->crc = crc_old;
 	return crc_new;
 }
+
+void mc_interface_set_min_erpm(float min_erpm) {
+        motor_now()->m_conf.s_pid_min_erpm = min_erpm;
+}

--- a/mc_interface.h
+++ b/mc_interface.h
@@ -91,6 +91,7 @@ float mc_interface_get_distance(void);
 float mc_interface_get_distance_abs(void);
 
 setup_values mc_interface_get_setup_values(void);
+void mc_interface_set_min_erpm(float min_erpm);
 
 // odometer
 uint64_t mc_interface_get_odometer(void);

--- a/mcpwm_foc.c
+++ b/mcpwm_foc.c
@@ -687,8 +687,8 @@ void mcpwm_foc_init(volatile mc_configuration *conf_m1, volatile mc_configuratio
 	m_init_done = true;
 }
 
-void change_sw(int f_sw) {
-        timer_reinit(f_sw);
+void mcpwm_foc_change_sw(int f_sw) {
+		timer_reinit(f_sw);
         }
 
 void mcpwm_foc_deinit(void) {

--- a/mcpwm_foc.c
+++ b/mcpwm_foc.c
@@ -687,6 +687,10 @@ void mcpwm_foc_init(volatile mc_configuration *conf_m1, volatile mc_configuratio
 	m_init_done = true;
 }
 
+void change_sw(int f_sw) {
+        timer_reinit(f_sw);
+        }
+
 void mcpwm_foc_deinit(void) {
 	if (!m_init_done) {
 		return;

--- a/mcpwm_foc.h
+++ b/mcpwm_foc.h
@@ -120,7 +120,7 @@ void mcpwm_foc_tim_sample_int_handler(void);
 void mcpwm_foc_adc_int_handler(void *p, uint32_t flags);
 
 //play tunes
-void change_sw(int f_sw);
+void mcpwm_foc_change_sw(int f_sw);
 
 // Defines
 #define MCPWM_FOC_CURRENT_SAMP_OFFSET				(2) // Offset from timer top for ADC samples

--- a/mcpwm_foc.h
+++ b/mcpwm_foc.h
@@ -119,6 +119,9 @@ mc_state mcpwm_foc_get_state_motor(bool is_second_motor);
 void mcpwm_foc_tim_sample_int_handler(void);
 void mcpwm_foc_adc_int_handler(void *p, uint32_t flags);
 
+//play tunes
+void change_sw(int f_sw);
+
 // Defines
 #define MCPWM_FOC_CURRENT_SAMP_OFFSET				(2) // Offset from timer top for ADC samples
 


### PR DESCRIPTION
==========  
**Although there are already some results, this pull request is still in-progress**   

The only issue right now: VESC tool sometimes become a bit more difficult to connect to. Currently solving.

==========
Based on the pull request #328 I made earlier, I was able to made a VESC startup tune prototype.
This is the result. 
[![Demo here](http://img.youtube.com/vi/eFeOw0AzH2c/0.jpg)](http://www.youtube.com/watch?v=eFeOw0AzH2c "Demo Here")
(I tested and it worked on both small drone motor and my 6" direct drive scooter hub motor.)

I will wait for Benjamin to review/approve #328 first, make necessary changes (if any), then submit the completed version of this startup tune feature in this pull request. 

Also, since "startup tune" will be a general feature, I will do more testing on it first.

==========
- Added config options to enable / disable the startup tune.  
- Does not require user to manually change the min_erpm for it to work, it will lower the min_erpm temporaily and revert back to original value after playing tunes.  
==========
Related issues:
#324 
https://vesc-project.com/node/647