### PR TITLE
Send back app and mc config to requester port

### DIFF
--- a/commands.h
+++ b/commands.h
@@ -46,8 +46,10 @@ void commands_set_hw_data_handler(void(*func)(unsigned char *data, unsigned int 
 void commands_send_app_data(unsigned char *data, unsigned int len);
 void commands_send_hw_data(unsigned char *data, unsigned int len);
 void commands_send_gpd_buffer_notify(void);
-void commands_send_mcconf(COMM_PACKET_ID packet_id, mc_configuration *mcconf);
-void commands_send_appconf(COMM_PACKET_ID packet_id, app_configuration *appconf);
+void commands_send_mcconf(COMM_PACKET_ID packet_id, mc_configuration* mcconf,
+    void(*reply_func)(unsigned char* data, unsigned int len));
+void commands_send_appconf(COMM_PACKET_ID packet_id, app_configuration* appconf,
+    void(*reply_func)(unsigned char* data, unsigned int len));
 void commands_apply_mcconf_hw_limits(mc_configuration *mcconf);
 void commands_init_plot(char *namex, char *namey);
 void commands_plot_add_graph(char *name);

--- a/conf_general.c
+++ b/conf_general.c
@@ -1314,7 +1314,7 @@ int conf_general_autodetect_apply_sensors_foc(float current,
 		}
 
 		if (send_mcconf_on_success) {
-			commands_send_mcconf(COMM_GET_MCCONF, mcconf_old);
+			commands_send_mcconf(COMM_GET_MCCONF, mcconf_old, 0);
 		}
 	}
 
@@ -1959,7 +1959,7 @@ int conf_general_detect_apply_all_foc_can(bool detect_can, float max_power_loss,
 			appconf->can_status_msgs_r1 = 0b00001111;
 			conf_general_store_app_configuration(appconf);
 			app_set_configuration(appconf);
-			commands_send_appconf(COMM_GET_APPCONF, appconf);
+			commands_send_appconf(COMM_GET_APPCONF, appconf, 0);
 			chThdSleepMilliseconds(1000);
 		}
 
@@ -1972,7 +1972,7 @@ int conf_general_detect_apply_all_foc_can(bool detect_can, float max_power_loss,
 		mc_interface_select_motor_thread(1);
 		*mcconf = *mc_interface_get_configuration();
 #endif
-		commands_send_mcconf(COMM_GET_MCCONF, mcconf);
+		commands_send_mcconf(COMM_GET_MCCONF, mcconf, 0);
 		chThdSleepMilliseconds(1000);
 	}
 

--- a/nrf/nrf_driver.c
+++ b/nrf/nrf_driver.c
@@ -499,7 +499,7 @@ void nrf_driver_process_packet(unsigned char *buf, unsigned char len) {
 		conf_general_store_app_configuration(&appconf);
 		app_set_configuration(&appconf);
 
-		commands_send_appconf(COMM_GET_APPCONF, &appconf);
+		commands_send_appconf(COMM_GET_APPCONF, &appconf, 0);
 
 		unsigned char data[2];
 		data[0] = COMM_NRF_START_PAIRING;


### PR DESCRIPTION
When COMM_GET_APPCONF and COMM_GET_MCCONF are received in commands_process_packet, replied config packet is always sent back to last received reply_function, instead of one passed to commands_process_packet. 
This bug occures when multiple vesc tool instances are connected from different devices, some won't receive back config.