### PR TITLE
Add hw specific backups

### DIFF
--- a/conf_general.c
+++ b/conf_general.c
@@ -121,10 +121,15 @@ void conf_general_init(void) {
 		if (g_backup.runtime_init_flag == BACKUP_VAR_INIT_CODE) {
 			backup_tmp.runtime = g_backup.runtime;
 		}
+
+		if (g_backup.hw_config_init_flag == BACKUP_VAR_INIT_CODE) {
+			memcpy((void*)backup_tmp.hw_config, (uint8_t*)g_backup.hw_config, sizeof(g_backup.hw_config));
+		}
 	}
 
 	backup_tmp.odometer_init_flag = BACKUP_VAR_INIT_CODE;
 	backup_tmp.runtime_init_flag = BACKUP_VAR_INIT_CODE;
+	backup_tmp.hw_config_init_flag = BACKUP_VAR_INIT_CODE;
 
 	g_backup = backup_tmp;
 	conf_general_store_backup_data();

--- a/datatypes.h
+++ b/datatypes.h
@@ -1365,6 +1365,10 @@ typedef struct __attribute__((packed)) {
 
 	uint32_t runtime_init_flag;
 	uint64_t runtime; // Seconds
+
+	// HW-specific data
+	uint32_t hw_config_init_flag;
+	uint8_t hw_config[128];
 } backup_data;
 
 #endif /* DATATYPES_H_ */


### PR DESCRIPTION
Data stored in this memory will be persistent across firmware updates.

It can be used to store motor position offset and configs that an end user would change but expect to be kept after a firmware update.

This uses the same approach used in the VESC BMS firmware.