### PR TITLE
Watchdog reset recovery by switching to UART app

### DIFF
--- a/gpdrive.c
+++ b/gpdrive.c
@@ -261,7 +261,7 @@ void gpdrive_init(volatile mc_configuration *configuration) {
 	stop_pwm_hw();
 
 	// Check if the system has resumed from IWDG reset
-	if (timeout_had_IWDG_reset()) {
+	if (timeout_had_IWDG_reset(true)) {
 		mc_interface_fault_stop(FAULT_CODE_BOOTING_FROM_WATCHDOG_RESET, false, false);
 	}
 

--- a/lispBM/lispif.c
+++ b/lispBM/lispif.c
@@ -61,7 +61,7 @@ void lispif_init(void) {
 	// Do not attempt to start lisp after a watchdog reset, in case lisp
 	// was the cause of it.
 	// TODO: Anything else to check?
-	if (!timeout_had_IWDG_reset() && terminal_get_first_fault() != FAULT_CODE_BOOTING_FROM_WATCHDOG_RESET) {
+	if (!timeout_had_IWDG_reset(true) && terminal_get_first_fault() != FAULT_CODE_BOOTING_FROM_WATCHDOG_RESET) {
 		start_lisp(false, true);
 	}
 }

--- a/main.c
+++ b/main.c
@@ -265,6 +265,14 @@ int main(void) {
 	app_uartcomm_initialize();
 	app_configuration *appconf = mempools_alloc_appconf();
 	conf_general_read_app_configuration(appconf);
+
+	// check whether we're rebooting from a watchdog reset
+	if (timeout_had_IWDG_reset(false)) {
+		// switch to uart app when recovering from an IWDG reset
+		// (but don't write it back to allow power cycling)
+		appconf->app_to_use = APP_UART;
+	}
+
 	app_set_configuration(appconf);
 	app_uartcomm_start(UART_PORT_BUILTIN);
 	app_uartcomm_start(UART_PORT_EXTRA_HEADER);

--- a/main.c
+++ b/main.c
@@ -269,8 +269,9 @@ int main(void) {
 	// check whether we're rebooting from a watchdog reset
 	if (timeout_had_IWDG_reset(false)) {
 		// switch to uart app when recovering from an IWDG reset
-		// (but don't write it back to allow power cycling)
 		appconf->app_to_use = APP_UART;
+		// store the changed app permanently, forcing the user to re-selct the desired app
+		conf_general_store_app_configuration(appconf);
 	}
 
 	app_set_configuration(appconf);

--- a/mcpwm.c
+++ b/mcpwm.c
@@ -457,7 +457,7 @@ void mcpwm_init(volatile mc_configuration *configuration) {
 	chThdCreateStatic(rpm_thread_wa, sizeof(rpm_thread_wa), NORMALPRIO, rpm_thread, NULL);
 
 	// Check if the system has resumed from IWDG reset
-	if (timeout_had_IWDG_reset()) {
+	if (timeout_had_IWDG_reset(true)) {
 		mc_interface_fault_stop(FAULT_CODE_BOOTING_FROM_WATCHDOG_RESET, false, false);
 	}
 

--- a/mcpwm_foc.c
+++ b/mcpwm_foc.c
@@ -524,7 +524,7 @@ void mcpwm_foc_init(mc_configuration *conf_m1, mc_configuration *conf_m2) {
 	// Check if the system has resumed from IWDG reset and generate fault if it has. This can be used to
 	// tell if some frozen thread caused a watchdog reset. Note that this also will trigger after running
 	// the bootloader and after the reset command.
-	if (timeout_had_IWDG_reset()) {
+	if (timeout_had_IWDG_reset(true)) {
 		mc_interface_fault_stop(FAULT_CODE_BOOTING_FROM_WATCHDOG_RESET, false, false);
 	}
 

--- a/timeout.c
+++ b/timeout.c
@@ -172,12 +172,20 @@ void timeout_configure_IWDT(void) {
 	}
 }
 
-bool timeout_had_IWDG_reset(void) {
+/**
+ * Check if we've rebooted after a watchdog timer reset
+ *
+ * @param preserve_flag   set to true to allow subsequent check
+ *                        set to false to clear the flag after the check
+ */
+bool timeout_had_IWDG_reset(bool preserve_flag) {
 	// Check if the system has resumed from IWDG reset
 	if (RCC_GetFlagStatus(RCC_FLAG_IWDGRST) != RESET) {
 		/* IWDGRST flag set */
-		/* Clear reset flags */
-		RCC_ClearFlag();
+		if (preserve_flag == false) {
+			/* Clear reset flags */
+			RCC_ClearFlag();
+		}
 		return true;
 	}
 

--- a/timeout.h
+++ b/timeout.h
@@ -45,7 +45,7 @@ bool timeout_kill_sw_active(void);
 systime_t timeout_get_timeout_msec(void);
 void timeout_configure_IWDT(void);
 void timeout_configure_IWDT_slowest(void);
-bool timeout_had_IWDG_reset(void);
+bool timeout_had_IWDG_reset(bool preserve_flag);
 void timeout_feed_WDT(uint8_t index);
 float timeout_get_brake_current(void);
 KILL_SW_MODE timeout_get_kill_sw_mode(void);


### PR DESCRIPTION
To prevent bootloops, we automatically switch to the UART app to when we're booting from a WDT reset. The first commit is the main one, keeping the switch to UART app temporary, i.e. a hard restart or power cycle will load the original settings. The second commit makes the change to UART permanent. I've left it as a separate optional commit as I'm not sure if there might be use cases where an automatic permanent switch to the UART app is not desirable.