### PR TITLE
Windows unit testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ ALL_UNITTESTS := utils
 UT_OUT_DIR := $(BUILD_DIR)/unit_tests
 
 $(UT_OUT_DIR):
-	$(V1) mkdir -p $@
+	$(V1) $(MKDIR) $@
 
 .PHONY: all_ut
 all_ut: $(addsuffix _elf, $(addprefix ut_, $(ALL_UNITTESTS))) $(ALL_PYTHON_UNITTESTS)
@@ -281,7 +281,7 @@ ut_$(1)_%: TARGET=$(1)
 ut_$(1)_%: OUTDIR=$(UT_OUT_DIR)/$$(TARGET)
 ut_$(1)_%: UT_ROOT_DIR=$(ROOT_DIR)/tests/$(1)
 ut_$(1)_%: $$(UT_OUT_DIR)
-	$(V1) mkdir -p $(UT_OUT_DIR)/$(1)
+	$(V1) $(MKDIR) $(UT_OUT_DIR)/$(1)
 	$(V1) cd $$(UT_ROOT_DIR) && \
 		$$(MAKE) -r --no-print-directory \
 		BUILD_TYPE=ut \

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -192,6 +192,7 @@ gtest_install: | $(DL_DIR) $(TOOLS_DIR)
 gtest_install: GTEST_URL  := https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
 gtest_install: GTEST_FILE := $(notdir $(GTEST_URL))
 gtest_install: gtest_clean
+ifneq ($(OSFAMILY), windows)
 	# download the file unconditionally since google code gives back 404
 	# for HTTP HEAD requests which are used when using the wget -N option
 	$(V1) [ ! -f "$(DL_DIR)/$(GTEST_FILE)" ] || $(RM) -f "$(DL_DIR)/$(GTEST_FILE)"
@@ -199,13 +200,21 @@ gtest_install: gtest_clean
 
 	# extract the source
 	$(V1) [ ! -d "$(GTEST_DIR)" ] || $(RM) -rf "$(GTEST_DIR)"
-	$(V1) mkdir -p "$(GTEST_DIR)"
+	$(V1) $(MKDIR) "$(GTEST_DIR)"
 	$(V1) unzip -q -d "$(TOOLS_DIR)" "$(DL_DIR)/$(GTEST_FILE)"
+else
+	$(V1) curl --continue - --location --insecure --output "$(DL_DIR)/$(GTEST_FILE)" "$(GTEST_URL)"
+	$(V1) powershell -noprofile -command Expand-Archive -DestinationPath $(GTEST_DIR) -LiteralPath "$(DL_DIR)/$(GTEST_FILE)"
+endif
 
 .PHONY: gtest_clean
 gtest_clean:
 	$(V0) @echo " CLEAN        $(GTEST_DIR)"
+ifneq ($(OSFAMILY), windows)
 	$(V1) [ ! -d "$(GTEST_DIR)" ] || $(RM) -rf "$(GTEST_DIR)"
+else
+	$(V1) powershell -noprofile -command if (Test-Path $(GTEST_DIR)) {Remove-Item -Recurse $(GTEST_DIR)}
+endif
 
 
 ##############################


### PR DESCRIPTION
This improves unit testing support on Windows.

Note that MinGW is still required, this does not attempt to make `make all_ut_run` work with MSVC.