### PR TITLE
[Unit test] Use compiler-specific double-->single flags

### DIFF
--- a/tests/utils/Makefile
+++ b/tests/utils/Makefile
@@ -8,6 +8,23 @@ EXTRAINCDIRS += $(HERE)/
 
 
 CFLAGS += -O0
+
+# Set compiler-specific flags
+GCC_CXXFLAGS = -fsingle-precision-constant
+CLANG_CXXFLAGS = -cl-single-precision-constant
+UNKNOWN_CXXFLAGS = -fsingle-precision-constant
+
+# Detect if CXX is clang++ or g++, in this order.
+COMPILER_VERSION := $(shell $(CXX) --version)
+ifneq '' '$(findstring clang,$(COMPILER_VERSION))'
+  CFLAGS += $(CLANG_CXXFLAGS)
+else ifneq '' '$(findstring g++,$(COMPILER_VERSION))'
+  CFLAGS += $(GCC_CXXFLAGS)
+else
+  $(warning Unknown compiler)
+  CFLAGS += $(UNKNOWN_CXXFLAGS)
+endif
+
 CFLAGS += -Wall -Werror
 CFLAGS += -g
 CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS)) -I.


### PR DESCRIPTION
Not all compilers support `-fsingle-precision-constant`.