### PR TITLE
Turn FPU math into truth table

### DIFF
--- a/math/optimized_helper_functions.h
+++ b/math/optimized_helper_functions.h
@@ -1,0 +1,95 @@
+/*
+	Copyright 2021 Kenn Sebesta
+
+	This file is part of the VESC firmware.
+
+	The VESC firmware is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    The VESC firmware is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    */
+
+#ifndef OPTIMIZED_HELPER_FUNCTIONS_H_
+#define OPTIMIZED_HELPER_FUNCTIONS_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "datatypes.h"
+#include <math.h>
+#include <stdlib.h>
+
+// This takes advantage of the IEEE 754 standard, which requires that the sign
+// bit of single-precision floats is the last bit.
+// It is faster than `signbit()` because it does not have a bit shift and does no type checking.
+// On the flip side, it is dangerous because it does no checking of any kind. It will
+// not care if the input is not a `float`, if it is `NaN`, etc...
+// It is guaranteed to work on all systems which adhere to IEEE 754.
+// This works on both big- and little-endian systems.
+// The macro returns 1 if a `float` is negative, 0 if otherwise
+#define IS_FLOAT_IEEE754_NEGATIVE(x) (*(uint32_t *)(&(x)) & (1U<<31))
+
+
+/**
+ * @brief calculate_mod_alpha_beta_filter_sign Exploits the fact that two of the three
+ * currents will always have the same sign, and the third will always have the opposite sign.
+ * @param mod_alpha_filter_sgn Returns a value on the set of [-4/3, -2/3, 2/3, 4/3]
+ * @param mod_beta_filter_sgn Returns a value on the set of [-2/sqrt(3), 0, 2/sqrt(3)]
+ * @param ia_filter The filtered i_a
+ * @param ib_filter The filtered i_b
+ * @param ic_filter The filtered i_c
+ */
+inline __attribute__((always_inline)) void calculate_mod_alpha_beta_filter_sign(float *mod_alpha_filter_sgn, float *mod_beta_filter_sgn, float ia_filter, float ib_filter, float ic_filter) {
+	// This calculates the below code, which is effectively a truth table with floats as outputs:
+	//    mod_alpha_filter_sgn = (1.0 / 3.0) * (2 * SIGN(ia_filter) - SIGN(ib_filter) - SIGN(ic_filter));
+	//    mod_beta_filter_sgn = ONE_BY_SQRT3 * (SIGN(ib_filter) - SIGN(ic_filter));
+
+	/* Perform a compile-time assert, checking that a float and a uint32_t are the same size on this machine. */
+	_Static_assert(sizeof(float) == sizeof(uint32_t), "This compilation is not compatible. Please fix the IEEE754 relationship between floats and uints");
+
+#pragma GCC diagnostic push  // Stores any GCC directives
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"  // Disables the strict-aliasing directive. This is necessary for the IS_FLOAT_IEEE754_NEGATIVE() macro.
+
+	// Check if both `ib_filter` and `ic_filter` have the same sign.
+	if (IS_FLOAT_IEEE754_NEGATIVE(ib_filter) == IS_FLOAT_IEEE754_NEGATIVE(ic_filter)) {
+		// Both `ib_filter` and `ic_filter` have the same sign, so they cancel out
+		*mod_beta_filter_sgn = 0;
+
+		// Check if `ia_filter` is negative
+		if (IS_FLOAT_IEEE754_NEGATIVE(ia_filter)) {
+			// ia_filter is negative, which means both `ib_filter` and `ic_filter` are positive.
+			*mod_alpha_filter_sgn = -4.0 / 3.0;
+		} else {
+			// ia_filter is positive, which means both `ib_filter` and `ic_filter` are negative.
+			*mod_alpha_filter_sgn =  4.0 / 3.0;
+		}
+	} else  {
+		// `ib_filter` and `ic_filter` have opposite signs
+
+		if (IS_FLOAT_IEEE754_NEGATIVE(ia_filter)) {
+			// ia_filter is negative. `ib_filter` and `ic_filter` have opposite signs so they cancel out.
+			*mod_alpha_filter_sgn = -2.0 / 3.0;
+		} else {
+			// ia_filter is positive. `ib_filter` and `ic_filter` have opposite signs so they cancel out.
+			*mod_alpha_filter_sgn =  2.0 / 3.0;
+		}
+
+		if (IS_FLOAT_IEEE754_NEGATIVE(ib_filter)) {
+			// ib_filter is negative, ic_filter is positive
+			*mod_beta_filter_sgn = -TWO_BY_SQRT3;
+		} else {
+			// ib_filter is positive, ic_filter is negative
+			*mod_beta_filter_sgn =  TWO_BY_SQRT3;
+		}
+	}
+#pragma GCC diagnostic pop  // This restores the GCC directives
+}
+
+#endif  // OPTIMIZED_HELPER_FUNCTIONS_H_

