### PR TITLE
use NVIC_SystemReset in COMM_REBOOT command

### DIFF
--- a/comm/commands.c
+++ b/comm/commands.c
@@ -648,9 +648,7 @@ void commands_process_packet(unsigned char *data, unsigned int len,
 
 	case COMM_REBOOT:
 		conf_general_store_backup_data();
-		// Lock the system and enter an infinite loop. The watchdog will reboot.
-		__disable_irq();
-		for(;;){};
+		NVIC_SystemReset();
 		break;
 
 	case COMM_ALIVE:


### PR DESCRIPTION
Reopening this as the previous one got closed.

Using watchdog reset to reboot system causes FAULT_CODE_BOOTING_FROM_WATCHDOG_RESET after startup.
Instead use NVIC_SystemReset to reboot system. (both ways are doing a reset by pulling NRST pin low).

After commit 1309ece84be5f69968f7fc149d0f9e241613e082 it is now possible to reproduce this and get watchdog fault in "print faults" by pressing reboot in vesc tool.