### PR TITLE
Set abs max to reasonable value during detection

### DIFF
--- a/conf_general.c
+++ b/conf_general.c
@@ -1561,6 +1561,7 @@ int conf_general_detect_apply_all_foc(float max_power_loss,
 	mcconf->foc_current_ki = 1.0;
 	mcconf->l_current_max = MCCONF_L_CURRENT_MAX;
 	mcconf->l_current_min = MCCONF_L_CURRENT_MIN;
+	mcconf->l_abs_current_max = MCCONF_L_MAX_ABS_CURRENT;			
 	mcconf->l_current_max_scale = MCCONF_L_CURRENT_MAX_SCALE;
 	mcconf->l_current_min_scale = MCCONF_L_CURRENT_MIN_SCALE;
 	mcconf->l_watt_max = MCCONF_L_WATT_MAX;
@@ -1577,6 +1578,7 @@ int conf_general_detect_apply_all_foc(float max_power_loss,
 	mcconf_second->foc_current_ki = 1.0;
 	mcconf_second->l_current_max = MCCONF_L_CURRENT_MAX;
 	mcconf_second->l_current_min = MCCONF_L_CURRENT_MIN;
+	mcconf_second->l_abs_current_max = MCCONF_L_MAX_ABS_CURRENT;
 	mcconf_second->l_current_max_scale = MCCONF_L_CURRENT_MAX_SCALE;
 	mcconf_second->l_current_min_scale = MCCONF_L_CURRENT_MIN_SCALE;
 	mcconf_second->l_watt_max = MCCONF_L_WATT_MAX;
@@ -1710,6 +1712,9 @@ int conf_general_detect_apply_all_foc(float max_power_loss,
 	if (res && res_linkage_m2) {
 		mcconf_old->l_current_max = i_max;
 		mcconf_old->l_current_min = -i_max;
+		float abs_max = i_max * 1.5;
+		utils_truncate_number(&abs_max, HW_LIM_CURRENT_ABS);
+		mcconf_old->l_abs_current_max = abs_max;		
 		mcconf_old->motor_type = MOTOR_TYPE_FOC;
 		mcconf_old->foc_motor_r = r;
 		mcconf_old->foc_motor_l = l;
@@ -1729,6 +1734,9 @@ int conf_general_detect_apply_all_foc(float max_power_loss,
 #ifdef HW_HAS_DUAL_MOTORS
 		mcconf_old_second->l_current_max = r_l_imax_args.i_max;
 		mcconf_old_second->l_current_min = -r_l_imax_args.i_max;
+		float abs_max = r_l_imax_args.i_max * 1.5;
+		utils_truncate_number(&abs_max, HW_LIM_CURRENT_ABS);
+		mcconf_old_second->l_abs_current_max = abs_max;
 		mcconf_old_second->motor_type = MOTOR_TYPE_FOC;
 		mcconf_old_second->foc_motor_r = r_l_imax_args.r;
 		mcconf_old_second->foc_motor_l = r_l_imax_args.l;


### PR DESCRIPTION
During the FOC wizard the motor config can be reset to default. 
The motor max current can be set by the wizard to be higher than the default abs max current.

This change sets the abs max current to the motor config default before detection, 
then to 1.5x the detected max motor current after detection.
