### PR TITLE
[Utils] Fix minor `utils_norm_angle()` discrepancy

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -75,7 +75,7 @@ void utils_norm_angle_rad(float *angle) {
 		*angle += 2.0 * M_PI;
 	}
 
-	while (*angle >  M_PI) {
+	while (*angle >=  M_PI) {
 		*angle -= 2.0 * M_PI;
 	}
 }


### PR DESCRIPTION
The API contract stipulates `-pi <= angle < pi`, but the code delivered `-pi <= angle <= pi`.

Fixes https://github.com/vedderb/bldc/issues/439.