### PR TITLE
Fixes in traction control for scooters

### DIFF
--- a/applications/app_adc.c
+++ b/applications/app_adc.c
@@ -34,6 +34,7 @@
 #define MIN_MS_WITHOUT_POWER			500
 #define FILTER_SAMPLES					5
 #define RPM_FILTER_SAMPLES				8
+#define TC_DIFF_MAX_PASS				60  // TODO: move to app_conf
 
 // Threads
 static THD_FUNCTION(adc_thread, arg);
@@ -541,6 +542,8 @@ static THD_FUNCTION(adc_thread, arg) {
 								}
 
 								float diff = rpm_tmp - rpm_lowest;
+                                if (diff < TC_DIFF_MAX_PASS) diff = 0;
+                                if (diff > config.tc_max_diff) diff = config.tc_max_diff;
 								current_out = utils_map(diff, 0.0, config.tc_max_diff, current_rel, 0.0);
 							}
 
@@ -554,6 +557,8 @@ static THD_FUNCTION(adc_thread, arg) {
 
 					if (config.tc) {
 						float diff = rpm_local - rpm_lowest;
+                        if (diff < TC_DIFF_MAX_PASS) diff = 0;
+                        if (diff > config.tc_max_diff) diff = config.tc_max_diff;
 						current_out = utils_map(diff, 0.0, config.tc_max_diff, current_rel, 0.0);
 					}
 				}


### PR DESCRIPTION
This commit changes 2 things: 
1. does not allow the motor current to go in the opposite direction relative to the movement (allows you to set less than 1000 tc_diff_max on large motors without jerks and kicks) 
2. adds the parameter of the permissible erpm and makes the function less "clear". In reality, on an electric scooter during acceleration, the difference is 40-60 erpm, so in any case, your implementation of traction control cuts off some of the power, but this correction will remove this problem.

I tested it in practice and it seems to me that it has a good effect on the use, but I did not add the option to adc_config, since I want to keep compatibility with the original vesc tool. 
If the commit is accepted, it is better to put the option that is now in define as the third item in the Traction Control settings, so that it can be disabled (0) or set a different value, depending on the desired severity of the algorithm