### PR TITLE
[Make][Tools] Reliably get the compiler version

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -225,9 +225,6 @@ endif
 
 ifneq ("$(wildcard $(ARM_SDK_DIR))","")
   ARM_SDK_PREFIX := $(ARM_SDK_DIR)/bin/arm-none-eabi-
-
-  # Get the ARM GCC version
-  ARM_GCC_VERSION := $(shell $(ARM_SDK_PREFIX)gcc -dumpversion)
 else
   ifneq ($(MAKECMDGOALS),arm_sdk_install)
     $(info **WARNING** ARM-SDK not in $(ARM_SDK_DIR)  Please run 'make arm_sdk_install')
@@ -236,6 +233,11 @@ else
   ARM_SDK_PREFIX ?= arm-none-eabi-
 endif
 
+
+# Get the ARM GCC version
+ifneq ("$(ARM_SDK_PREFIX)","")
+  ARM_GCC_VERSION := $(shell $(ARM_SDK_PREFIX)gcc -dumpversion)
+endif
 
 # Get the git branch name, commit hash, and clean/dirty state
 GIT_BRANCH_NAME := $(shell git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
If the user didn't have ARM SDK in the ./tools path, then previously they
would not get the compiler version string.