### PR TITLE
[Unit tests][Utils.c] Fix unit test compilation

### DIFF
--- a/tests/utils/Makefile
+++ b/tests/utils/Makefile
@@ -11,6 +11,7 @@ CFLAGS += -O0
 CFLAGS += -Wall -Werror
 CFLAGS += -g
 CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS)) -I.
+CFLAGS += -DUNIT_TEST
 
 CONLYFLAGS += -std=gnu99
 

--- a/tests/utils/ch.h
+++ b/tests/utils/ch.h
@@ -2,4 +2,7 @@
 #define CH_H
 
 typedef int systime_t;
+typedef struct  {
+   uint32_t *p_stklimit;
+} thread_t;
 #endif  // CH_H

--- a/utils.c
+++ b/utils.c
@@ -856,8 +856,12 @@ int utils_check_min_stack_left(thread_t *tp) {
  * Check how much stack the current thread has left now.
  */
 int utils_stack_left_now(void) {
+#ifndef UNIT_TEST
 	struct port_intctx *r13 = (struct port_intctx *)__get_PSP();
 	return ((stkalign_t *)(r13 - 1) - chThdGetSelfX()->p_stklimit) * sizeof(stkalign_t);
+#else
+   return -1;
+#endif  // UNIT_TEST
 }
 
 void utils_rotate_vector3(float *input, float *rotation, float *output, bool reverse) {


### PR DESCRIPTION
The test compilation were broken by the addition of some threading utilities.