### PR TITLE
Encoder split cleanup

### DIFF
--- a/encoder/enc_ad2s1205.c
+++ b/encoder/enc_ad2s1205.c
@@ -84,10 +84,6 @@ encoder_ret_t enc_ad2s1205_init(AD2S1205_config_t *AD2S1205_config) {
 	return ENCODER_OK;
 }
 
-float enc_ad2s1205_read_deg(void) {
-	return last_enc_angle;
-}
-
 void enc_ad2s1205_routine(float rate) {
 	uint16_t pos;
 	// SAMPLE signal should have been be asserted in sync with ADC sampling
@@ -160,6 +156,10 @@ void enc_ad2s1205_routine(float rate) {
 			last_enc_angle = ((float) pos * 360.0) / 4096.0;
 		}
 	}
+}
+
+float enc_ad2s1205_read_deg(void) {
+	return last_enc_angle;
 }
 
 float enc_ad2s1205_resolver_loss_of_tracking_error_rate(void) {

--- a/encoder/enc_ad2s1205.h
+++ b/encoder/enc_ad2s1205.h
@@ -28,8 +28,8 @@
 void enc_ad2s1205_deinit(void);
 encoder_ret_t enc_ad2s1205_init(AD2S1205_config_t *AD2S1205_config);
 
-float enc_ad2s1205_read_deg(void);
 void enc_ad2s1205_routine(float rate);
+float enc_ad2s1205_read_deg(void);
 
 float enc_ad2s1205_resolver_loss_of_tracking_error_rate(void);
 float enc_ad2s1205_resolver_degradation_of_signal_error_rate(void);

--- a/encoder/enc_as504x.c
+++ b/encoder/enc_as504x.c
@@ -64,16 +64,16 @@ static uint8_t AS504x_spi_transfer_err_check(spi_bb_state *sw_spi,
 		uint16_t *in_buf, const uint16_t *out_buf, int length);
 static void AS504x_determinate_if_connected(AS504x_config_t *cfg, bool was_last_valid);
 
-encoder_ret_t enc_as504x_init(AS504x_config_t *cfg) {
-	memset(&cfg->state, 0, sizeof(AS504x_state));
-	spi_bb_init(&(cfg->sw_spi));
-	return ENCODER_OK;
-}
-
 void enc_as504x_deinit(AS504x_config_t *cfg) {
 	spi_bb_deinit(&(cfg->sw_spi));
 	cfg->state.last_enc_angle = 0.0;
 	cfg->state.spi_error_rate = 0.0;
+}
+
+encoder_ret_t enc_as504x_init(AS504x_config_t *cfg) {
+	memset(&cfg->state, 0, sizeof(AS504x_state));
+	spi_bb_init(&(cfg->sw_spi));
+	return ENCODER_OK;
 }
 
 void enc_as504x_routine(AS504x_config_t *cfg, float rate) {

--- a/encoder/enc_as504x.h
+++ b/encoder/enc_as504x.h
@@ -24,8 +24,8 @@
 #include "encoder/encoder_datatype.h"
 
 // Functions
-encoder_ret_t enc_as504x_init(AS504x_config_t *AS504x_config);
 void enc_as504x_deinit(AS504x_config_t *cfg);
+encoder_ret_t enc_as504x_init(AS504x_config_t *AS504x_config);
 void enc_as504x_routine(AS504x_config_t *cfg, float rate);
 
 // Macros

--- a/encoder/enc_mt6816.c
+++ b/encoder/enc_mt6816.c
@@ -34,6 +34,22 @@
 
 #define MT6816_NO_MAGNET_ERROR_MASK		0x0002
 
+void enc_mt6816_deinit(MT6816_config_t *cfg) {
+	if (cfg->spi_dev == NULL) {
+		return;
+	}
+
+	palSetPadMode(cfg->miso_gpio, cfg->miso_pin, PAL_MODE_INPUT_PULLUP);
+	palSetPadMode(cfg->sck_gpio, cfg->sck_pin, PAL_MODE_INPUT_PULLUP);
+	palSetPadMode(cfg->nss_gpio, cfg->nss_pin, PAL_MODE_INPUT_PULLUP);
+	palSetPadMode(cfg->mosi_gpio, cfg->mosi_pin, PAL_MODE_INPUT_PULLUP);
+
+	spiStop(cfg->spi_dev);
+
+	cfg->state.last_enc_angle = 0.0;
+	cfg->state.spi_error_rate = 0.0;
+}
+
 encoder_ret_t enc_mt6816_init(MT6816_config_t *cfg) {
 	if (cfg->spi_dev == NULL) {
 		return ENCODER_ERROR;
@@ -52,22 +68,6 @@ encoder_ret_t enc_mt6816_init(MT6816_config_t *cfg) {
 	cfg->state.encoder_no_magnet_error_rate = 0.0;
 
 	return ENCODER_OK;
-}
-
-void enc_mt6816_deinit(MT6816_config_t *cfg) {
-	if (cfg->spi_dev == NULL) {
-		return;
-	}
-
-	palSetPadMode(cfg->miso_gpio, cfg->miso_pin, PAL_MODE_INPUT_PULLUP);
-	palSetPadMode(cfg->sck_gpio, cfg->sck_pin, PAL_MODE_INPUT_PULLUP);
-	palSetPadMode(cfg->nss_gpio, cfg->nss_pin, PAL_MODE_INPUT_PULLUP);
-	palSetPadMode(cfg->mosi_gpio, cfg->mosi_pin, PAL_MODE_INPUT_PULLUP);
-
-	spiStop(cfg->spi_dev);
-
-	cfg->state.last_enc_angle = 0.0;
-	cfg->state.spi_error_rate = 0.0;
 }
 
 void enc_mt6816_routine(MT6816_config_t *cfg, float rate) {

--- a/encoder/enc_mt6816.h
+++ b/encoder/enc_mt6816.h
@@ -25,8 +25,8 @@
 #include "datatypes.h"
 #include "encoder/encoder_datatype.h"
 
-encoder_ret_t enc_mt6816_init(MT6816_config_t *mt6816_config);
 void enc_mt6816_deinit(MT6816_config_t *cfg);
+encoder_ret_t enc_mt6816_init(MT6816_config_t *mt6816_config);
 void enc_mt6816_routine(MT6816_config_t *cfg, float rate);
 
 // Macros

--- a/encoder/enc_ts5700n8501.c
+++ b/encoder/enc_ts5700n8501.c
@@ -44,24 +44,6 @@ static uint32_t spi_val = 0;
 
 static float last_enc_angle = 0.0;
 
-encoder_ret_t enc_ts5700n8501_init(TS5700N8501_config_t *ts5700n8501_config) {
-	if (ts5700n8501_config->sd == NULL) {
-		return ENCODER_ERROR;
-	}
-
-	spi_error_rate = 0.0;
-	spi_error_cnt = 0;
-	ts5700n8501_is_running = true;
-	ts5700n8501_stop_now = false;
-
-	ts5700n8501_config_now = *ts5700n8501_config;
-
-	chThdCreateStatic(ts5700n8501_thread_wa, sizeof(ts5700n8501_thread_wa),
-	NORMALPRIO - 10, ts5700n8501_thread, NULL);
-
-	return ENCODER_OK;
-}
-
 void enc_ts5700n8501_deinit(void) {
 	if (ts5700n8501_config_now.sd == NULL) {
 		return;
@@ -84,25 +66,22 @@ void enc_ts5700n8501_deinit(void) {
 	spi_error_rate = 0.0;
 }
 
-float enc_ts5700n8501_read_deg(void) {
-	return last_enc_angle;
-}
+encoder_ret_t enc_ts5700n8501_init(TS5700N8501_config_t *ts5700n8501_config) {
+	if (ts5700n8501_config->sd == NULL) {
+		return ENCODER_ERROR;
+	}
 
-uint8_t* enc_ts5700n8501_get_raw_status(void) {
-	return (uint8_t*) ts5700n8501_raw_status;
-}
+	spi_error_rate = 0.0;
+	spi_error_cnt = 0;
+	ts5700n8501_is_running = true;
+	ts5700n8501_stop_now = false;
 
-int16_t enc_ts5700n8501_get_abm(void) {
-	return (uint16_t) ts5700n8501_raw_status[4]
-			| ((uint16_t) ts5700n8501_raw_status[5] << 8);
-}
+	ts5700n8501_config_now = *ts5700n8501_config;
 
-void enc_ts5700n8501_reset_errors(void) {
-	ts5700n8501_reset_errors = true;
-}
+	chThdCreateStatic(ts5700n8501_thread_wa, sizeof(ts5700n8501_thread_wa),
+	NORMALPRIO - 10, ts5700n8501_thread, NULL);
 
-void enc_ts5700n8501_reset_multiturn(void) {
-	ts5700n8501_reset_multiturn = true;
+	return ENCODER_OK;
 }
 
 static void TS5700N8501_delay_uart(void) {
@@ -268,4 +247,25 @@ static THD_FUNCTION(ts5700n8501_thread, arg) {
 			UTILS_LP_FAST(spi_error_rate, 1.0, 1.0 / LOOP_RATE);
 		}
 	}
+}
+
+float enc_ts5700n8501_read_deg(void) {
+	return last_enc_angle;
+}
+
+uint8_t* enc_ts5700n8501_get_raw_status(void) {
+	return (uint8_t*) ts5700n8501_raw_status;
+}
+
+int16_t enc_ts5700n8501_get_abm(void) {
+	return (uint16_t) ts5700n8501_raw_status[4]
+			| ((uint16_t) ts5700n8501_raw_status[5] << 8);
+}
+
+void enc_ts5700n8501_reset_errors(void) {
+	ts5700n8501_reset_errors = true;
+}
+
+void enc_ts5700n8501_reset_multiturn(void) {
+	ts5700n8501_reset_multiturn = true;
 }

--- a/encoder/enc_ts5700n8501.h
+++ b/encoder/enc_ts5700n8501.h
@@ -24,8 +24,9 @@
 #include "datatypes.h"
 #include "encoder/encoder_datatype.h"
 
-encoder_ret_t enc_ts5700n8501_init(TS5700N8501_config_t *ts5700n8501_config);
 void enc_ts5700n8501_deinit(void);
+encoder_ret_t enc_ts5700n8501_init(TS5700N8501_config_t *ts5700n8501_config);
+
 
 float enc_ts5700n8501_read_deg(void);
 

--- a/encoder/encoder.h
+++ b/encoder/encoder.h
@@ -31,8 +31,8 @@
 #include "enc_abi.h"
 
 // Functions
-encoder_ret_t encoder_init(volatile mc_configuration *conf);
 void encoder_deinit(void);
+encoder_ret_t encoder_init(volatile mc_configuration *conf);
 
 float encoder_read_deg(void);
 float encoder_read_deg_multiturn(void);


### PR DESCRIPTION
Clean up the encoder files to have consistent ordering of functions.

- deinit
- init
- routine
- worker/helper functions
- getter functions

I am not against moving the getter functions above the routine fn if that is done in all files.