### PR TITLE
Balance App: bugfix for speed based variable tiltback config

### DIFF
--- a/applications/app_balance.c
+++ b/applications/app_balance.c
@@ -214,7 +214,11 @@ void app_balance_configure(balance_config *conf, imu_config *conf2) {
 
 	// Variable nose angle adjustment / tiltback (setting is per 1000erpm, convert to per erpm)
 	tiltback_variable = balance_conf.tiltback_variable / 1000;
-	tiltback_variable_max_erpm = fabsf(balance_conf.tiltback_variable_max / tiltback_variable);
+	if (tiltback_variable > 0) {
+		tiltback_variable_max_erpm = fabsf(balance_conf.tiltback_variable_max / tiltback_variable);
+	} else {
+		tiltback_variable_max_erpm = 100000;
+	}
 
 	// Reset loop time variables
 	last_time = 0;


### PR DESCRIPTION
Avoid division by zero