### PR TITLE
Flux linkage clunk fix

### DIFF
--- a/conf_general.c
+++ b/conf_general.c
@@ -1076,6 +1076,7 @@ bool conf_general_measure_flux_linkage_openloop(float current, float duty,
 		mcconf->foc_observer_gain = 0.5e3 / SQ(*linkage);
 		mc_interface_set_configuration(mcconf);
 		chThdSleepMilliseconds(500);
+		mcpwm_foc_stop_pwm(0);
 		mcpwm_foc_set_current(0.0);
 		chThdSleepMilliseconds(5);
 

--- a/conf_general.c
+++ b/conf_general.c
@@ -1075,9 +1075,17 @@ bool conf_general_measure_flux_linkage_openloop(float current, float duty,
 		mcconf->foc_motor_flux_linkage = *linkage;
 		mcconf->foc_observer_gain = 0.5e3 / SQ(*linkage);
 		mc_interface_set_configuration(mcconf);
+
+		// Give the observer time to settle
 		chThdSleepMilliseconds(500);
-		mcpwm_foc_stop_pwm(0);
+
+		// Turn off the FETs
+		mcpwm_foc_stop_pwm(false);
+
+		// Clear any lingering current set points
 		mcpwm_foc_set_current(0.0);
+
+		// Let the H-bridges settle
 		chThdSleepMilliseconds(5);
 
 		float linkage_sum = 0.0;


### PR DESCRIPTION
@mxlemming was observing brutal deceleration events while doing FOC parameter detection: https://youtu.be/5-GUBNtrckA

@ElwinBoots found a potential fix. Basically, the system was driving the current to 0 instead of letting the system decelerate on its own.

Below is the output from Elwin's o-scope, before and after.

#### Clunk, no fix:
https://discord.com/channels/904830990319485030/910536475488190464/923900927931469874

#### Fix, no clunk:
https://discord.com/channels/904830990319485030/910536475488190464/923901070424551447

We'd like some wider test coverage to see if this perturbs parameter identification.