### PR TITLE
Document how to open vesc firmware project in Qt Creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ sudo udevadm trigger
 
 1.  `pip install aqtinstall`
 2.  `make qt_install`
+3.  Open Qt Creator IDE installed in `tools/Qt/Tools/QtCreator/bin/qtcreator`
+4.  With Qt Creator, open the vesc firmware Qt Creator project, named vesc.pro. You will find it in `Project/Qt Creator/vesc.pro`
+5.  The IDE is configured by default to build 100_250 firmware, this can be changed in the bottom of the left panel, there you will find all hardware variants supported by VESC
 
 ## Upload to VESC
 ### Method 1 - Flash it using an STLink SWD debugger


### PR DESCRIPTION
Took me a bit of browsing in the discord to learn that the vesc.pro existed, so I'm adding it to the README. Debugging is possible but it may need some safety advice and platform-dependant stuff so its better to leave it out for now.