### PR TITLE
[MCPWM_FOC] Make rotor lock feature use D axis

### DIFF
--- a/mcpwm_foc.c
+++ b/mcpwm_foc.c
@@ -890,7 +890,8 @@ void mcpwm_foc_set_pid_pos(float pos) {
 void mcpwm_foc_set_current(float current) {
 	motor_now()->m_control_mode = CONTROL_MODE_CURRENT;
 	motor_now()->m_iq_set = current;
-
+	motor_now()->m_id_set = 0;
+	
 	if (fabsf(current) < motor_now()->m_conf->cc_min_current) {
 		return;
 	}
@@ -980,7 +981,8 @@ void mcpwm_foc_set_openloop_phase(float current, float phase) {
 						  motor_now()->m_conf->l_current_max * motor_now()->m_conf->l_current_max_scale);
 
 	motor_now()->m_control_mode = CONTROL_MODE_OPENLOOP_PHASE;
-	motor_now()->m_iq_set = current;
+	motor_now()->m_id_set = current;
+	motor_now()->m_iq_set = 0;
 
 	motor_now()->m_openloop_phase = DEG2RAD_f(phase);
 	utils_norm_angle_rad((float*)&motor_now()->m_openloop_phase);
@@ -2786,7 +2788,7 @@ void mcpwm_foc_adc_int_handler(void *p, uint32_t flags) {
 					motor_now->m_motor_state.phase = motor_now->m_phase_now_encoder_no_index;
 				}
 
-				if (!motor_now->m_phase_override) {
+				if (!motor_now->m_phase_override && motor_now->m_control_mode != CONTROL_MODE_OPENLOOP_PHASE) {
 					id_set_tmp = 0.0;
 				}
 				break;
@@ -2794,7 +2796,7 @@ void mcpwm_foc_adc_int_handler(void *p, uint32_t flags) {
 				motor_now->m_phase_now_observer = correct_hall(motor_now->m_phase_now_observer, dt, motor_now);
 				motor_now->m_motor_state.phase = motor_now->m_phase_now_observer;
 
-				if (!motor_now->m_phase_override) {
+				if (!motor_now->m_phase_override && motor_now->m_control_mode != CONTROL_MODE_OPENLOOP_PHASE) {
 					id_set_tmp = 0.0;
 				}
 				break;
@@ -2807,7 +2809,7 @@ void mcpwm_foc_adc_int_handler(void *p, uint32_t flags) {
 					motor_now->m_motor_state.phase = motor_now->m_phase_now_observer;
 				}
 
-				if (!motor_now->m_phase_override) {
+				if (!motor_now->m_phase_override && motor_now->m_control_mode != CONTROL_MODE_OPENLOOP_PHASE) {
 					id_set_tmp = 0.0;
 				}
 				break;
@@ -2824,7 +2826,7 @@ void mcpwm_foc_adc_int_handler(void *p, uint32_t flags) {
 					motor_now->m_phase_observer_override = false;
 				}
 
-				if (!motor_now->m_phase_override) {
+				if (!motor_now->m_phase_override && motor_now->m_control_mode != CONTROL_MODE_OPENLOOP_PHASE) {
 					id_set_tmp = 0.0;
 				}
 				break;
@@ -2847,7 +2849,7 @@ void mcpwm_foc_adc_int_handler(void *p, uint32_t flags) {
 						conf_now->foc_sl_erpm_hfi,
 						motor_now);
 
-				if (!motor_now->m_phase_override) {
+				if (!motor_now->m_phase_override && motor_now->m_control_mode != CONTROL_MODE_OPENLOOP_PHASE) {
 					id_set_tmp = 0.0;
 				}
 				break;
@@ -3175,7 +3177,9 @@ static void timer_update(volatile motor_all_state_t *motor, float dt) {
 					motor->m_control_mode == CONTROL_MODE_HANDBRAKE ||
 					motor->m_control_mode == CONTROL_MODE_OPENLOOP ||
 					motor->m_control_mode == CONTROL_MODE_OPENLOOP_PHASE)) {
+		// For various control modes, check whether the controller needs to be disabled. Disable when current request is below threshold and field weakening has stopped.
 		if (fabsf(motor->m_iq_set) < motor->m_conf->cc_min_current &&
+				fabsf(motor->m_id_set) < motor->m_conf->cc_min_current &&
 				motor->m_i_fw_set < motor->m_conf->cc_min_current &&
 				motor->m_current_off_delay < dt) {
 			motor->m_control_mode = CONTROL_MODE_NONE;


### PR DESCRIPTION
Changes rotor lock feature from Q axis to D axis. This has two advantages:
1. Now the angle you put in is the angle you really get in the alpha beta frame (no 90 degree offset).
2. Now when the rotor is being locked, the D axis is really the D axis and Q is really the Q axis. This helps for FRF measurements.

HT to @ElwinBoots

Tested extensively by @mxlemming and @ElwinBoots.