### PR TITLE
PAS: add constant torque control type

### DIFF
--- a/applications/app_pas.c
+++ b/applications/app_pas.c
@@ -207,6 +207,9 @@ static THD_FUNCTION(pas_thread, arg) {
 					}
 				}
 				break;
+			case PAS_CTRL_TYPE_CONSTANT_TORQUE:
+				output = pedal_rpm > config.pedal_rpm_start ? config.current_scaling : 0;
+				break;
 			default:
 				break;
 		}

--- a/confgenerator.h
+++ b/confgenerator.h
@@ -9,7 +9,7 @@
 
 // Constants
 #define MCCONF_SIGNATURE		3706516163
-#define APPCONF_SIGNATURE		1531606261
+#define APPCONF_SIGNATURE		763356168
 
 // Functions
 int32_t confgenerator_serialize_mcconf(uint8_t *buffer, const mc_configuration *conf);

--- a/datatypes.h
+++ b/datatypes.h
@@ -574,7 +574,8 @@ typedef enum {
 // PAS control types
 typedef enum {
 	PAS_CTRL_TYPE_NONE = 0,
-	PAS_CTRL_TYPE_CADENCE
+	PAS_CTRL_TYPE_CADENCE,
+	PAS_CTRL_TYPE_CONSTANT_TORQUE
 } pas_control_type;
 
 // PAS sensor types


### PR DESCRIPTION
For gearless electric bicycles, riding up the slope and during start,
good torque support from the motor helps the rider ride with less
effort. Pedal assist based on cadence provides higher torque with higher
pedalling speed. In the situations mentioned above, where user naturally
pedals slow, aid from cadence based system is less. On a geared setup,
changing to low gear comes to the rider's help.

Here another control type is provided - Constant Torque, whenever the
rider pedals, motor would provide constant torque. The torque value can
be set using 'PAS max current' setting thus acting as fine PAS assist
level.

This type of control is similar to 'Basic PAS, constant throttle' of
'PAS Control Schemes' [1], with the difference that throttle setting
in that article corresponds to speed, while here torque.

Also riding experience on some of the popular (not high end) e-bicycles
having PAS indicates they might be having this kind of control
internally.

[1] https://ebikes.ca/learn/pedal-assist.html

---

VESC tool pull request is being sent shortly