### PR TITLE
[Make][Windows] Force the use of `cmd` shell for ChibiOS rules.mk

### DIFF
--- a/ChibiOS_3.0.5/os/common/ports/ARMCMx/compilers/GCC/rules.mk
+++ b/ChibiOS_3.0.5/os/common/ports/ARMCMx/compilers/GCC/rules.mk
@@ -313,7 +313,7 @@ clean:
 # Include the dependency files, should be the last of the makefile
 #
 ifeq ($(OS),Windows_NT)
-  $(shell if not exist ".dep" mkdir .dep )
+  $(shell cmd /C if not exist ".dep" mkdir ".dep")
 else
   $(shell mkdir .dep 2>/dev/null)
 endif


### PR DESCRIPTION
This guarantees that it won't matter if Git for Windows's sh.exe is on the path and aliases `make`'s sh.exe.