### PR TITLE
Stabilize battery level with resting voltage and Watt hour tracking

### DIFF
--- a/motor/mc_interface.c
+++ b/motor/mc_interface.c
@@ -1549,8 +1549,9 @@ float mc_interface_get_battery_level(float *wh_left) {
 
 // this could be an exposed setting along battery Ah, cell type and cell number
 // proper resting time is about a minute, but for now lets not rely too much in the Wh tracker
-#define MIN_RESTING_TIME_SECONDS	5.0
-
+#ifndef MIN_RESTING_TIME_SECONDS
+#define MIN_RESTING_TIME_SECONDS	0.0
+#endif
 	// modulation state is the quickest way to determine if current is flowing. Needs to be quick to avoid sampling sag
 	if(mcpwm_foc_get_state() != MC_STATE_OFF) {
 		last_resting_time = chVTGetSystemTimeX();


### PR DESCRIPTION
The battery level (SOC) code was relying solely on instantaneous battery voltage. Even at light loads battery sag produced large changes in the battery % displayed in the gauges. At higher loads, the SOC would sag as much as 80%.

Here is an example of the old ways vs the new approach

![image](https://user-images.githubusercontent.com/309472/164055698-4d921ede-c01e-407a-8836-c680c8430c20.png)
Note that this is an early dataset with very light filtering. The code proposed in this commit uses stronger filtering so those small drops are less noticeable. Both traces use the same 14Ah battery, same drive unit and same rider, although the intensity might have been different.

For reference of the filtering, this is the response to voltage vs time when its relying only on the input voltage (motor not driven for enough time). I'm using a lab power supply to change the input voltage.
![image](https://user-images.githubusercontent.com/309472/164056910-e8841ef1-b641-457f-b5fb-f54402843d69.png)

The drops are caused by the recovery time of the cell. Resting voltage should be longer instead of the short 5 seconds being used now, but it can be increased later. If resting time is set to 60 seconds, it may be risking some significant drift over time if the drive never stops for those 60 seconds.
Also, batteries have less capacity at low temperatures and high currents that we're not compensating for, so we better have some data points in between.

And here is a more complete picture showing the periods without battery current and how the input voltage takes some time to recover, affecting the SOC estimation
![image](https://user-images.githubusercontent.com/309472/164060790-ebe56026-f34b-4a78-bdfc-ad1bd15af1e5.png)

Resting time has a big impact on the estimation, it would make sense to expose it in mcconf