### PR TITLE
Pass reply_func to sample_send_thread

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -640,7 +640,7 @@ void commands_process_packet(unsigned char *data, unsigned int len,
 			raw = data[ind++];
 		}
 
-		mc_interface_sample_print_data(mode, sample_len, decimation, raw);
+		mc_interface_sample_print_data(mode, sample_len, decimation, raw, send_func);
 	} break;
 
 	case COMM_REBOOT:

--- a/mc_interface.h
+++ b/mc_interface.h
@@ -84,7 +84,8 @@ float mc_interface_get_pid_pos_set(void);
 float mc_interface_get_pid_pos_now(void);
 void mc_interface_update_pid_pos_offset(float angle_now, bool store);
 float mc_interface_get_last_sample_adc_isr_duration(void);
-void mc_interface_sample_print_data(debug_sampling_mode mode, uint16_t len, uint8_t decimation, bool raw);
+void mc_interface_sample_print_data(debug_sampling_mode mode, uint16_t len, uint8_t decimation, bool raw, 
+		void(*reply_func)(unsigned char *data, unsigned int len));
 float mc_interface_temp_fet_filtered(void);
 float mc_interface_temp_motor_filtered(void);
 float mc_interface_get_battery_level(float *wh_left);


### PR DESCRIPTION
When data is being sampled another command can be received on a different port and cause the sampled data to be sent to the wrong port. This change saves the reply_func for the requester so other commands can be processed on other ports without issue.