### PR TITLE
uartcomm use TIME_INFINITE in thread wait

### DIFF
--- a/applications/app_uartcomm.c
+++ b/applications/app_uartcomm.c
@@ -229,7 +229,7 @@ static THD_FUNCTION(packet_process_thread, arg) {
 	}
 
 	for(;;) {
-		chEvtWaitAnyTimeout(ALL_EVENTS, ST2MS(10));
+		chEvtWaitAnyTimeout(ALL_EVENTS, TIME_INFINITE);
 
 		bool rx = true;
 		while (rx) {


### PR DESCRIPTION
Currently uart thread waits for new data with CHN_INPUT_AVAILABLE event only for 10 ticks, and after that expires continues execution to try to get new byte even if there is no new data available.

Insted use TIME_INFINITE to wait for new uart data.

Same logic could be implemented in CAN read thread but i haven't tested that.

