### PR TITLE
Unit test doubles

### DIFF
--- a/tests/utils_math/Makefile
+++ b/tests/utils_math/Makefile
@@ -25,7 +25,7 @@ else
   CFLAGS += $(UNKNOWN_CXXFLAGS)
 endif
 
-CFLAGS += -Wall -Werror
+CFLAGS += -Wall -Wdouble-promotion -Werror
 CFLAGS += -g
 CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS)) -I.
 

--- a/tests/utils_math/unittest.cpp
+++ b/tests/utils_math/unittest.cpp
@@ -131,6 +131,10 @@ TEST_F(NormAngle_rad, ValInRange) {
    utils_norm_angle_rad(&inputVal);
    EXPECT_NEAR(-M_PI, inputVal, eps);
 
+   inputVal = M_PI-1e-6;
+   utils_norm_angle_rad(&inputVal);
+   EXPECT_NEAR(M_PI-1e-6, inputVal, eps);
+
    inputVal = M_PI-1;
    utils_norm_angle_rad(&inputVal);
    EXPECT_NEAR(M_PI-1, inputVal, eps);
@@ -151,9 +155,9 @@ TEST_F(NormAngle_rad, ValInRange) {
 TEST_F(NormAngle_rad, ValBelowRange) {
    float inputVal;
 
-   inputVal = M_PI;
+   inputVal = -M_PI-1e-6;
    utils_norm_angle_rad(&inputVal);
-   EXPECT_EQ(-M_PI, inputVal);
+   EXPECT_NEAR(M_PI-1e-6, inputVal, eps);
 
    inputVal = -2*M_PI;
    utils_norm_angle_rad(&inputVal);
@@ -174,6 +178,10 @@ TEST_F(NormAngle_rad, ValBelowRange) {
  */
 TEST_F(NormAngle_rad, ValAboveRange) {
    float inputVal;
+
+   inputVal = M_PI;
+   utils_norm_angle_rad(&inputVal);
+   EXPECT_NEAR(-M_PI, inputVal, eps);
 
    inputVal = 2*M_PI;
    utils_norm_angle_rad(&inputVal);

--- a/tests/utils_math/unittest.cpp
+++ b/tests/utils_math/unittest.cpp
@@ -30,7 +30,10 @@ protected:
   }
 };
 
+
+//----------------------------------------
 // Test fixture for utils_norm_angle()
+//----------------------------------------
 class NormAngle_deg : public MiscMath {
 protected:
   virtual void SetUp() {
@@ -93,7 +96,10 @@ TEST_F(NormAngle_deg, ValAboveRange) {
    EXPECT_EQ(359, inputVal);
 }
 
+
+//----------------------------------------
 // Test fixture for utils_norm_angle_rad()
+//----------------------------------------
 class NormAngle_rad : public MiscMath {
 protected:
   virtual void SetUp() {
@@ -157,9 +163,9 @@ TEST_F(NormAngle_rad, ValBelowRange) {
    utils_norm_angle_rad(&inputVal);
    EXPECT_NEAR(-1, inputVal, eps);
 
-   inputVal = -3*M_PI+1;
+   inputVal = -3*M_PI-1;
    utils_norm_angle_rad(&inputVal);
-   EXPECT_NEAR(-M_PI+1, inputVal, eps);
+   EXPECT_NEAR(M_PI-1, inputVal, eps);
 }
 
 

--- a/tests/utils_math/unittest.cpp
+++ b/tests/utils_math/unittest.cpp
@@ -129,19 +129,19 @@ TEST_F(NormAngle_rad, ValInRange) {
 
    inputVal = -M_PI;
    utils_norm_angle_rad(&inputVal);
-   EXPECT_NEAR(-M_PI, inputVal, eps);
+   EXPECT_FLOAT_EQ(-M_PI, inputVal);
 
    inputVal = M_PI-1e-6;
    utils_norm_angle_rad(&inputVal);
-   EXPECT_NEAR(M_PI-1e-6, inputVal, eps);
+   EXPECT_FLOAT_EQ(M_PI-1e-6, inputVal);
 
    inputVal = M_PI-1;
    utils_norm_angle_rad(&inputVal);
-   EXPECT_NEAR(M_PI-1, inputVal, eps);
+   EXPECT_FLOAT_EQ(M_PI-1, inputVal);
 
    inputVal = -M_PI+1;
    utils_norm_angle_rad(&inputVal);
-   EXPECT_NEAR(-M_PI+1, inputVal, eps);
+   EXPECT_FLOAT_EQ(-M_PI+1, inputVal);
 
    inputVal = -1;
    utils_norm_angle_rad(&inputVal);
@@ -157,19 +157,19 @@ TEST_F(NormAngle_rad, ValBelowRange) {
 
    inputVal = -M_PI-1e-6;
    utils_norm_angle_rad(&inputVal);
-   EXPECT_NEAR(M_PI-1e-6, inputVal, eps);
+   EXPECT_FLOAT_EQ(M_PI-1e-6, inputVal);
 
    inputVal = -2*M_PI;
    utils_norm_angle_rad(&inputVal);
-   EXPECT_NEAR(0, inputVal, eps);
+   EXPECT_FLOAT_EQ(0, inputVal);
 
    inputVal = -2*M_PI-1;
    utils_norm_angle_rad(&inputVal);
-   EXPECT_NEAR(-1, inputVal, eps);
+   EXPECT_FLOAT_EQ(-1, inputVal);
 
    inputVal = -3*M_PI-1;
    utils_norm_angle_rad(&inputVal);
-   EXPECT_NEAR(M_PI-1, inputVal, eps);
+   EXPECT_FLOAT_EQ(M_PI-1, inputVal);
 }
 
 
@@ -181,18 +181,17 @@ TEST_F(NormAngle_rad, ValAboveRange) {
 
    inputVal = M_PI;
    utils_norm_angle_rad(&inputVal);
-   EXPECT_NEAR(-M_PI, inputVal, eps);
+   EXPECT_FLOAT_EQ(-M_PI, inputVal);
 
    inputVal = 2*M_PI;
    utils_norm_angle_rad(&inputVal);
-   EXPECT_NEAR(0, inputVal, eps);
+   EXPECT_FLOAT_EQ(0, inputVal);
 
    inputVal = 2*M_PI+1;
    utils_norm_angle_rad(&inputVal);
-   EXPECT_NEAR(1, inputVal, eps);
+   EXPECT_FLOAT_EQ(1, inputVal);
 
    inputVal = 3.5*M_PI;
    utils_norm_angle_rad(&inputVal);
-   EXPECT_NEAR(-0.5*M_PI, inputVal, eps);
+   EXPECT_FLOAT_EQ(-0.5*M_PI, inputVal);
 }
-


### PR DESCRIPTION
This changes the unit tests so that we can test with the `-Wdouble-promotion` flag enabled.

All unit tests pass.