### PR TITLE
fixed lisp set_current and set_current_rel not resetting timeout

### DIFF
--- a/lispBM/lispif_vesc_extensions.c
+++ b/lispBM/lispif_vesc_extensions.c
@@ -991,6 +991,7 @@ static lbm_value ext_app_adc_override(lbm_value *args, lbm_uint argn) {
 
 static lbm_value ext_set_current(lbm_value *args, lbm_uint argn) {
 	CHECK_NUMBER_ALL();
+	timeout_reset();
 
 	if (argn == 1) {
 		mc_interface_set_current(lbm_dec_as_float(args[0]));
@@ -1006,6 +1007,7 @@ static lbm_value ext_set_current(lbm_value *args, lbm_uint argn) {
 
 static lbm_value ext_set_current_rel(lbm_value *args, lbm_uint argn) {
 	CHECK_NUMBER_ALL();
+	timeout_reset();
 
 	if (argn == 1) {
 		mc_interface_set_current_rel(lbm_dec_as_float(args[0]));


### PR DESCRIPTION
This caused stuttering especially when using M365 dashboard script. Tested and works.