### PR TITLE
Fix SPI NSS PORT and PIN for MKV

### DIFF
--- a/hwconf/hw_60.h
+++ b/hwconf/hw_60.h
@@ -285,6 +285,7 @@
 #endif
 
 // SPI pins
+#if !defined(HW60_IS_MK5)
 #define HW_SPI_DEV				SPID1
 #define HW_SPI_GPIO_AF			GPIO_AF_SPI1
 #define HW_SPI_PORT_NSS			GPIOA
@@ -295,6 +296,18 @@
 #define HW_SPI_PIN_MOSI			7
 #define HW_SPI_PORT_MISO		GPIOA
 #define HW_SPI_PIN_MISO			6
+#else
+#define HW_SPI_DEV				SPID1
+#define HW_SPI_GPIO_AF			GPIO_AF_SPI1
+#define HW_SPI_PORT_NSS			GPIOB
+#define HW_SPI_PIN_NSS			11
+#define HW_SPI_PORT_SCK			GPIOA
+#define HW_SPI_PIN_SCK			5
+#define HW_SPI_PORT_MOSI		GPIOA
+#define HW_SPI_PIN_MOSI			7
+#define HW_SPI_PORT_MISO		GPIOA
+#define HW_SPI_PIN_MISO			6
+#endif
 
 // SPI for DRV8301
 #if !defined(HW60_IS_MK3) && !defined(HW60_IS_MK4) && !defined(HW60_IS_MK5)


### PR DESCRIPTION
I noticed that `HW_SPI_PORT_NSS` and `HW_SPI_PIN_NSS` were set wrong when I set `AS5047_USE_HW_SPI_PINS` and connected my AS5047 to the COMM port. I checked the schematic, noted it should be PB11 and tested it on my MKV. I'm not sure if this change also applies to MKIV and MKIII. I suspect it might, but I don't have that hardware and I can't find any schematics for them.