### PR TITLE
Simplify foc fpu math

### DIFF
--- a/mcpwm_foc.c
+++ b/mcpwm_foc.c
@@ -2990,8 +2990,11 @@ void mcpwm_foc_adc_int_handler(void *p, uint32_t flags) {
 		}
 
 		// Update corresponding modulation
-		motor_now->m_motor_state.mod_d = motor_now->m_motor_state.vd / ((2.0 / 3.0) * motor_now->m_motor_state.v_bus);
-		motor_now->m_motor_state.mod_q = motor_now->m_motor_state.vq / ((2.0 / 3.0) * motor_now->m_motor_state.v_bus);
+		/* voltageNormalize = 1/(2/3*V_bus) */
+		const float voltageNormalize = 1.5 / motor_now->m_motor_state.v_bus;
+
+		motor_now->m_motor_state.mod_d = motor_now->m_motor_state.vd * voltageNormalize;
+		motor_now->m_motor_state.mod_q = motor_now->m_motor_state.vq * voltageNormalize;
 	}
 
 	// Calculate duty cycle
@@ -3791,10 +3794,13 @@ static void control_current(volatile motor_all_state_t *motor, float dt) {
 
 	utils_saturate_vector_2d((float*)&state_m->vd, (float*)&state_m->vq, max_v_mag);
 
-    // mod_d and mod_q are normalized such that 1 corresponds to the max possible voltage. This includes overmodulation and therefore cannot be made in any direction.
-    // Note that this scaling is different than max_v_mag, which is without over modulation.
-	state_m->mod_d = state_m->vd / ((2.0 / 3.0) * state_m->v_bus); 
-	state_m->mod_q = state_m->vq / ((2.0 / 3.0) * state_m->v_bus);
+	// mod_d and mod_q are normalized such that 1 corresponds to the max possible voltage:
+	//    voltageNormalize = 1/(2/3*V_bus)
+	// This includes overmodulation and therefore cannot be made in any direction.
+	// Note that this scaling is different from max_v_mag, which is without over modulation.
+	const float voltageNormalize = 1.5 / state_m->v_bus;
+	state_m->mod_d = state_m->vd * voltageNormalize;
+	state_m->mod_q = state_m->vq * voltageNormalize;
 
 	// TODO: Have a look at this?
 #ifdef HW_HAS_INPUT_CURRENT_SENSOR
@@ -3851,14 +3857,14 @@ static void control_current(volatile motor_all_state_t *motor, float dt) {
 				motor->m_hfi.ready = true;
 			}
 
-			mod_alpha_tmp += hfi_voltage * utils_tab_sin_32_1[motor->m_hfi.ind * motor->m_hfi.table_fact] / ((2.0 / 3.0) * state_m->v_bus);
-			mod_beta_tmp -= hfi_voltage * utils_tab_cos_32_1[motor->m_hfi.ind * motor->m_hfi.table_fact] / ((2.0 / 3.0) * state_m->v_bus);
+			mod_alpha_tmp += hfi_voltage * utils_tab_sin_32_1[motor->m_hfi.ind * motor->m_hfi.table_fact] * voltageNormalize;
+			mod_beta_tmp -= hfi_voltage * utils_tab_cos_32_1[motor->m_hfi.ind * motor->m_hfi.table_fact] * voltageNormalize;
 		} else {
 			motor->m_hfi.prev_sample = utils_tab_sin_32_1[motor->m_hfi.ind * motor->m_hfi.table_fact] * state_m->i_alpha -
 					utils_tab_cos_32_1[motor->m_hfi.ind * motor->m_hfi.table_fact] * state_m->i_beta;
 
-			mod_alpha_tmp -= hfi_voltage * utils_tab_sin_32_1[motor->m_hfi.ind * motor->m_hfi.table_fact] / ((2.0 / 3.0) * state_m->v_bus);
-			mod_beta_tmp += hfi_voltage * utils_tab_cos_32_1[motor->m_hfi.ind * motor->m_hfi.table_fact] / ((2.0 / 3.0) * state_m->v_bus);
+			mod_alpha_tmp -= hfi_voltage * utils_tab_sin_32_1[motor->m_hfi.ind * motor->m_hfi.table_fact] * voltageNormalize;
+			mod_beta_tmp += hfi_voltage * utils_tab_cos_32_1[motor->m_hfi.ind * motor->m_hfi.table_fact] * voltageNormalize;
 		}
 
 		utils_saturate_vector_2d(&mod_alpha_tmp, &mod_beta_tmp, SQRT3_BY_2 * 0.95);
