### PR TITLE
Frequency response function

### DIFF
--- a/confgenerator.c
+++ b/confgenerator.c
@@ -113,6 +113,10 @@ int32_t confgenerator_serialize_mcconf(uint8_t *buffer, const mc_configuration *
 	buffer_append_uint16(buffer, conf->foc_hfi_start_samples, &ind);
 	buffer_append_float32_auto(buffer, conf->foc_hfi_obs_ovr_sec, &ind);
 	buffer[ind++] = conf->foc_hfi_samples;
+	buffer_append_float32_auto(buffer, conf->foc_prbs_voltage, &ind);
+	buffer_append_float32_auto(buffer, conf->foc_prbs_current, &ind);
+	buffer[ind++] = conf->foc_prbs_channel;
+	buffer[ind++] = conf->foc_prbs_mode;
 	buffer[ind++] = conf->foc_offsets_cal_on_boot;
 	buffer_append_float32_auto(buffer, conf->foc_offsets_current[0], &ind);
 	buffer_append_float32_auto(buffer, conf->foc_offsets_current[1], &ind);
@@ -482,6 +486,10 @@ bool confgenerator_deserialize_mcconf(const uint8_t *buffer, mc_configuration *c
 	conf->foc_hfi_start_samples = buffer_get_uint16(buffer, &ind);
 	conf->foc_hfi_obs_ovr_sec = buffer_get_float32_auto(buffer, &ind);
 	conf->foc_hfi_samples = buffer[ind++];
+	conf->foc_prbs_voltage = buffer_get_float32_auto(buffer, &ind);
+	conf->foc_prbs_current = buffer_get_float32_auto(buffer, &ind);
+	conf->foc_prbs_channel = buffer[ind++];
+	conf->foc_prbs_mode = buffer[ind++];
 	conf->foc_offsets_cal_on_boot = buffer[ind++];
 	conf->foc_offsets_current[0] = buffer_get_float32_auto(buffer, &ind);
 	conf->foc_offsets_current[1] = buffer_get_float32_auto(buffer, &ind);
@@ -847,6 +855,10 @@ void confgenerator_set_defaults_mcconf(mc_configuration *conf) {
 	conf->foc_hfi_start_samples = MCCONF_FOC_HFI_START_SAMPLES;
 	conf->foc_hfi_obs_ovr_sec = MCCONF_FOC_HFI_OBS_OVR_SEC;
 	conf->foc_hfi_samples = MCCONF_FOC_HFI_SAMPLES;
+	conf->foc_prbs_voltage = MCCONF_FOC_PRBS_VOLTAGE;
+	conf->foc_prbs_current = MCCONF_FOC_PRBS_CURRENT;
+	conf->foc_prbs_channel = MCCONF_FOC_PRBS_CHANNEL;
+	conf->foc_prbs_mode = MCCONF_FOC_PRBS_MODE;
 	conf->foc_offsets_cal_on_boot = MCCONF_FOC_OFFSETS_CAL_ON_BOOT;
 	conf->foc_offsets_current[0] = MCCONF_FOC_OFFSETS_CURRENT_0;
 	conf->foc_offsets_current[1] = MCCONF_FOC_OFFSETS_CURRENT_1;

--- a/confgenerator.h
+++ b/confgenerator.h
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 
 // Constants
-#define MCCONF_SIGNATURE		2525666056
+#define MCCONF_SIGNATURE		55037106
 #define APPCONF_SIGNATURE		3733512279
 
 // Functions

--- a/datatypes.h
+++ b/datatypes.h
@@ -234,6 +234,18 @@ typedef enum {
 } foc_hfi_samples;
 
 typedef enum {
+   PRBS_CHANNEL_D = 0,
+   PRBS_CHANNEL_Q,
+   PRBS_CHANNEL_DQ,
+} foc_prbs_channel_enum;
+
+typedef enum {
+   PRBS_MODE_OFF = 0,
+   PRBS_MODE_CURRRENT,
+   PRBS_MODE_VOLTAGE,
+} foc_prbs_mode_enum;
+
+typedef enum {
 	BMS_TYPE_NONE = 0,
 	BMS_TYPE_VESC
 } BMS_TYPE;
@@ -416,6 +428,12 @@ typedef struct {
 	uint16_t foc_hfi_start_samples;
 	float foc_hfi_obs_ovr_sec;
 	foc_hfi_samples foc_hfi_samples;
+
+	float foc_prbs_voltage;
+	float foc_prbs_current;
+	foc_prbs_channel_enum foc_prbs_channel;
+	foc_prbs_mode_enum foc_prbs_mode;
+
 	bool foc_offsets_cal_on_boot;
 	float foc_offsets_current[3];
 	float foc_offsets_voltage[3];

--- a/mc_interface.c
+++ b/mc_interface.c
@@ -98,7 +98,7 @@ static volatile motor_if_state_t m_motor_2;
 #endif
 
 // Sampling variables
-#define ADC_SAMPLE_MAX_LEN		2000
+#define ADC_SAMPLE_MAX_LEN		2048
 __attribute__((section(".ram4"))) static volatile int16_t m_curr0_samples[ADC_SAMPLE_MAX_LEN];
 __attribute__((section(".ram4"))) static volatile int16_t m_curr1_samples[ADC_SAMPLE_MAX_LEN];
 __attribute__((section(".ram4"))) static volatile int16_t m_ph1_samples[ADC_SAMPLE_MAX_LEN];

--- a/mc_interface.c
+++ b/mc_interface.c
@@ -2053,7 +2053,13 @@ void mc_interface_mc_timer_isr(bool is_second_motor) {
 			m_vzero_samples[m_sample_now] = zero;
 			m_curr_fir_samples[m_sample_now] = (int16_t)(current * (8.0 / FAC_CURRENT));
 			m_f_sw_samples[m_sample_now] = (int16_t)(f_samp / 10.0);
-			m_frf_samples_mV[m_sample_now] = (int16_t)(mcpwm_foc_get_vd() * 1000 + 0.5);
+
+			if (conf_now->foc_prbs_channel == PRBS_CHANNEL_D) {
+				m_frf_samples_mV[m_sample_now] = (int16_t)(mcpwm_foc_get_vd() * 1000 + 0.5);
+			} else if (conf_now->foc_prbs_channel == PRBS_CHANNEL_Q) {
+				m_frf_samples_mV[m_sample_now] = (int16_t)(mcpwm_foc_get_vq() * 1000 + 0.5);
+			}
+
 			m_status_samples[m_sample_now] = (mcpwm_foc_get_prbs() << 7) | (((mcpwm_read_hall_phase() << 3) | mcpwm_get_comm_step()) & 0x7F);
 
 			m_sample_now++;

--- a/mcconf/mcconf_default.h
+++ b/mcconf/mcconf_default.h
@@ -394,6 +394,18 @@
 #ifndef MCCONF_FOC_HFI_SAMPLES
 #define MCCONF_FOC_HFI_SAMPLES			HFI_SAMPLES_16 // Samples per motor revolution for HFI
 #endif
+#ifndef MCCONF_FOC_PRBS_VOLTAGE
+#define MCCONF_FOC_PRBS_VOLTAGE  		3  //
+#endif
+#ifndef MCCONF_FOC_PRBS_CURRENT
+#define MCCONF_FOC_PRBS_CURRENT  		1  //
+#endif
+#ifndef MCCONF_FOC_PRBS_CHANNEL
+#define MCCONF_FOC_PRBS_CHANNEL			PRBS_CHANNEL_D  //
+#endif
+#ifndef MCCONF_FOC_PRBS_MODE
+#define MCCONF_FOC_PRBS_MODE				PRBS_MODE_OFF  //
+#endif
 #ifndef MCCONF_FOC_OFFSETS_CAL_ON_BOOT
 #define MCCONF_FOC_OFFSETS_CAL_ON_BOOT	true // Measure offsets every boot
 #endif

--- a/mcpwm_foc.h
+++ b/mcpwm_foc.h
@@ -105,6 +105,7 @@ float mcpwm_foc_get_ts(void);
 bool mcpwm_foc_is_using_encoder(void);
 void mcpwm_foc_get_observer_state(float *x1, float *x2);
 void mcpwm_foc_set_current_off_delay(float delay_sec);
+bool mcpwm_foc_get_prbs(void);
 
 // Functions where the motor can be selected
 float mcpwm_foc_get_tot_current_motor(bool is_second_motor);


### PR DESCRIPTION
Developed in collaboration with @ErwinBoots, this was the outgrowth of https://vesc-project.com/node/3257.

It has been used a fair amount on a VESC6 Mk3, and seems to work well. 

This needs to be merged alongside https://github.com/vedderb/vesc_tool/pull/177.

One limitation which we would like to move past at some point soon is the ability to get multiple samples sequentially. Ideally a user should be able to get several cycles of data and average them together for a cleaner signal.

@vedderb could you let us know how this looks? In particular, notice how we have hijacked the `hfi` configuration to configure this as well. Obviously that's not okay, but I'm not really sure the right way to do this.