### PR TITLE
Improve Sin/Cos Encoder, fix lowpass filter, fix scaling

### DIFF
--- a/encoder/enc_sincos.c
+++ b/encoder/enc_sincos.c
@@ -72,8 +72,9 @@ float enc_sincos_read_deg(ENCSINCOS_config_t *cfg) {
 			UTILS_LP_FAST(cfg->state.signal_low_error_rate, 0.0, timestep);
 
 			float angle_tmp = RAD2DEG_f(utils_fast_atan2(sin, cos));
-			UTILS_LP_FAST(angle, angle_tmp, cfg->filter_constant);
-			cfg->state.last_enc_angle = angle;
+			utils_norm_angle(&angle_tmp);
+			UTILS_LP_FAST_360(cfg->state.last_enc_angle, angle_tmp, cfg->filter_constant);
+			angle = cfg->state.last_enc_angle;
 		}
 	}
 

--- a/util/utils_math.h
+++ b/util/utils_math.h
@@ -98,6 +98,24 @@ void utils_rotate_vector3(float *input, float *rotation, float *output, bool rev
 #define UTILS_LP_FAST(value, sample, filter_constant)	(value -= (filter_constant) * ((value) - (sample)))
 
 /**
+ * A simple low pass filter able to filter wrapping values between 0 and 360
+ *
+ * @param value
+ * The filtered value.
+ *
+ * @param sample
+ * Next sample.
+ *
+ * @param filter_constant
+ * Filter constant. Range 0.0 to 1.0, where 1.0 gives the unfiltered value.
+ */
+#define UTILS_LP_FAST_360(value, sample, filter_constant)	( ((sample) - (value)) > 180.0 ? \
+                                                            value -= (filter_constant) * ((value) - ((sample) + 360.0)) : \
+                                                            (((sample) - (value)) < -180.0 ? \
+                                                                (value -= (filter_constant) * ((value) - ((sample) - 360.0))) : \
+                                                                (value -= (filter_constant) * ((value) - (sample)))) )
+
+/**
  * A fast approximation of a moving average filter with N samples. See
  * https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average
  * https://en.wikipedia.org/wiki/Exponential_smoothing


### PR DESCRIPTION
Current Sin/Cos Encoder implementation has two issues:

1. `UTILS_LP_FAST(angle, angle_tmp, cfg->filter_constant);` : angle variable is always zero in this context. Therefore the returned angle is always cfg->filter_constant * angle_tmp (with default filter constant of 0.5). This also leads to a wrong Encoder Ratio which is twice as high as desired.
2. `UTILS_LP_FAST` in general is not able to filter wrapping numbers. For example, if last value is 350° and new value is 20°, the filter returns 185°, which is not the desired value of 5°. I added a UTILS_LP_FAST_360 which is capable of filtering wrapping values with 0 <= value < 360

