### PR TITLE
Adjusted PWM switching frequency to match the setting

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -1698,15 +1698,15 @@ void commands_apply_mcconf_hw_limits(mc_configuration *mcconf) {
 #ifdef HW_LIM_FOC_CTRL_LOOP_FREQ
     if (mcconf->foc_sample_v0_v7 == true) {
     	//control loop executes twice per pwm cycle when sampling in v0 and v7
-		utils_truncate_number(&mcconf->foc_f_sw, HW_LIM_FOC_CTRL_LOOP_FREQ);
-		ctrl_loop_freq = mcconf->foc_f_sw;
+		utils_truncate_number(&mcconf->foc_f_sw, HW_LIM_FOC_CTRL_LOOP_FREQ / 2.0);
+		ctrl_loop_freq = mcconf->foc_f_sw * 2.0;
     } else {
 #ifdef HW_HAS_DUAL_MOTORS
-    	utils_truncate_number(&mcconf->foc_f_sw, HW_LIM_FOC_CTRL_LOOP_FREQ);
-    	ctrl_loop_freq = mcconf->foc_f_sw;
+    	utils_truncate_number(&mcconf->foc_f_sw, HW_LIM_FOC_CTRL_LOOP_FREQ / 2.0);
+    	ctrl_loop_freq = mcconf->foc_f_sw * 2.0;
 #else
-		utils_truncate_number(&mcconf->foc_f_sw, HW_LIM_FOC_CTRL_LOOP_FREQ * 2.0);
-		ctrl_loop_freq = mcconf->foc_f_sw / 2.0;
+		utils_truncate_number(&mcconf->foc_f_sw, HW_LIM_FOC_CTRL_LOOP_FREQ);
+		ctrl_loop_freq = mcconf->foc_f_sw;
 #endif
     }
 #endif
@@ -1976,7 +1976,7 @@ static THD_FUNCTION(blocking_thread, arg) {
 				float current = buffer_get_float32(data, 1e3, &ind);
 
 				mcconf->motor_type = MOTOR_TYPE_FOC;
-				mcconf->foc_f_sw = 10000.0;
+				mcconf->foc_f_sw = 5000.0;
 				mcconf->foc_current_kp = 0.01;
 				mcconf->foc_current_ki = 10.0;
 				mc_interface_set_configuration(mcconf);
@@ -2024,7 +2024,7 @@ static THD_FUNCTION(blocking_thread, arg) {
 				float current = buffer_get_float32(data, 1e3, &ind);
 
 				mcconf->motor_type = MOTOR_TYPE_FOC;
-				mcconf->foc_f_sw = 10000.0;
+				mcconf->foc_f_sw = 5000.0;
 				mcconf->foc_current_kp = 0.01;
 				mcconf->foc_current_ki = 10.0;
 				mc_interface_set_configuration(mcconf);

--- a/conf_general.c
+++ b/conf_general.c
@@ -1516,7 +1516,7 @@ int conf_general_detect_apply_all_foc(float max_power_loss,
 
 	mcconf->motor_type = MOTOR_TYPE_FOC;
 	mcconf->foc_sensor_mode = FOC_SENSOR_MODE_SENSORLESS;
-	mcconf->foc_f_sw = 10000.0; // Lower f_sw => less dead-time distortion
+	mcconf->foc_f_sw = 5000.0; // Lower f_sw => less dead-time distortion
 	mcconf->foc_current_kp = 0.0005;
 	mcconf->foc_current_ki = 1.0;
 	mcconf->l_current_max = MCCONF_L_CURRENT_MAX;
@@ -1532,7 +1532,7 @@ int conf_general_detect_apply_all_foc(float max_power_loss,
 #ifdef HW_HAS_DUAL_MOTORS
 	mcconf_second->motor_type = MOTOR_TYPE_FOC;
 	mcconf_second->foc_sensor_mode = FOC_SENSOR_MODE_SENSORLESS;
-	mcconf_second->foc_f_sw = 10000.0; // Lower f_sw => less dead-time distortion
+	mcconf_second->foc_f_sw = 5000.0; // Lower f_sw => less dead-time distortion
 	mcconf_second->foc_current_kp = 0.0005;
 	mcconf_second->foc_current_ki = 1.0;
 	mcconf_second->l_current_max = MCCONF_L_CURRENT_MAX;
@@ -1629,12 +1629,12 @@ int conf_general_detect_apply_all_foc(float max_power_loss,
 	// Increase switching frequency for flux linkage measurement
 	// as dead-time distortion has less effect at higher modulation.
 	// Having a smooth rotation is more important.
-	mcconf->foc_f_sw = 20000.0;
+	mcconf->foc_f_sw = 10000.0;
 	mc_interface_set_configuration(mcconf);
 
 #ifdef HW_HAS_DUAL_MOTORS
 	mc_interface_select_motor_thread(2);
-	mcconf_second->foc_f_sw = 20000.0;
+	mcconf_second->foc_f_sw = 10000.0;
 	mc_interface_set_configuration(mcconf_second);
 	mc_interface_select_motor_thread(1);
 #endif

--- a/hwconf/hw_100_250.h
+++ b/hwconf/hw_100_250.h
@@ -236,7 +236,7 @@
 #define MCCONF_DEFAULT_MOTOR_TYPE		MOTOR_TYPE_FOC
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW					30000.0
+#define MCCONF_FOC_F_SW					15000.0
 #endif
 #ifndef MCCONF_L_MAX_ABS_CURRENT
 #define MCCONF_L_MAX_ABS_CURRENT		400.0	// The maximum absolute current above which a fault is generated

--- a/hwconf/hw_100_500.h
+++ b/hwconf/hw_100_500.h
@@ -229,7 +229,7 @@
 #define MCCONF_DEFAULT_MOTOR_TYPE		MOTOR_TYPE_FOC
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW					30000.0
+#define MCCONF_FOC_F_SW					15000.0
 #endif
 #ifndef MCCONF_L_MAX_ABS_CURRENT
 #define MCCONF_L_MAX_ABS_CURRENT		650.0	// The maximum absolute current above which a fault is generated

--- a/hwconf/hw_140_300.h
+++ b/hwconf/hw_140_300.h
@@ -229,7 +229,7 @@
 #define MCCONF_DEFAULT_MOTOR_TYPE		MOTOR_TYPE_FOC
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW					30000.0
+#define MCCONF_FOC_F_SW					15000.0
 #endif
 #ifndef MCCONF_L_MAX_ABS_CURRENT
 #define MCCONF_L_MAX_ABS_CURRENT		450.0	// The maximum absolute current above which a fault is generated

--- a/hwconf/hw_75_300.h
+++ b/hwconf/hw_75_300.h
@@ -280,7 +280,7 @@
 #define MCCONF_DEFAULT_MOTOR_TYPE		MOTOR_TYPE_FOC
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW					30000.0
+#define MCCONF_FOC_F_SW					15000.0
 #endif
 #ifndef MCCONF_L_MAX_ABS_CURRENT
 #define MCCONF_L_MAX_ABS_CURRENT		420.0	// The maximum absolute current above which a fault is generated

--- a/hwconf/hw_Cheap_FOCer_2.h
+++ b/hwconf/hw_Cheap_FOCer_2.h
@@ -256,7 +256,7 @@
 #endif
 
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW                 20000.0
+#define MCCONF_FOC_F_SW                 10000.0
 #endif
 
 #ifndef MCCONF_L_CURRENT_MAX

--- a/hwconf/hw_Little_FOCer.h
+++ b/hwconf/hw_Little_FOCer.h
@@ -278,7 +278,7 @@
 #define MCCONF_DEFAULT_MOTOR_TYPE       MOTOR_TYPE_FOC
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW                 20000.0
+#define MCCONF_FOC_F_SW                 10000.0
 #endif
 
 // Setting limits

--- a/hwconf/hw_a200s_v2.h
+++ b/hwconf/hw_a200s_v2.h
@@ -241,7 +241,7 @@
 #define MCCONF_DEFAULT_MOTOR_TYPE		MOTOR_TYPE_FOC
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW					30000.0
+#define MCCONF_FOC_F_SW					15000.0
 #endif
 #ifndef MCCONF_L_MAX_ABS_CURRENT
 #define MCCONF_L_MAX_ABS_CURRENT		180.0	// The maximum absolute current above which a fault is generated

--- a/hwconf/hw_a50s.h
+++ b/hwconf/hw_a50s.h
@@ -231,7 +231,7 @@
 #define MCCONF_DEFAULT_MOTOR_TYPE		MOTOR_TYPE_FOC
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW					35000.0
+#define MCCONF_FOC_F_SW					17500.0
 #endif
 #ifndef MCCONF_L_MAX_ABS_CURRENT
 #define MCCONF_L_MAX_ABS_CURRENT		80.0	// The maximum absolute current above which a fault is generated

--- a/hwconf/hw_das_mini.h
+++ b/hwconf/hw_das_mini.h
@@ -229,7 +229,7 @@
 #define MCCONF_L_MAX_ABS_CURRENT		40.0	// The maximum absolute current above which a fault is generated
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW					30000.0
+#define MCCONF_FOC_F_SW					15000.0
 #endif
 #ifndef MCCONF_FOC_SAMPLE_V0_V7
 #define MCCONF_FOC_SAMPLE_V0_V7			false	// Run control loop in both v0 and v7 (requires phase shunts)

--- a/hwconf/hw_das_rs.h
+++ b/hwconf/hw_das_rs.h
@@ -255,7 +255,7 @@
 #define MCCONF_FOC_CURRENT_KI				5800.0
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW						20000.0
+#define MCCONF_FOC_F_SW						10000.0
 #endif
 #ifndef MCCONF_FOC_MOTOR_L
 #define MCCONF_FOC_MOTOR_L					0.0048

--- a/hwconf/hw_es19.h
+++ b/hwconf/hw_es19.h
@@ -269,7 +269,7 @@
 #define MCCONF_DEFAULT_MOTOR_TYPE		MOTOR_TYPE_FOC
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW					30000.0
+#define MCCONF_FOC_F_SW					15000.0
 #endif
 #ifndef MCCONF_L_MAX_ABS_CURRENT
 #define MCCONF_L_MAX_ABS_CURRENT		700.0	// The maximum absolute current above which a fault is generated

--- a/hwconf/hw_gesc.h
+++ b/hwconf/hw_gesc.h
@@ -265,7 +265,7 @@
 #define MCCONF_DEFAULT_MOTOR_TYPE		MOTOR_TYPE_FOC
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW					30000.0
+#define MCCONF_FOC_F_SW					15000.0
 #endif
 #ifndef MCCONF_L_MAX_ABS_CURRENT
 #define MCCONF_L_MAX_ABS_CURRENT		120.0	// The maximum absolute current above which a fault is generated

--- a/hwconf/hw_hd60.h
+++ b/hwconf/hw_hd60.h
@@ -268,7 +268,7 @@
 #define MCCONF_DEFAULT_MOTOR_TYPE		MOTOR_TYPE_FOC
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW					30000.0
+#define MCCONF_FOC_F_SW					15000.0
 #endif
 
 #ifndef MCCONF_M_DRV8301_OC_MODE

--- a/hwconf/hw_hd75.h
+++ b/hwconf/hw_hd75.h
@@ -280,7 +280,7 @@
 #define MCCONF_DEFAULT_MOTOR_TYPE		MOTOR_TYPE_FOC
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW					30000.0
+#define MCCONF_FOC_F_SW					15000.0
 #endif
 
 #ifndef APPCONF_SHUTDOWN_MODE

--- a/hwconf/hw_raiden7.h
+++ b/hwconf/hw_raiden7.h
@@ -240,7 +240,7 @@
 #define MCCONF_L_MAX_VOLTAGE			84.0	// Maximum input voltage
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW					20000.0
+#define MCCONF_FOC_F_SW					10000.0
 #endif
 #ifndef MCCONF_FOC_DT_US
 #define MCCONF_FOC_DT_US				0.2 // Microseconds for dead time compensation

--- a/hwconf/hw_rd2.h
+++ b/hwconf/hw_rd2.h
@@ -276,7 +276,7 @@
 #define MCCONF_FOC_CURRENT_KI			6.0
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW					30000.0
+#define MCCONF_FOC_F_SW					15000.0
 #endif
 #ifndef MCCONF_FOC_MOTOR_L
 #define MCCONF_FOC_MOTOR_L				6.0e-6

--- a/hwconf/hw_uavc_omega.h
+++ b/hwconf/hw_uavc_omega.h
@@ -237,7 +237,7 @@
 #define MCCONF_DEFAULT_MOTOR_TYPE		MOTOR_TYPE_FOC
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW					30000.0
+#define MCCONF_FOC_F_SW					15000.0
 #endif
 
 // Setting limits

--- a/hwconf/hw_uavc_qcube.h
+++ b/hwconf/hw_uavc_qcube.h
@@ -237,7 +237,7 @@
 #define MCCONF_DEFAULT_MOTOR_TYPE		MOTOR_TYPE_FOC
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW					30000.0
+#define MCCONF_FOC_F_SW					15000.0
 #endif
 #ifndef MCCONF_FOC_SAMPLE_V0_V7
 #define MCCONF_FOC_SAMPLE_V0_V7			false	// Run control loop in both v0 and v7 (requires phase shunts)

--- a/hwconf/hw_ubox_single.h
+++ b/hwconf/hw_ubox_single.h
@@ -246,7 +246,7 @@
 #define MCCONF_DEFAULT_MOTOR_TYPE		MOTOR_TYPE_FOC
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW					30000.0
+#define MCCONF_FOC_F_SW					15000.0
 #endif
 
 #ifndef MCCONF_L_MAX_ABS_CURRENT

--- a/hwconf/hw_uxv_sr.h
+++ b/hwconf/hw_uxv_sr.h
@@ -251,7 +251,7 @@
 #define MCCONF_DEFAULT_MOTOR_TYPE		MOTOR_TYPE_FOC
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW					30000.0
+#define MCCONF_FOC_F_SW					15000.0
 #endif
 #ifndef MCCONF_FOC_OPENLOOP_RPM
 #define MCCONF_FOC_OPENLOOP_RPM         1500.0  // Openloop RPM (sensorless low speed or when finding index pulse)

--- a/hwconf/hw_warrior6.h
+++ b/hwconf/hw_warrior6.h
@@ -218,7 +218,7 @@
 #define MCCONF_FOC_SAMPLE_V0_V7			false	// Run control loop in both v0 and v7 (requires phase shunts)
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW					20000.0
+#define MCCONF_FOC_F_SW					10000.0
 #endif
 #ifndef MCCONF_L_IN_CURRENT_MAX
 #define MCCONF_L_IN_CURRENT_MAX			40.0	// Input current limit in Amperes (Upper)

--- a/hwconf/luna/mcconf_luna_bbshd_52v.h
+++ b/hwconf/luna/mcconf_luna_bbshd_52v.h
@@ -151,7 +151,7 @@
 #define MCCONF_FOC_CURRENT_KI 32.6
 
 // Switching Frequency
-#define MCCONF_FOC_F_SW 50000
+#define MCCONF_FOC_F_SW 25000
 
 // Dead Time Compensation
 #define MCCONF_FOC_DT_US 0.12

--- a/mcconf/mcconf_default.h
+++ b/mcconf/mcconf_default.h
@@ -245,7 +245,7 @@
 #define MCCONF_FOC_CURRENT_KI			50.0
 #endif
 #ifndef MCCONF_FOC_F_SW
-#define MCCONF_FOC_F_SW					25000.0
+#define MCCONF_FOC_F_SW					12500.0
 #endif
 #ifndef MCCONF_FOC_DT_US
 #define MCCONF_FOC_DT_US				0.12 // Microseconds for dead time compensation

--- a/virtual_motor.c
+++ b/virtual_motor.c
@@ -127,12 +127,12 @@ void virtual_motor_set_configuration(volatile mc_configuration *conf){
 	virtual_motor.km = 1.5 * virtual_motor.pole_pairs;
 #ifdef HW_HAS_PHASE_SHUNTS
 	if (m_conf->foc_sample_v0_v7) {
-		virtual_motor.Ts = (1.0 / m_conf->foc_f_sw) ;
+		virtual_motor.Ts = (0.5 / m_conf->foc_f_sw) ; //Sample time is half when measuring twice per period.
 	} else {
-		virtual_motor.Ts = (1.0 / (m_conf->foc_f_sw / 2.0));
+		virtual_motor.Ts = (1.0 / m_conf->foc_f_sw);
 	}
 #else
-	virtual_motor.Ts = (1.0 / m_conf->foc_f_sw) ;
+	virtual_motor.Ts = (1.0 / m_conf->foc_f_sw) ;  //Adjusted this to match foc_sample_v0_v7 disabled. Was a bug?
 #endif
 
 	if(m_conf->foc_motor_ld_lq_diff > 0.0){


### PR DESCRIPTION
Industry standard for the switching frequency is to have it define the switching frequency of the igbts / mosfets. 

Yes, center aligned PWM has less first harmonic content than edge aligned, but still there is a large first harmonic component at higher duty cycles.  

For reference:
![afbeelding](https://user-images.githubusercontent.com/79989749/148283062-e70d69b8-0712-4b22-8557-c6fb57ebbec1.png)


You can also easily confirm this using rotor lock and an audio spectrum analyzer (e.g. Spectroid). At higher duty cycles there is a prominent first harmonic, unless you excite in the (0 .. 60. .. 120 ... deg) angle direction.

20 kHz VESC setting without the fix, exciting in 90 deg rotor lock:
![Screenshot_20220105-212845_Spectroid](https://user-images.githubusercontent.com/79989749/148285204-130b0870-2f69-48b7-902b-d2eb0250fd93.jpg)

Clear 10 kHz visible.

20 kHz VESC setting without the fix, exciting in 0 deg rotor lock:
![Screenshot_20220105-212946_Spectroid](https://user-images.githubusercontent.com/79989749/148285252-9e118d08-5afa-4398-ba7c-3fd014315ba7.jpg)

No 10 kHz visible.

When the motor is rotating of course all angles are being excited so you will hear the 10 kHz. Especially of higher duty cycles the first harmonic becomes large. 

Most important reason why I would like to get this changed/fixed is that this might actually scare away people from industry that might actually be able to bring a lot to the VESC project. I almost stopped looking into VESC due to this, and only continues because a college lent me a VESC of his. Would be sad if we lose out on knowledgeable people due to a simple semantics thing.

Interested to hear your thoughts on this!

PS. everything runs fine with this PR on my motors. Adjusted all locations I could find that use the parameter, to not cause any change in behavior.
