### PR TITLE
Backport ChibiOS hw i2c fixes.

### DIFF
--- a/ChibiOS_3.0.5/os/hal/ports/STM32/LLD/I2Cv1/i2c_lld.c
+++ b/ChibiOS_3.0.5/os/hal/ports/STM32/LLD/I2Cv1/i2c_lld.c
@@ -65,6 +65,9 @@
 #define I2C_EV5_MASTER_MODE_SELECT                                          \
   ((uint32_t)(((I2C_SR2_MSL | I2C_SR2_BUSY) << 16) | I2C_SR1_SB))
 
+#define I2C_EV5_MASTER_MODE_SELECT_NO_BUSY                                  \
+  ((uint32_t)((I2C_SR2_MSL << 16) | I2C_SR1_SB))
+
 #define I2C_EV6_MASTER_TRA_MODE_SELECTED                                    \
   ((uint32_t)(((I2C_SR2_MSL | I2C_SR2_BUSY | I2C_SR2_TRA) << 16) |          \
               I2C_SR1_ADDR | I2C_SR1_TXE))
@@ -79,7 +82,11 @@
 #define I2C_EV9_MASTER_ADD10                                                \
   ((uint32_t)(((I2C_SR2_MSL | I2C_SR2_BUSY) << 16) | I2C_SR1_ADD10))
 
-#define I2C_EV_MASK 0x00FFFFFF
+#define I2C_EV5_MASTER_MODE_INVALID                                         \
+  ((uint32_t)(((I2C_SR2_MSL | I2C_SR2_BUSY) << 16) | (I2C_SR1_SB |          \
+              I2C_SR1_STOPF)))
+
+#define I2C_EV_MASK 0x00FF00FF
 
 #define I2C_ERROR_MASK                                                      \
   ((uint16_t)(I2C_SR1_BERR | I2C_SR1_ARLO | I2C_SR1_AF | I2C_SR1_OVR |      \
@@ -148,7 +155,7 @@ static void i2c_lld_set_clock(I2CDriver *i2cp) {
 
   osalDbgCheck((i2cp != NULL) &&
                (clock_speed > 0) &&
-               (clock_speed <= 4000000));
+               (clock_speed <= 400000));
 
   /* CR2 Configuration.*/
   dp->CR2 &= (uint16_t)~I2C_CR2_FREQ;
@@ -252,6 +259,7 @@ static void i2c_lld_serve_event_interrupt(I2CDriver *i2cp) {
      done by the DMA.*/
   switch (I2C_EV_MASK & (event | (regSR2 << 16))) {
   case I2C_EV5_MASTER_MODE_SELECT:
+  case I2C_EV5_MASTER_MODE_SELECT_NO_BUSY:
     if ((i2cp->addr >> 8) > 0) { 
       /* 10-bit address: 1 1 1 1 0 X X R/W */
       dp->DR = 0xF0 | (0x6 & (i2cp->addr >> 8)) | (0x1 & i2cp->addr);
@@ -276,6 +284,7 @@ static void i2c_lld_serve_event_interrupt(I2CDriver *i2cp) {
     break;
   case I2C_EV8_2_MASTER_BYTE_TRANSMITTED:
     /* Catches BTF event after the end of transmission.*/
+    (void)dp->DR; /* Clear BTF.*/
     if (dmaStreamGetTransactionSize(i2cp->dmarx) > 0) {
       /* Starts "read after write" operation, LSB = 1 -> receive.*/
       i2cp->addr |= 0x01;
@@ -286,6 +295,10 @@ static void i2c_lld_serve_event_interrupt(I2CDriver *i2cp) {
     dp->CR1 |= I2C_CR1_STOP;
     _i2c_wakeup_isr(i2cp);
     break;
+  case I2C_EV5_MASTER_MODE_INVALID:
+      i2c_lld_abort_operation(i2cp);
+      dp->CR2 &= ~I2C_CR2_ITEVTEN;
+      break;
   default:
     break;
   }
@@ -537,17 +550,17 @@ void i2c_lld_init(void) {
 void i2c_lld_start(I2CDriver *i2cp) {
   I2C_TypeDef *dp = i2cp->i2c;
 
-  i2cp->txdmamode = STM32_DMA_CR_PSIZE_BYTE | STM32_DMA_CR_MSIZE_BYTE |
-                    STM32_DMA_CR_MINC       | STM32_DMA_CR_DMEIE |
-                    STM32_DMA_CR_TEIE       | STM32_DMA_CR_TCIE |
-                    STM32_DMA_CR_DIR_M2P;
-  i2cp->rxdmamode = STM32_DMA_CR_PSIZE_BYTE | STM32_DMA_CR_MSIZE_BYTE |
-                    STM32_DMA_CR_MINC       | STM32_DMA_CR_DMEIE |
-                    STM32_DMA_CR_TEIE       | STM32_DMA_CR_TCIE |
-                    STM32_DMA_CR_DIR_P2M;
-
   /* If in stopped state then enables the I2C and DMA clocks.*/
   if (i2cp->state == I2C_STOP) {
+
+      i2cp->txdmamode = STM32_DMA_CR_PSIZE_BYTE | STM32_DMA_CR_MSIZE_BYTE |
+          STM32_DMA_CR_MINC | STM32_DMA_CR_DMEIE |
+          STM32_DMA_CR_TEIE | STM32_DMA_CR_TCIE |
+          STM32_DMA_CR_DIR_M2P;
+      i2cp->rxdmamode = STM32_DMA_CR_PSIZE_BYTE | STM32_DMA_CR_MSIZE_BYTE |
+          STM32_DMA_CR_MINC | STM32_DMA_CR_DMEIE |
+          STM32_DMA_CR_TEIE | STM32_DMA_CR_TCIE |
+          STM32_DMA_CR_DIR_P2M;
 
 #if STM32_I2C_USE_I2C1
     if (&I2CD1 == i2cp) {


### PR DESCRIPTION
There are several hw i2c bugs that were fixed in newer versions of chibios that can cause interrupt stroms and make foc loop to either execute too late or cause watchdog to reset.
This happens mainly when there is noise present on i2c lines.

Relevent discussions about that on chibios forums:
http://forum.chibios.org/viewtopic.php?t=5198
http://forum.chibios.org/viewtopic.php?f=35&t=5298
ChibiOS bugs in this backport: #781, #1045, #1048,  #1064, #1120