### PR TITLE
Make fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ all_fw_package: all_fw all_fw_package_clean
 	$(V0) @echo " PACKAGE        $(ROOT_DIR)/package/*"
 
 # Place all firmware files into `./package` directory
-	$(V1) python3 package_firmware.py
+	$(V1) $(PYTHON) package_firmware.py
 
 # Find all the leftover object and lst files
 	$(eval BUILD_CRUFT := $(call rwildcard,$(ROOT_DIR)/build,*.lst *.o))

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -216,6 +216,9 @@ gtest_clean:
 
 ifneq ("$(wildcard $(ARM_SDK_DIR))","")
   ARM_SDK_PREFIX := $(ARM_SDK_DIR)/bin/arm-none-eabi-
+
+  # Get the ARM GCC version
+  ARM_GCC_VERSION := $(shell $(ARM_SDK_PREFIX)gcc -dumpversion)
 else
   ifneq ($(MAKECMDGOALS),arm_sdk_install)
     $(info **WARNING** ARM-SDK not in $(ARM_SDK_DIR)  Please run 'make arm_sdk_install')
@@ -224,8 +227,6 @@ else
   ARM_SDK_PREFIX ?= arm-none-eabi-
 endif
 
-# Get the ARM GCC version
-ARM_GCC_VERSION := $(shell $(ARM_SDK_PREFIX)gcc -dumpversion)
 
 # Get the git branch name, commit hash, and clean/dirty state
 GIT_BRANCH_NAME := $(shell git rev-parse --abbrev-ref HEAD)

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -89,7 +89,7 @@ qt_sdk_install: QT_SDK_FILE := $(notdir $(QT_SDK_URL))
 qt_sdk_install: | $(DL_DIR) $(TOOLS_DIR)
 qt_sdk_install: qt_sdk_clean
 # binary only release so just download and extract it
-	$(V1) aqt install-qt --keep --archive-dest "$(DL_DIR)/Qt" $(QT_SDK_HOST) desktop $(QT_SDK_VER) $(QT_SDK_ARCH) --outputdir $(QT_ROOT)
+	$(V1) $(PYTHON) -m aqt install-qt --keep --archive-dest "$(DL_DIR)/Qt" $(QT_SDK_HOST) desktop $(QT_SDK_VER) $(QT_SDK_ARCH) --outputdir $(QT_ROOT)
 
 .PHONY: qt_sdk_clean
 qt_sdk_clean:
@@ -141,7 +141,7 @@ endif
 
 qt_creator_install:
 # binary only release so just download and extract it
-	$(V1) aqt install-tool --keep --archive-dest "$(DL_DIR)/Qt" $(QT_CREATOR_HOST) desktop tools_qtcreator qt.tools.qtcreator --outputdir $(QT_CREATOR_DIR)
+	$(V1) $(PYTHON) -m aqt install-tool --keep --archive-dest "$(DL_DIR)/Qt" $(QT_CREATOR_HOST) desktop tools_qtcreator qt.tools.qtcreator --outputdir $(QT_CREATOR_DIR)
 
 .PHONY: qt_creator_configure
 qt_creator_configure:


### PR DESCRIPTION
Minor Makefile fixes dealing with Python on all platforms and removing spurious warning when there is no ARM compiler installed.

Testing coverage:
- [x] Checked on Windows
- [x] Checked on POSIX
