### PR TITLE
Increase max imu rate

### DIFF
--- a/imu/bmi160_wrapper.c
+++ b/imu/bmi160_wrapper.c
@@ -80,9 +80,12 @@ static bool reset_init_bmi(BMI_STATE *s) {
 	}else if(s->rate_hz <= 800){
 		s->sensor.accel_cfg.odr = BMI160_ACCEL_ODR_800HZ;
 		s->sensor.gyro_cfg.odr = BMI160_GYRO_ODR_800HZ;
-	}else{
+	}else if(s->rate_hz <= 1600){
 		s->sensor.accel_cfg.odr = BMI160_ACCEL_ODR_1600HZ;
 		s->sensor.gyro_cfg.odr = BMI160_GYRO_ODR_1600HZ;
+	}else{
+		s->sensor.accel_cfg.odr = BMI160_ACCEL_ODR_1600HZ;
+		s->sensor.gyro_cfg.odr = BMI160_GYRO_ODR_3200HZ;
 	}
 
 	chThdSleepMilliseconds(50);

--- a/imu/lsm6ds3.c
+++ b/imu/lsm6ds3.c
@@ -188,7 +188,7 @@ static THD_FUNCTION(lsm6ds3_thread, arg) {
 		}
 
 		// Delay between loops
-		chThdSleepMilliseconds((int)((1000.0 / rate_hz)));
+		chThdSleepMicroseconds(1000000 / rate_hz);
 	}
 }
 


### PR DESCRIPTION
Small PR to increase the max allowed IMU update rate. I've found I can get a slight performance gain with a higher rate. Some of the supported IMUs have output data rates up to 8khz so I figured I'd set the max to 10khz.