### PR TITLE
Minor adjustments for HW_RD2 & the build tool-chain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endif
 
 # Enable this if you want to see the full log while compiling.
 ifeq ($(USE_VERBOSE_COMPILE),)
-  USE_VERBOSE_COMPILE = yes
+  USE_VERBOSE_COMPILE = no
 endif
 
 # If enabled, this option makes the build process faster by not compiling

--- a/Makefile
+++ b/Makefile
@@ -322,3 +322,6 @@ upload-pi-remote: build/$(PROJECT).elf
 
 debug-start:
 	openocd -f stm32-bv_openocd.cfg
+
+size: build/$(PROJECT).elf
+	@$(SZ) $<

--- a/hwconf/hw_rd2.c
+++ b/hwconf/hw_rd2.c
@@ -232,7 +232,7 @@ void hw_try_restore_i2c(void) {
 	}
 }
 
-float hw75_300_get_temp(void) {
+float hw_rd2_get_temp(void) {
 	float t1 = (1.0 / ((logf(NTC_RES(ADC_Value[ADC_IND_TEMP_MOS]) / 10000.0) / 3380.0) + (1.0 / 298.15)) - 273.15);
 	float t2 = (1.0 / ((logf(NTC_RES(ADC_Value[ADC_IND_TEMP_MOS_2]) / 10000.0) / 3380.0) + (1.0 / 298.15)) - 273.15);
 	float t3 = (1.0 / ((logf(NTC_RES(ADC_Value[ADC_IND_TEMP_MOS_3]) / 10000.0) / 3380.0) + (1.0 / 298.15)) - 273.15);

--- a/hwconf/hw_rd2.h
+++ b/hwconf/hw_rd2.h
@@ -17,8 +17,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
     */
 
-#ifndef HW_75_300_H_
-#define HW_75_300_H_
+#ifndef HW_RD2_H_
+#define HW_RD2_H_
 
 #define HW_NAME					"RD2"
 
@@ -108,7 +108,7 @@
 
 // NTC Termistors
 #define NTC_RES(adc_val)		((4095.0 * 10000.0) / adc_val - 10000.0)
-#define NTC_TEMP(adc_ind)		hw75_300_get_temp()
+#define NTC_TEMP(adc_ind)		hw_rd2_get_temp()
 
 #define NTC_RES_MOTOR(adc_val)	(10000.0 / ((4095.0 / (float)adc_val) - 1.0)) // Motor temp sensor on low side
 
@@ -255,13 +255,19 @@
 #define MCCONF_L_MAX_ABS_CURRENT		480.0
 #endif
 #ifndef MCCONF_L_RPM_MAX
-#define MCCONF_L_RPM_MAX				30000.0
+#define MCCONF_L_RPM_MAX				30750.0
 #endif
 #ifndef MCCONF_L_RPM_MIN
-#define MCCONF_L_RPM_MIN				-30000.0
+#define MCCONF_L_RPM_MIN				-30750.0
 #endif
 #ifndef MCCONF_L_RPM_START
-#define MCCONF_L_RPM_START				0.9
+#define MCCONF_L_RPM_START				0.8
+#endif
+#ifndef MCCONF_L_WATT_MAX
+#define MCCONF_L_WATT_MAX				11000.0
+#endif
+#ifndef MCCONF_L_WATT_MIN
+#define MCCONF_L_WATT_MIN				-11000.0
 #endif
 #ifndef MCCONF_FOC_CURRENT_KP
 #define MCCONF_FOC_CURRENT_KP			0.01
@@ -290,16 +296,16 @@
 
 // Setup Info
 #ifndef MCCONF_SI_MOTOR_POLES
-#define MCCONF_SI_MOTOR_POLES			8 // Motor pole count
+#define MCCONF_SI_MOTOR_POLES			8
 #endif
 #ifndef MCCONF_SI_BATTERY_TYPE
-#define MCCONF_SI_BATTERY_TYPE			BATTERY_TYPE_LIION_3_0__4_2 // Battery Type
+#define MCCONF_SI_BATTERY_TYPE			BATTERY_TYPE_LIION_3_0__4_2
 #endif
 #ifndef MCCONF_SI_BATTERY_CELLS
-#define MCCONF_SI_BATTERY_CELLS			14 // Battery Cells
+#define MCCONF_SI_BATTERY_CELLS			14
 #endif
 #ifndef MCCONF_SI_BATTERY_AH
-#define MCCONF_SI_BATTERY_AH			69.0 // Battery amp hours
+#define MCCONF_SI_BATTERY_AH			69.0
 #endif
 
 // Setting limits
@@ -313,6 +319,6 @@
 #define HW_LIM_TEMP_FET			-40.0, 110.0
 
 // HW-specific functions
-float hw75_300_get_temp(void);
+float hw_rd2_get_temp(void);
 
-#endif /* HW_75_300_H_ */
+#endif /* HW_RD2_H_ */


### PR DESCRIPTION
For the tool chain, turned of verbose build output and added a target size rule. For the hw_rd2, naming adjustments of the inclusion guard and the get_temperature function (old legacy names, not valid for this target), and some minor changes/cleanup of the accompanied config params.