@@ -3985,8 +3991,11 @@ static void update_valpha_vbeta(volatile motor_all_state_t *motor, float mod_alp
 	// Keep the modulation updated so that the filter stays updated
 	// even when the motor is undriven.
 	if (motor->m_state != MC_STATE_RUNNING) {
-		mod_alpha = v_alpha / ((2.0 / 3.0) * state_m->v_bus);
-		mod_beta = v_beta / ((2.0 / 3.0) * state_m->v_bus);
+		/* voltageNormalize = 1/(2/3*V_bus) */
+		const float voltageNormalize = 1.5 / state_m->v_bus;
+
+		mod_alpha = v_alpha * voltageNormalize;
+		mod_beta = v_beta * voltageNormalize;
 	}
 
 	float abs_rpm = fabsf(RADPS2RPM_f(motor->m_pll_speed));


### PR DESCRIPTION
This simplifies math, eliminating FPU operations --and in particular FPU divisions-- on the critical ADC interrupt handler pathway.

There should be no effect aside from more compact, more streamlined assembly code.

### Before
```
   text	   data	    bss	    dec	    hex	filename
 300896	   3444	 144964	 449304	  6db18	build/BLDC_4_ChibiOS.elf
```

### After

```
   text	   data	    bss	    dec	    hex	filename
 300704	   3444	 144964	 449112	  6da58	build/BLDC_4_ChibiOS.elf
```

## Example output

Note there is one less division and one less operation; there's no access of the program counter; and `1.5` is able to be loaded by a `vmov.f32` instruction (which likely helps the ART accelerator optimize predictive caching at run-time). It's not much of a difference, but it's free for the taking.

This also isn't the complete story since `voltageNormalize` is reused further down in the code, saving at least two additional divisions. Divisions take 14 cycles per operation, so this alone is a net savings of >50 cycles per ADC interrupt.

### Before
```
	state_m->mod_d = state_m->vd / ((2.0 / 3.0) * state_m->v_bus);
 8029670:	ed94 6a1f 	vldr	s12, [r4, #124]	; 0x7c
 8029674:	eddf 6ae2 	vldr	s13, [pc, #904]	; 8029a00 <mcpwm_foc_adc_int_handler+0x12b0>
 8029678:	ed94 7a16 	vldr	s14, [r4, #88]	; 0x58
 802967c:	ee27 7a26 	vmul.f32	s14, s14, s13
 8029680:	eec6 7a07 	vdiv.f32	s15, s12, s14
 8029684:	edc4 7a19 	vstr	s15, [r4, #100]	; 0x64
	state_m->mod_q = state_m->vq / ((2.0 / 3.0) * state_m->v_bus);
 8029688:	ed94 6a20 	vldr	s12, [r4, #128]	; 0x80
 802968c:	edd4 7a16 	vldr	s15, [r4, #88]	; 0x58
 8029690:	ee67 7aa6 	vmul.f32	s15, s15, s13
 8029694:	ee86 7a27 	vdiv.f32	s14, s12, s15
 8029698:	ed84 7a1a 	vstr	s14, [r4, #104]	; 0x68
```

### After
```
	const float voltageNormalize = 1.5 / state_m->v_bus;
 8029564:	edd4 7a1f 	vldr	s15, [r4, #124]	; 0x7c
 8029568:	eef7 6a08 	vmov.f32	s13, #120	; 0x3fc00000  1.5
 802956c:	eec6 aa87 	vdiv.f32	s21, s13, s14
	state_m->mod_d = state_m->vd * voltageNormalize;
 8029560:	ed94 7a16 	vldr	s14, [r4, #88]	; 0x58
 8029570:	ee6a 7aa7 	vmul.f32	s15, s21, s15
 8029574:	edc4 7a19 	vstr	s15, [r4, #100]	; 0x64
	state_m->mod_q = state_m->vq * voltageNormalize;
 8029578:	edd4 7a20 	vldr	s15, [r4, #128]	; 0x80
 802957c:	ee6a 7aa7 	vmul.f32	s15, s21, s15
 8029580:	edc4 7a1a 	vstr	s15, [r4, #104]	; 0x68
```