--- a/math/optimized_helper_functions.h
+++ b/math/optimized_helper_functions.h
@@ -47,6 +47,10 @@
  * @param ic_filter The filtered i_c
  */
 inline __attribute__((always_inline)) void calculate_mod_alpha_beta_filter_sign(float *mod_alpha_filter_sgn, float *mod_beta_filter_sgn, float ia_filter, float ib_filter, float ic_filter) {
+#ifdef FLOAT_BITWISE_OPTIMIZATIONS_TURNED_OFF
+	*mod_alpha_filter_sgn = (1.0 / 3.0) * (2 * SIGN(ia_filter) - SIGN(ib_filter) - SIGN(ic_filter));
+	*mod_beta_filter_sgn = ONE_BY_SQRT3 * (SIGN(ib_filter) - SIGN(ic_filter));
+#else
 	// This calculates the below code, which is effectively a truth table with floats as outputs:
 	//    mod_alpha_filter_sgn = (1.0 / 3.0) * (2 * SIGN(ia_filter) - SIGN(ib_filter) - SIGN(ic_filter));
 	//    mod_beta_filter_sgn = ONE_BY_SQRT3 * (SIGN(ib_filter) - SIGN(ic_filter));
@@ -90,6 +94,7 @@ inline __attribute__((always_inline)) void calculate_mod_alpha_beta_filter_sign(
 		}
 	}
 #pragma GCC diagnostic pop  // This restores the GCC directives
+#endif
 }
 
 #endif  // OPTIMIZED_HELPER_FUNCTIONS_H_

--- a/mcpwm_foc.c
+++ b/mcpwm_foc.c
@@ -38,6 +38,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <assert.h>
 #include "virtual_motor.h"
 #include "digital_filter.h"
 
@@ -3557,6 +3558,73 @@ static THD_FUNCTION(pid_thread, arg) {
 	}
 }
 
