### PR TITLE
[Utils] Streamline `utils_saturate_vector_2d()`

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -331,7 +331,7 @@ float utils_fast_atan2(float y, float x) {
 }
 
 /**
- * Truncate the magnitude of a vector.
+ * Saturates the magnitude of a vector.
  *
  * @param x
  * The first component.
@@ -343,19 +343,23 @@ float utils_fast_atan2(float y, float x) {
  * The maximum magnitude.
  *
  * @return
- * True if saturation happened, false otherwise
+ * True if saturated, false otherwise
  */
 bool utils_saturate_vector_2d(float *x, float *y, float max) {
 	bool retval = false;
-	float mag = sqrtf(SQ(*x) + SQ(*y));
-	max = fabsf(max);
 
-	if (mag < 1e-10) {
-		mag = 1e-10;
+	float mag2 = SQ(*x) + SQ(*y);
+	float max2 = SQ(max);
+
+	// Ensure magnitude doesn't become too small
+	if (mag2 < 1e-20) {
+		mag2 = 1e-20;
 	}
 
-	if (mag > max) {
-		const float f = max / mag;
+	// Check if we need to normalize. Comparing the squared values
+	// because it `x ?> y` and `x^2 ?< y^2` give identical results.
+	if (mag2 > max2) {
+		const float f = sqrtf(max2 / mag2);
 		*x *= f;
 		*y *= f;
 		retval = true;


### PR DESCRIPTION
There was no need to do the `sqrt()` unless the absolute magnitude is exceeded. This compares squared values, and then if there is a need to normalize the `sqrt()` is taken only at that point.

Old:
```
   text	   data	    bss	    dec	    hex	filename
 275200	   3196	 140900	 419296	  665e0	build/BLDC_4_ChibiOS.elf```
```

New:
```
   text	   data	    bss	    dec	    hex	filename
 275200	   3196	 140900	 419296	  665e0	build/BLDC_4_ChibiOS.elf
```

So no change in size, which we expect. The `sqrt()` operation doesn't go away, it's just not used as often in real-world practice.

This does have the downside that the computational burden is no longer as predictable. It could be that a poor choice of saturation could cause this code branch to run materially slower than one where the maximum is well-chosen. The consequence is that this trades uniformity of experience for optimization of a frequently-called routine.

This has been unit tested, per the following cases:

```
//----------------------------------------
// Test fixture for utils_saturate_vector_2d()
//----------------------------------------
class Saturate2dVector : public MiscMath {
protected:
  virtual void SetUp() {
  }

  virtual void TearDown() {
  }
protected:
   float eps = 0.000001f;

};

TEST_F(Saturate2dVector, ValsInRange) {
   float inputVal_x;
   float inputVal_y;
   float inputVal_max;
   bool ret;

   inputVal_x = 1.0;
   inputVal_y = 1.0;
   inputVal_max = 10.0;
   ret = utils_saturate_vector_2d(&inputVal_x, &inputVal_y, inputVal_max);
   EXPECT_EQ(1, inputVal_x);
   EXPECT_EQ(1, inputVal_y);
   EXPECT_EQ(false, ret);

   inputVal_x = 1.0;
   inputVal_y = -1.0;
   inputVal_max = 10.0;
   ret = utils_saturate_vector_2d(&inputVal_x, &inputVal_y, inputVal_max);
   EXPECT_EQ(1, inputVal_x);
   EXPECT_EQ(-1, inputVal_y);
   EXPECT_EQ(false, ret);

   inputVal_x = -1.0;
   inputVal_y = 1.0;
   inputVal_max = 10.0;
   ret = utils_saturate_vector_2d(&inputVal_x, &inputVal_y, inputVal_max);
   EXPECT_EQ(-1, inputVal_x);
   EXPECT_EQ(1, inputVal_y);
   EXPECT_EQ(false, ret);

   inputVal_x = -1.0;
   inputVal_y = -1.0;
   inputVal_max = 10.0;
   ret = utils_saturate_vector_2d(&inputVal_x, &inputVal_y, inputVal_max);
   EXPECT_EQ(-1, inputVal_x);
   EXPECT_EQ(-1, inputVal_y);
   EXPECT_EQ(false, ret);
}


TEST_F(Saturate2dVector, ValsOnEdgeOfRange) {
   float inputVal_x;
   float inputVal_y;
   float inputVal_max;
   bool ret;

   inputVal_x = 1.0;
   inputVal_y = 1.0;
   inputVal_max = sqrt(2);
   ret = utils_saturate_vector_2d(&inputVal_x, &inputVal_y, inputVal_max);
   EXPECT_NEAR(1, inputVal_x, eps);
   EXPECT_NEAR(1, inputVal_y, eps);
}
TEST_F(Saturate2dVector, ValsBeyondRange) {
   float inputVal_x;
   float inputVal_y;
   float inputVal_max;
   bool ret;

   inputVal_x = 10.0;
   inputVal_y = 10.0;
   inputVal_max = 10.0;
   ret = utils_saturate_vector_2d(&inputVal_x, &inputVal_y, inputVal_max);
   EXPECT_NEAR(10/sqrt(2), inputVal_x, eps);
   EXPECT_NEAR(10/sqrt(2), inputVal_y, eps);
   EXPECT_EQ(true, ret);

   inputVal_x = -10.0;
   inputVal_y = -10.0;
   inputVal_max = 10.0;
   ret = utils_saturate_vector_2d(&inputVal_x, &inputVal_y, inputVal_max);
   EXPECT_NEAR(-10/sqrt(2), inputVal_x, eps);
   EXPECT_NEAR(-10/sqrt(2), inputVal_y, eps);
   EXPECT_EQ(true, ret);

   inputVal_x = 10.0;
   inputVal_y = -10.0;
   inputVal_max = 10.0;
   ret = utils_saturate_vector_2d(&inputVal_x, &inputVal_y, inputVal_max);
   EXPECT_NEAR(10/sqrt(2), inputVal_x, eps);
   EXPECT_NEAR(-10/sqrt(2), inputVal_y, eps);
   EXPECT_EQ(true, ret);

   inputVal_x = -10.0;
   inputVal_y = 10.0;
   inputVal_max = 10.0;
   ret = utils_saturate_vector_2d(&inputVal_x, &inputVal_y, inputVal_max);
   EXPECT_NEAR(-10/sqrt(2), inputVal_x, eps);
   EXPECT_NEAR(10/sqrt(2), inputVal_y, eps);
   EXPECT_EQ(true, ret);

}

TEST_F(Saturate2dVector, ValsAreDegenerate) {
   float inputVal_x;
   float inputVal_y;
   float inputVal_max;
   bool ret;

   inputVal_x = 0.0;
   inputVal_y = 0.0;
   inputVal_max = 0.0;
   ret = utils_saturate_vector_2d(&inputVal_x, &inputVal_y, inputVal_max);
   EXPECT_EQ(0, inputVal_x);
   EXPECT_EQ(0, inputVal_y);
   EXPECT_EQ(true, ret);

   inputVal_x = 1.0;
   inputVal_y = 1.0;
   inputVal_max = -10.0;
   ret = utils_saturate_vector_2d(&inputVal_x, &inputVal_y, inputVal_max);
   EXPECT_EQ(1, inputVal_x);
   EXPECT_EQ(1, inputVal_y);
   EXPECT_EQ(false, ret);

   inputVal_x = 10.0;
   inputVal_y = 10.0;
   inputVal_max = -10.0;
   ret = utils_saturate_vector_2d(&inputVal_x, &inputVal_y, inputVal_max);
   EXPECT_NEAR(10/sqrt(2), inputVal_x, eps);
   EXPECT_NEAR(10/sqrt(2), inputVal_y, eps);
   EXPECT_EQ(true, ret);
}
```

All tests pass.

## Degenerate case for a negative maximum

Interestingly, there's a degenerate case of what to do with a negative maximum value. Every time `utils_saturate_vector_2d()` is called in the project code there is no possibility of a negative value. If a negative value *were* passed to the original function then no scaling would have happened (`if (mag > max)...`). However, with the new code, a negative maximum could result in scaling by the absolute value of the maximum. (It currently doesn't because of the `if (mag2 < 1e-20)` catch.)

I'm not sure which is best, they both seem like bad outcomes, but it seems more robust to normalize than to ignore a value because of its sign.