### PR TITLE
Increase i2c_bb frequency to 400khz

### DIFF
--- a/i2c_bb.c
+++ b/i2c_bb.c
@@ -263,5 +263,5 @@ static bool clock_stretch_timeout(i2c_bb_state *s) {
 }
 
 static void i2c_delay(void) {
-	timer_sleep(1e-6);
+	timer_sleep(2.5e-7);
 }


### PR DESCRIPTION
I know in the past you mentioned making this configurable, and I thought to do so as well. However it seems the i2c_bb driver is only used by the IMUs and all 4 currently supported IMUs work at 400khz. So I figured I'd start with the simplest solution. 

If it must be configurable, do you want a single setting for i2c_bb on the main app config page? Or should i2c_bb accept a frequency as an input, and have users define it, and then put the frequency option on the IMU config page (which would only apply to i2c IMUs). Personally I'm kinda happy to be done with it as a 1 liner :smile: 