+// This takes advantage of the IEEE 754 standard, which requires that the sign
+// bit of single-precision floats is the last bit.
+// It is faster than `signbit()` because it does not have a bit shift and does no type checking.
+// On the flip side, it is dangerous because it does no checking of any kind. It will
+// not care if the input is not a `float`, if it is `NaN`, etc...
+// It is guaranteed to work on all systems which adhere to IEEE 754.
+// This works on both big- and little-endian systems.
+// The macro returns 1 if a `float` is negative, 0 if otherwise
+#define IS_FLOAT_IEEE754_NEGATIVE(x) (*(uint32_t *)(&(x)) & (1U<<31))
+
+
+/**
+ * @brief calculate_mod_alpha_beta_filter_sign Exploits the fact that two of the three
+ * currents will always have the same sign, and the third will always have the opposite sign.
+ * @param mod_alpha_filter_sgn Returns a value on the set of [-4/3, -2/3, 2/3, 4/3]
+ * @param mod_beta_filter_sgn Returns a value on the set of [-2/sqrt(3), 0, 2/sqrt(3)]
+ * @param ia_filter The filtered i_a
+ * @param ib_filter The filtered i_b
+ * @param ic_filter The filtered i_c
+ */
+inline __attribute__((always_inline)) void calculate_mod_alpha_beta_filter_sign(float *mod_alpha_filter_sgn, float *mod_beta_filter_sgn, float ia_filter, float ib_filter, float ic_filter) {
+	// This calculates the below code, which is effectively a truth table with floats as outputs:
+	//    mod_alpha_filter_sgn = (1.0 / 3.0) * (2 * SIGN(ia_filter) - SIGN(ib_filter) - SIGN(ic_filter));
+	//    mod_beta_filter_sgn = ONE_BY_SQRT3 * (SIGN(ib_filter) - SIGN(ic_filter));
+
+	/* Perform a compile-time assert, checking that a float and a uint32_t are the same size on this machine. */
+	_Static_assert(sizeof(float) == sizeof(uint32_t), "This compilation is not compatible. Please fix the IEEE754 relationship between floats and uints");
+
+
+#pragma GCC diagnostic push  // Stores any GCC directives
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"  // Disables the strict-aliasing directive. This is necessary for the IS_FLOAT_IEEE754_NEGATIVE() macro.
+	// Check if both `ib_filter` and `ic_filter` have the same sign.
+	if (IS_FLOAT_IEEE754_NEGATIVE(ib_filter) == IS_FLOAT_IEEE754_NEGATIVE(ic_filter)) {
+		// Both `ib_filter` and `ic_filter` have the same sign, so they cancel out
+		*mod_beta_filter_sgn = 0;
+
+		// Check if `ia_filter` is negative
+		if (IS_FLOAT_IEEE754_NEGATIVE(ia_filter)) {
+			// ia_filter is negative, which means both `ib_filter` and `ic_filter` are positive.
+			*mod_alpha_filter_sgn = -4.0 / 3.0;
+		} else {
+			// ia_filter is positive, which means both `ib_filter` and `ic_filter` are negative.
+			*mod_alpha_filter_sgn =  4.0 / 3.0;
+		}
+	} else  {
+		// `ib_filter` and `ic_filter` have opposite signs
+
+		if (IS_FLOAT_IEEE754_NEGATIVE(ia_filter)) {
+			// ia_filter is negative. `ib_filter` and `ic_filter` have opposite signs so they cancel out.
+			*mod_alpha_filter_sgn = -2.0 / 3.0;
+		} else {
+			// ia_filter is positive. `ib_filter` and `ic_filter` have opposite signs so they cancel out.
+			*mod_alpha_filter_sgn =  2.0 / 3.0;
+		}
+
+		if (IS_FLOAT_IEEE754_NEGATIVE(ib_filter)) {
+			// ib_filter is negative, ic_filter is positive
+			*mod_beta_filter_sgn = -TWO_BY_SQRT3;
+		} else {
+			// ib_filter is positive, ic_filter is negative
+			*mod_beta_filter_sgn =  TWO_BY_SQRT3;
+		}
+	}
+#pragma GCC diagnostic pop  // This restores the GCC directives
+}
+
+
 // See http://cas.ensmp.fr/~praly/Telechargement/Journaux/2010-IEEE_TPEL-Lee-Hong-Nam-Ortega-Praly-Astolfi.pdf
 void observer_update(float v_alpha, float v_beta, float i_alpha, float i_beta,
 					 float dt, volatile float *x1, volatile float *x2, volatile float *phase, volatile motor_all_state_t *motor) {
@@ -3976,10 +4044,10 @@ static void update_valpha_vbeta(volatile motor_all_state_t *motor, float mod_alp
 	const float ib_filter = -0.5 * i_alpha_filter + SQRT3_BY_2 * i_beta_filter;
 	const float ic_filter = -0.5 * i_alpha_filter - SQRT3_BY_2 * i_beta_filter;
 
-	/* mod_alpha_sign = 2/3*sign(ia) - 1/3*sign(ib) - 1/3*sign(ic) */
-	/* mod_beta_sign  = 1/sqrt(3)*sign(ib) - 1/sqrt(3)*sign(ic) */
-	const float mod_alpha_filter_sgn = (1.0 / 3.0) * (2.0 * SIGN(ia_filter) - SIGN(ib_filter) - SIGN(ic_filter));
-	const float mod_beta_filter_sgn = ONE_BY_SQRT3 * (SIGN(ib_filter) - SIGN(ic_filter));
+	// Why are we calculating these variables?
+	float mod_alpha_filter_sgn;
+	float mod_beta_filter_sgn;
+	calculate_mod_alpha_beta_filter_sign(&mod_alpha_filter_sgn, &mod_beta_filter_sgn, ia_filter, ib_filter, ic_filter);
 
 	const float mod_comp_fact = conf_now->foc_dt_us * 1e-6 * conf_now->foc_f_sw;
 	const float mod_alpha_comp = mod_alpha_filter_sgn * mod_comp_fact;

--- a/mcpwm_foc.c
+++ b/mcpwm_foc.c
@@ -41,6 +41,7 @@
 #include <assert.h>
 #include "virtual_motor.h"
 #include "digital_filter.h"
+#include "math/optimized_helper_functions.h"
 
 // Private types
 typedef struct {
@@ -3558,73 +3559,6 @@ static THD_FUNCTION(pid_thread, arg) {
 	}
 }
 
-// This takes advantage of the IEEE 754 standard, which requires that the sign
-// bit of single-precision floats is the last bit.
-// It is faster than `signbit()` because it does not have a bit shift and does no type checking.
-// On the flip side, it is dangerous because it does no checking of any kind. It will
-// not care if the input is not a `float`, if it is `NaN`, etc...
-// It is guaranteed to work on all systems which adhere to IEEE 754.
-// This works on both big- and little-endian systems.
-// The macro returns 1 if a `float` is negative, 0 if otherwise
-#define IS_FLOAT_IEEE754_NEGATIVE(x) (*(uint32_t *)(&(x)) & (1U<<31))
-
-
-/**
- * @brief calculate_mod_alpha_beta_filter_sign Exploits the fact that two of the three
- * currents will always have the same sign, and the third will always have the opposite sign.
- * @param mod_alpha_filter_sgn Returns a value on the set of [-4/3, -2/3, 2/3, 4/3]
- * @param mod_beta_filter_sgn Returns a value on the set of [-2/sqrt(3), 0, 2/sqrt(3)]
- * @param ia_filter The filtered i_a
- * @param ib_filter The filtered i_b
- * @param ic_filter The filtered i_c
- */
-inline __attribute__((always_inline)) void calculate_mod_alpha_beta_filter_sign(float *mod_alpha_filter_sgn, float *mod_beta_filter_sgn, float ia_filter, float ib_filter, float ic_filter) {
-	// This calculates the below code, which is effectively a truth table with floats as outputs:
-	//    mod_alpha_filter_sgn = (1.0 / 3.0) * (2 * SIGN(ia_filter) - SIGN(ib_filter) - SIGN(ic_filter));
-	//    mod_beta_filter_sgn = ONE_BY_SQRT3 * (SIGN(ib_filter) - SIGN(ic_filter));
-
-	/* Perform a compile-time assert, checking that a float and a uint32_t are the same size on this machine. */
-	_Static_assert(sizeof(float) == sizeof(uint32_t), "This compilation is not compatible. Please fix the IEEE754 relationship between floats and uints");
-
-
-#pragma GCC diagnostic push  // Stores any GCC directives
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"  // Disables the strict-aliasing directive. This is necessary for the IS_FLOAT_IEEE754_NEGATIVE() macro.
-	// Check if both `ib_filter` and `ic_filter` have the same sign.
-	if (IS_FLOAT_IEEE754_NEGATIVE(ib_filter) == IS_FLOAT_IEEE754_NEGATIVE(ic_filter)) {
-		// Both `ib_filter` and `ic_filter` have the same sign, so they cancel out
-		*mod_beta_filter_sgn = 0;
-
-		// Check if `ia_filter` is negative
-		if (IS_FLOAT_IEEE754_NEGATIVE(ia_filter)) {
-			// ia_filter is negative, which means both `ib_filter` and `ic_filter` are positive.
-			*mod_alpha_filter_sgn = -4.0 / 3.0;
-		} else {
-			// ia_filter is positive, which means both `ib_filter` and `ic_filter` are negative.
-			*mod_alpha_filter_sgn =  4.0 / 3.0;
-		}
-	} else  {
-		// `ib_filter` and `ic_filter` have opposite signs
-
-		if (IS_FLOAT_IEEE754_NEGATIVE(ia_filter)) {
-			// ia_filter is negative. `ib_filter` and `ic_filter` have opposite signs so they cancel out.
-			*mod_alpha_filter_sgn = -2.0 / 3.0;
-		} else {
-			// ia_filter is positive. `ib_filter` and `ic_filter` have opposite signs so they cancel out.
-			*mod_alpha_filter_sgn =  2.0 / 3.0;
-		}
-
-		if (IS_FLOAT_IEEE754_NEGATIVE(ib_filter)) {
-			// ib_filter is negative, ic_filter is positive
-			*mod_beta_filter_sgn = -TWO_BY_SQRT3;
-		} else {
-			// ib_filter is positive, ic_filter is negative
-			*mod_beta_filter_sgn =  TWO_BY_SQRT3;
-		}
-	}
-#pragma GCC diagnostic pop  // This restores the GCC directives
-}
-
-
 // See http://cas.ensmp.fr/~praly/Telechargement/Journaux/2010-IEEE_TPEL-Lee-Hong-Nam-Ortega-Praly-Astolfi.pdf
 void observer_update(float v_alpha, float v_beta, float i_alpha, float i_beta,
 					 float dt, volatile float *x1, volatile float *x2, volatile float *phase, volatile motor_all_state_t *motor) {
@@ -4044,7 +3978,8 @@ static void update_valpha_vbeta(volatile motor_all_state_t *motor, float mod_alp
 	const float ib_filter = -0.5 * i_alpha_filter + SQRT3_BY_2 * i_beta_filter;
 	const float ic_filter = -0.5 * i_alpha_filter - SQRT3_BY_2 * i_beta_filter;
 
-	// Why are we calculating these variables?
+	// Calculates the compensation required to account for deadtime current flowing through the flyback diode
+	// C.f. https://github.com/vedderb/bldc/pull/374#issuecomment-962933450
 	float mod_alpha_filter_sgn;
 	float mod_beta_filter_sgn;
 	calculate_mod_alpha_beta_filter_sign(&mod_alpha_filter_sgn, &mod_beta_filter_sgn, ia_filter, ib_filter, ic_filter);


### PR DESCRIPTION
I noticed that the below code was evaluated completely from the signs of `float` arguments:

```
mod_alpha_filter_sgn = (1.0 / 3.0) * (2.0 * SIGN(ia_filter) - SIGN(ib_filter) - SIGN(ic_filter));
mod_beta_filter_sgn = ONE_BY_SQRT3 * (SIGN(ib_filter) - SIGN(ic_filter));
```

Thus this is really just a truth table. This PR eliminates all the FPU math involved, resulting in an extremely streamlined calculation.

This is approximately 9x more performant in testing. On the testbed (nrf52840) it trims ~380 cycles per iteration down to ~47 cycles. It also compiles 96 bytes smaller, to boot.

It is not immediately easy to read, I have done my best to comment the crap out of this code so that it's obvious what's going on.

If anyone can fill in the reason for calculating this quantity, I would like to drop a comment in to explain how the outputs of this function are used.

Note that this PR makes bitwise use of the IEEE 754 spec by exploiting the fact that the last bit is reserved for the sign. This optimization is portable: it will work on big- and little-endian processors, and to the best of my knowledge there are no readily available processors which do not adhere to IEEE 754.