### PR TITLE
[Math][Optimization] Provide a CPU-efficient boxcar average

### DIFF
--- a/applications/app_adc.c
+++ b/applications/app_adc.c
@@ -129,19 +129,18 @@ static THD_FUNCTION(adc_thread, arg) {
 		read_voltage = pwr;
 
 		// Optionally apply a moving mean value filter
-		if (config.use_filter) {
+		{
 			static float pwrFilter_buffer[FILTER_SAMPLES] = { 0.0 };  // Initialize to all 0s. This is important insider the filter.
 
 			static MovingMeanFilterObject pwrFilterObj = {
-			   .filter_buffer = pwrFilter_buffer,
-			   .nominal_num_samples = FILTER_SAMPLES,
-			   .inv_nominal_num_samples = 1.0f/FILTER_SAMPLES,
-			   .current_idx = 0,
-			   .accumulator = 0,
-			   .isBufferFull = false
+				.filter_buffer = pwrFilter_buffer,
+				.nominal_num_samples = FILTER_SAMPLES,
+				.inv_nominal_num_samples = 1.0f/FILTER_SAMPLES,
+				.current_idx = 0,
+				.accumulator.val = 0,
 			};
 
-			pwr = utils_moving_average_filter_f(pwr, &pwrFilterObj);
+			pwr = utils_moving_average_filter_f(pwr, &pwrFilterObj, config.use_filter);
 		}
 
 		// Map the read voltage
@@ -192,7 +191,7 @@ static THD_FUNCTION(adc_thread, arg) {
 		read_voltage2 = brake;
 
 		// Optionally apply a moving mean value filter
-		if (config.use_filter) {
+		{
 			static float brakeFilter_buffer[FILTER_SAMPLES] = { 0.0 };  // Initialize to all 0s. This is important insider the filter.
 
 			static MovingMeanFilterObject brakeFilterObj = {
@@ -200,11 +199,10 @@ static THD_FUNCTION(adc_thread, arg) {
 			   .nominal_num_samples = FILTER_SAMPLES,
 			   .inv_nominal_num_samples = 1.0f/FILTER_SAMPLES,
 			   .current_idx = 0,
-			   .accumulator = 0,
-			   .isBufferFull = false
+			   .accumulator.val = 0,
 			};
 
-			brake = utils_moving_average_filter_f(brake, &brakeFilterObj);
+			brake = utils_moving_average_filter_f(brake, &brakeFilterObj, config.use_filter);
 		}
 
 		// Map and truncate the read voltage
@@ -438,11 +436,10 @@ static THD_FUNCTION(adc_thread, arg) {
 		   .nominal_num_samples = RPM_FILTER_SAMPLES,
 		   .inv_nominal_num_samples = 1.0f/RPM_FILTER_SAMPLES,
 		   .current_idx = 0,
-		   .accumulator = 0,
-		   .isBufferFull = false
+		   .accumulator.val = 0,
 		};
 
-		float rpm_filtered = utils_moving_average_filter_f(mc_interface_get_rpm(), &rpmFilterObj);
+		float rpm_filtered = utils_moving_average_filter_f(mc_interface_get_rpm(), &rpmFilterObj, true);
 
 
 		if (current_mode && cc_button && fabsf(pwr) < 0.001) {

--- a/applications/app_adc.c
+++ b/applications/app_adc.c
@@ -133,7 +133,7 @@ static THD_FUNCTION(adc_thread, arg) {
 			static float filter_buffer[FILTER_SAMPLES];  // ANSI-C guarantees this will initialize to all 0s. This is important insider the filter.
 			static uint32_t filter_current_idx = 0;
 			static float filtered_pwr_accum = 0;
-			static bool isBufferFull = true;
+			static bool isBufferFull = false;
 
 			pwr = utils_moving_average_filter_f(pwr, &filtered_pwr_accum, filter_buffer, &filter_current_idx, &isBufferFull, FILTER_SAMPLES);
 		}
@@ -429,7 +429,7 @@ static THD_FUNCTION(adc_thread, arg) {
 		static float filter_buffer[RPM_FILTER_SAMPLES];  // ANSI-C guarantees this will initialize to all 0s. This is important insider the filter.
 		static uint32_t filter_current_idx = 0;
 		static float filtered_pwr_accum = 0;
-		static bool isBufferFull = true;
+		static bool isBufferFull = false;
 
 		float rpm_filtered = utils_moving_average_filter_f(mc_interface_get_rpm(), &filtered_pwr_accum, filter_buffer, &filter_current_idx, &isBufferFull, FILTER_SAMPLES);
 

--- a/datatypes.h
+++ b/datatypes.h
@@ -1313,9 +1313,11 @@ typedef struct {
    float *filter_buffer;  // Initialize to all 0s. This is important inside the filter.
    uint32_t nominal_num_samples;  // the nominal number of samples/taps in the filter
    float inv_nominal_num_samples;  // The inverse of the above, used to avoid a division operation
-   uint32_t current_idx;  // The index for the new sample
-   float accumulator;  // The summing accumulator (which will be divided by the number of samples in order to calculate the average)
-   bool isBufferFull;  // Whether the buffer has reached capacity yet
+   uint16_t current_idx;  // The index for the new sample
+   union float_bytes {
+      float val;  // The summing accumulator (which will be divided by the number of samples in order to calculate the average)
+      uint32_t bytes;
+   } accumulator;
 } MovingMeanFilterObject;
 
 

--- a/datatypes.h
+++ b/datatypes.h
@@ -1309,4 +1309,15 @@ typedef struct __attribute__((packed)) {
 	uint64_t runtime; // Seconds
 } backup_data;
 
+typedef struct {
+   float *filter_buffer;  // Initialize to all 0s. This is important inside the filter.
+   uint32_t nominal_num_samples;  // the nominal number of samples/taps in the filter
+   float inv_nominal_num_samples;  // The inverse of the above, used to avoid a division operation
+   uint32_t current_idx;  // The index for the new sample
+   float accumulator;  // The summing accumulator (which will be divided by the number of samples in order to calculate the average)
+   bool isBufferFull;  // Whether the buffer has reached capacity yet
+} MovingMeanFilterObject;
+
+
+
 #endif /* DATATYPES_H_ */

--- a/utils.c
+++ b/utils.c
@@ -841,46 +841,42 @@ const char* utils_hw_type_to_string(HW_TYPE hw) {
  * recompute the entire sum for i=k..k+N, it exploites the fact that the sum from i=k-1..k+N-1 is
  * known from the previous iteration. Thus, all that remains is to do is remove val[k-1] and add
  * val[k+N].
- * @param val The fresh value
- * @param filter_accum The summing accumulator (which will be divided by the number of samples in order to calculate the average)
- * @param filter_buffer The ring buffer of filter samples
- * @param filter_new_idx The index for the new sample
- * @param isBufferFull Whether the buffer has reached capacity yet
- * @param nominal_num_samples the nominal number of samples/taps in the filter
+ * @param val The fresh value to be added to the filter
+ * @param filterObj A structure of the parameters needed for the filter. See the `struct`'s defintition for a description of the fields
  * @return the moving average
  */
-float utils_moving_average_filter_f(float val, float *filter_accum, float *filter_buffer, uint32_t *filter_new_idx, bool *isBufferFull, uint32_t nominal_num_samples) {
-   uint32_t filter_old_idx = *filter_new_idx + 1;
+float utils_moving_average_filter_f(float val, MovingMeanFilterObject *filterObj) {
+   uint32_t filter_old_idx = filterObj->current_idx + 1;
 
    // Wrap the index around the circular buffer
-   if (filter_old_idx >= nominal_num_samples) {
+   if (filter_old_idx >= filterObj->nominal_num_samples) {
       filter_old_idx = 0;
 
-      if (*isBufferFull == false) {
-         *isBufferFull = true;
+      if (filterObj->isBufferFull == false) {
+         filterObj->isBufferFull = true;
       }
    }
 
    // Store sample in buffer
-   filter_buffer[*filter_new_idx] = val;
+   filterObj->filter_buffer[filterObj->current_idx] = val;
 
    // Add the newest value to the moving accumulator
-   *filter_accum += filter_buffer[*filter_new_idx];
+   filterObj->accumulator += filterObj->filter_buffer[filterObj->current_idx];
 
    // Remove the oldest value from the moving accumulator. Note that we are depending on the oldest values being 0 when this is first starting out
-   *filter_accum -= filter_buffer[filter_old_idx];
+   filterObj->accumulator -= filterObj->filter_buffer[filter_old_idx];
 
-   *filter_new_idx = filter_old_idx;
+   filterObj->current_idx = filter_old_idx;
 
-   if (*isBufferFull == false) {
+   if (filterObj->isBufferFull == false) {
       // This looks weird, and like we might even be able to accidentally divide by 0, but
       //   that's ultimately not the case since `filter_old_idx` can only equal 0 at the same time
       //   as isFirstLoop = false.
       // This `if()` an important nuance because it keeps the filter from intializing incorrectly
       //   from sum(i=1..1)/NUM_SAMPLES
-      return *filter_accum/filter_old_idx;
+      return filterObj->accumulator/filter_old_idx;
    } else {
-      return *filter_accum/nominal_num_samples;
+      return filterObj->accumulator * filterObj->inv_nominal_num_samples;
    }
 }
 

--- a/utils.c
+++ b/utils.c
@@ -847,7 +847,7 @@ const char* utils_hw_type_to_string(HW_TYPE hw) {
  */
 float utils_moving_average_filter_f(const float val, MovingMeanFilterObject *filterObj, const bool isFilterOn) {
    // Set a magic value which represents that the filter is dirty and can't be used until the accumulator is reset
-   static const uint32_t MAGIC_DIRTY = 0xFFFFFFFF;
+   static const typeof(filterObj->accumulator.bytes) MAGIC_DIRTY = (typeof(filterObj->accumulator.bytes))UINT64_MAX;
 
    // Increment the index
    filterObj->current_idx++;

--- a/utils.c
+++ b/utils.c
@@ -837,7 +837,7 @@ const char* utils_hw_type_to_string(HW_TYPE hw) {
 
 
 /**
- * @brief utils_moving_average_filter_f This is the classic CPU-efficicient implementation of a moving average filter. Rather than
+ * @brief utils_moving_average_filter_f This is the classic CPU-efficient implementation of a moving average filter. Rather than
  * recompute the entire sum for i=k..k+N, it exploites the fact that the sum from i=k-1..k+N-1 is
  * known from the previous iteration. Thus, all that remains is to do is remove val[k-1] and add
  * val[k+N].
@@ -856,8 +856,8 @@ float utils_moving_average_filter_f(float val, float *filter_accum, float *filte
    if (filter_old_idx >= nominal_num_samples) {
       filter_old_idx = 0;
 
-      if (*isBufferFull == true) {
-         *isBufferFull = false;
+      if (*isBufferFull == false) {
+         *isBufferFull = true;
       }
    }
 
@@ -872,7 +872,7 @@ float utils_moving_average_filter_f(float val, float *filter_accum, float *filte
 
    *filter_new_idx = filter_old_idx;
 
-   if (*isBufferFull == true) {
+   if (*isBufferFull == false) {
       // This looks weird, and like we might even be able to accidentally divide by 0, but
       //   that's ultimately not the case since `filter_old_idx` can only equal 0 at the same time
       //   as isFirstLoop = false.

--- a/utils.h
+++ b/utils.h
@@ -66,6 +66,7 @@ float utils_batt_liion_norm_v_to_capacity(float norm_v);
 uint16_t utils_median_filter_uint16_run(uint16_t *buffer,
 		unsigned int *buffer_index, unsigned int filter_len, uint16_t sample);
 const char* utils_hw_type_to_string(HW_TYPE hw);
+float utils_moving_average_filter_f(float val, float *filter_accum, float *filter_buffer, uint32_t *filter_new_idx, bool *isBufferFull, uint32_t max_filter_samples);
 
 // Return the sign of the argument. -1 if negative, 1 if zero or positive.
 #define SIGN(x)				((x < 0) ? -1 : 1)

--- a/utils.h
+++ b/utils.h
@@ -66,7 +66,7 @@ float utils_batt_liion_norm_v_to_capacity(float norm_v);
 uint16_t utils_median_filter_uint16_run(uint16_t *buffer,
 		unsigned int *buffer_index, unsigned int filter_len, uint16_t sample);
 const char* utils_hw_type_to_string(HW_TYPE hw);
-float utils_moving_average_filter_f(float val, MovingMeanFilterObject *filterObj);
+float utils_moving_average_filter_f(const float val, MovingMeanFilterObject *filterObj, const bool isFilterOn);
 
 // Return the sign of the argument. -1 if negative, 1 if zero or positive.
 #define SIGN(x)				((x < 0) ? -1 : 1)

--- a/utils.h
+++ b/utils.h
@@ -66,7 +66,7 @@ float utils_batt_liion_norm_v_to_capacity(float norm_v);
 uint16_t utils_median_filter_uint16_run(uint16_t *buffer,
 		unsigned int *buffer_index, unsigned int filter_len, uint16_t sample);
 const char* utils_hw_type_to_string(HW_TYPE hw);
-float utils_moving_average_filter_f(float val, float *filter_accum, float *filter_buffer, uint32_t *filter_new_idx, bool *isBufferFull, uint32_t max_filter_samples);
+float utils_moving_average_filter_f(float val, MovingMeanFilterObject *filterObj);
 
 // Return the sign of the argument. -1 if negative, 1 if zero or positive.
 #define SIGN(x)				((x < 0) ? -1 : 1)


### PR DESCRIPTION
This is the classic CPU-efficient implementation of a moving average filter. Rather than recompute the entire sum for `i=k..k+N`, it exploites the fact that the sum from `i=k-1..k+N-1` is known from the previous iteration. Thus, all that remains is to do is remove `val[k-1]` and add `val[k+N]`. So an arbitrarily large O(n) filter becomes size invariant with only 2 addition operations.

I have not looked to see if there were other opportunities for using this CPU-optimized moving window filter. It's not clear to me how often this ADC thread runs, but I think it might be 500Hz. So this saves 6-12 floating point additions per loop, depending on if the ADC filter is turned on. If I'm right that it's a 500Hz loop, that's 3000-6000FPU operations/sec. That's not terrible!

It's also important to point out that previously, when the filter was first turned on the initial results were compromised because the filter was dividing by the *nominal* number of samples, but until the filter is completely filled it should be divided by the actual number of samples.

### Before
```
   text	   data	    bss	    dec	    hex	filename
 300976	   3444	 144884	 449304	  6db18	build/BLDC_4_ChibiOS.elf
```
### After
```
   text	   data	    bss	    dec	    hex	filename
 301152	   3444	 144892	 449488	  6dbd0	build/BLDC_4_ChibiOS.elf
```
NOTE: Not tested, not even unit tested.