### PR TITLE
Windows powershell fixes

### DIFF
--- a/ChibiOS_3.0.5/os/common/ports/ARMCMx/compilers/GCC/rules.mk
+++ b/ChibiOS_3.0.5/os/common/ports/ARMCMx/compilers/GCC/rules.mk
@@ -312,6 +312,13 @@ clean:
 #
 # Include the dependency files, should be the last of the makefile
 #
--include $(shell mkdir .dep 2>/dev/null) $(wildcard .dep/*)
+ifeq ($(OS),Windows_NT)
+  $(shell if not exist ".dep" mkdir .dep )
+else
+  $(shell mkdir .dep 2>/dev/null)
+endif
+
+-include $(wildcard .dep/*)
+
 
 # *** EOF ***

--- a/ChibiOS_3.0.5/os/hal/hal.mk
+++ b/ChibiOS_3.0.5/os/hal/hal.mk
@@ -3,7 +3,7 @@
 ifeq ($(USE_SMART_BUILD),yes)
 
 ifeq ($(OS),Windows_NT)
-  HALCONF := $(strip $(shell pwsh -noprofile -command cat halconf.h | findstr -i define))
+  HALCONF := $(strip $(shell powershell -noprofile -command cat halconf.h | findstr -i define))
 else
   HALCONF := $(strip $(shell cat halconf.h | egrep -e "define"))
 endif

--- a/ChibiOS_3.0.5/os/hal/ports/STM32/STM32F4xx/platform.mk
+++ b/ChibiOS_3.0.5/os/hal/ports/STM32/STM32F4xx/platform.mk
@@ -2,7 +2,7 @@
 ifeq ($(USE_SMART_BUILD),yes)
 
 ifeq ($(OS),Windows_NT)
-  HALCONF := $(strip $(shell pwsh -noprofile -command cat halconf.h | findstr -i define))
+  HALCONF := $(strip $(shell powershell -noprofile -command cat halconf.h | findstr -i define))
 else
   HALCONF := $(strip $(shell cat halconf.h | egrep -e "define"))
 endif

--- a/ChibiOS_3.0.5/os/rt/rt.mk
+++ b/ChibiOS_3.0.5/os/rt/rt.mk
@@ -3,7 +3,7 @@
 ifeq ($(USE_SMART_BUILD),yes)
 
 ifeq ($(OS),Windows_NT)
-  CHCONF := $(strip $(shell pwsh -noprofile -command cat chconf.h | findstr -i define))
+  CHCONF := $(strip $(shell powershell -noprofile -command cat chconf.h | findstr -i define))
 else
   CHCONF := $(strip $(shell cat chconf.h | egrep -e "define")),
 endif

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ fw_$(1)_clean:
 ifneq ($(OSFAMILY), windows)
 	$(V1) [ ! -d "$(BUILD_DIR)/$(1)" ] || $(RM) -r "$(BUILD_DIR)/$(1)"
 else
-	$(V1) pwsh -noprofile -command if (Test-Path $(BUILD_DIR)/$(1)) {Remove-Item -Recurse $(BUILD_DIR)/$(1)}
+	$(V1) powershell -noprofile -command if (Test-Path $(BUILD_DIR)/$(1)) {Remove-Item -Recurse $(BUILD_DIR)/$(1)}
 endif
 endef
 
@@ -228,7 +228,7 @@ all_fw_package: all_fw all_fw_package_clean
 ifneq ($(OSFAMILY), windows)
 	$(V1) $(RM) $(BUILD_CRUFT)
 else
-	$(V1) pwsh -noprofile -command {Remove-Item $(BUILD_CRUFT)}
+	$(V1) powershell -noprofile -command {Remove-Item $(BUILD_CRUFT)}
 endif
 
 .PHONY: all_fw_package_clean
@@ -237,7 +237,7 @@ all_fw_package_clean:
 ifneq ($(OSFAMILY), windows)
 	$(V1) [ ! -d "$(ROOT_DIR)/package/" ] || $(RM) -rf $(ROOT_DIR)/package/*
 else
-	$(V1) pwsh -noprofile -command if (Test-Path $(ROOT_DIR)/package/*) {Remove-Item -Recurse $(ROOT_DIR)/package/*}
+	$(V1) powershell -noprofile -command if (Test-Path $(ROOT_DIR)/package/*) {Remove-Item -Recurse $(ROOT_DIR)/package/*}
 endif
 
 

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -38,7 +38,7 @@ ifneq ($(OSFAMILY), windows)
 	$(V1) tar -C $(TOOLS_DIR) -xjf "$(DL_DIR)/$(ARM_SDK_FILE)"
 else
 	$(V1) curl --continue - --location --insecure --output "$(DL_DIR)/$(ARM_SDK_FILE)" "$(ARM_SDK_URL)"
-	$(V1) pwsh -noprofile -command Expand-Archive -DestinationPath $(ARM_SDK_DIR) -LiteralPath "$(DL_DIR)/$(ARM_SDK_FILE)"
+	$(V1) powershell -noprofile -command Expand-Archive -DestinationPath $(ARM_SDK_DIR) -LiteralPath "$(DL_DIR)/$(ARM_SDK_FILE)"
 
 endif
 
@@ -47,7 +47,7 @@ arm_sdk_clean:
 ifneq ($(OSFAMILY), windows)
 	$(V1) [ ! -d "$(ARM_SDK_DIR)" ] || $(RM) -r $(ARM_SDK_DIR)
 else
-	$(V1) pwsh -noprofile -command if (Test-Path $(ARM_SDK_DIR)) {Remove-Item -Recurse $(ARM_SDK_DIR)}
+	$(V1) powershell -noprofile -command if (Test-Path $(ARM_SDK_DIR)) {Remove-Item -Recurse $(ARM_SDK_DIR)}
 endif
 
 
@@ -96,7 +96,7 @@ qt_sdk_clean:
 ifneq ($(OSFAMILY), windows)
 	$(V1) [ ! -d "$(QT_SDK_DIR)" ] || $(RM) -r $(QT_SDK_DIR)
 else
-	$(V1) pwsh -noprofile -command if (Test-Path $(QT_SDK_DIR)) {Remove-Item -Recurse $(QT_SDK_DIR)}
+	$(V1) powershell -noprofile -command if (Test-Path $(QT_SDK_DIR)) {Remove-Item -Recurse $(QT_SDK_DIR)}
 endif
 
 
@@ -168,7 +168,7 @@ qt_creator_clean: qt_creator_uninstall
 ifneq ($(OSFAMILY), windows)
 	$(V1) [ ! -d "$(QT_CREATOR_DIR)" ] || $(RM) -r $(QT_CREATOR_DIR)
 else
-	$(V1) pwsh -noprofile -command if (Test-Path $(QT_CREATOR_DIR)) {Remove-Item -Recurse $(QT_CREATOR_DIR)}
+	$(V1) powershell -noprofile -command if (Test-Path $(QT_CREATOR_DIR)) {Remove-Item -Recurse $(QT_CREATOR_DIR)}
 endif
 
 

--- a/make/windows.mk
+++ b/make/windows.mk
@@ -45,4 +45,4 @@ export PYTHON
 ############################
 
 RM := del
-MKDIR := pwsh -noprofile -command New-Item -Force -itemtype "directory"
+MKDIR := powershell -noprofile -command New-Item -Force -itemtype "directory"


### PR DESCRIPTION
This fixes some Windows build issues which were related to having MS Powershell (not installed by default) vs Windows Powershell (installed by default).

Tested on Windows 10 machines with and without WSL.