### PR TITLE
Log faults if active on startup

### DIFF
--- a/mc_interface.c
+++ b/mc_interface.c
@@ -239,6 +239,12 @@ void mc_interface_init(void) {
 		break;
 	}
 
+	//Clear fault, to log first fault to terminal
+	m_motor_1.m_fault_now = FAULT_CODE_NONE;
+#ifdef HW_HAS_DUAL_MOTORS
+	m_motor_2.m_fault_now = FAULT_CODE_NONE;
+#endif
+
 	bms_init((bms_config*)&m_motor_1.m_conf.bms);
 }
 

--- a/mc_interface.c
+++ b/mc_interface.c
@@ -2440,7 +2440,7 @@ static void run_timer_tasks(volatile motor_if_state_t *motor) {
 	encoder_check_faults(&motor->m_conf, !is_motor_1);
 
 	// TODO: Implement for BLDC and GPDRIVE
-	if(motor->m_conf.motor_type == MOTOR_TYPE_FOC) {
+	if(motor->m_conf.motor_type == MOTOR_TYPE_FOC && mc_interface_dccal_done()) {
 		float curr0_offset;
 		float curr1_offset;
 		float curr2_offset;
@@ -2472,7 +2472,7 @@ static void run_timer_tasks(volatile motor_if_state_t *motor) {
 
 	// Monitor currents balance. The sum of the 3 currents should be zero
 #ifdef HW_HAS_3_SHUNTS
-	if (!motor->m_conf.foc_sample_high_current) { // This won't work when high current sampling is used
+	if (!motor->m_conf.foc_sample_high_current && mc_interface_dccal_done()) { // This won't work when high current sampling is used
 		motor->m_motor_current_unbalance = mc_interface_get_abs_motor_current_unbalance();
 
 		if (fabsf(motor->m_motor_current_unbalance) > fabsf(MCCONF_MAX_CURRENT_UNBALANCE)) {


### PR DESCRIPTION
Currently if fault is active on startup it won't be logged to terminal so it is' hard to notice faults like booting from watchdog reset.
Also current offset and unbalace faults shoudn't be triggered before dccal , since after that vairables are filled with real data from adc.