### PR TITLE
Convert all terminal command inputs to lowercase

### DIFF
--- a/terminal.c
+++ b/terminal.c
@@ -38,6 +38,7 @@
 #include "firmware_metadata.h"
 
 #include <string.h>
+#include <ctype.h>
 #include <stdio.h>
 #include <math.h>
 
@@ -73,6 +74,11 @@ void terminal_process_string(char *str) {
 	if (argc == 0) {
 		commands_printf("No command received\n");
 		return;
+	}
+
+	// force command argument to be lowercase
+	for(int i = 0; argv[0][i] != '\0'; i++){
+  		argv[0][i] = tolower(argv[0][i]);
 	}
 
 	for (int i = 0;i < callback_write;i++) {


### PR DESCRIPTION
I thought about doing thin in the qt vesc tool side, but figured it would be more robust firmware side instead.

When typing commands in android, it capitalizes the first letter. Which is an even bigger pain because you always have to retype every terminal command on android with no arrow keys.
This just ignores that capitalization for terminal commands and converts everything to lowercase before processing.