### PR TITLE
Update gcc/gdb version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ workspace.code-workspace
 *.pro.shared
 
 .vscode
+*.log
+null.d
+nul.d

--- a/Makefile
+++ b/Makefile
@@ -73,24 +73,24 @@ endif
 ##############################
 .PHONY: help
 help:
-	@echo
+	@echo ""
 	@echo "   This Makefile is known to work on Linux and Mac in a standard shell environment."
-	@echo
+	@echo ""
 	@echo "   Here is a summary of the available targets:"
-	@echo
+	@echo ""
 	@echo "   [Tool Installers]"
 	@echo "     arm_sdk_install      - Install the GNU ARM gcc toolchain"
 	@echo "     qt_install           - Install the all tools for Qt"
-	@echo
+	@echo ""
 	@echo "   [Big Hammer]"
 	@echo "     all_fw               - Build firmware for all boards"
 	@echo "     all_fw_package       - Packaage firmware for boards in package list"
-	@echo
+	@echo ""
 	@echo "   [Unit Tests]"
 	@echo "     all_ut               - Build all unit tests"
 	@echo "     all_ut_xml           - Run all unit tests and capture all XML output to files"
 	@echo "     all_ut_run           - Run all unit tests and dump XML output to console"
-	@echo
+	@echo ""
 	@echo "   [Firmware]"
 	@echo "     fw   - Build firmware for default target"
 	@echo "                            supported boards are: $(ALL_BOARD_NAMES)"
@@ -98,12 +98,12 @@ help:
 	@echo "     PROJECT=<target> fw   - Build firmware for <target>"
 	@echo "     fw_<board>_clean     - Remove firmware for <board>"
 	@echo "     fw_<board>_flash     - Use OpenOCD + SWD/JTAG to write firmware to <target>"
-	@echo
+	@echo ""
 	@echo "   Hint: Add V=1 to your command line to see verbose build output."
-	@echo
+	@echo ""
 	@echo "   Note: All tools will be installed into $(TOOLS_DIR)"
 	@echo "         All build output will be placed in $(BUILD_DIR)"
-	@echo
+	@echo ""
 
 
 $(DL_DIR):

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -11,19 +11,19 @@
 ####################
 # ARM (Cortex) SDK #
 ####################
-ARM_SDK_DIR := $(TOOLS_DIR)/gcc-arm-none-eabi-7-2018-q2-update
+ARM_SDK_DIR := $(TOOLS_DIR)/gcc-arm-none-eabi-10.3-2021.10
 
 .PHONY: arm_sdk_install
 ifdef LINUX
-  arm_sdk_install: ARM_SDK_URL  := https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2
+  arm_sdk_install: ARM_SDK_URL  := https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2
 endif
 
 ifdef MACOS
-  arm_sdk_install: ARM_SDK_URL  := https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-mac.tar.bz2
+  arm_sdk_install: ARM_SDK_URL  := https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-mac.tar.bz2
 endif
 
 ifdef WINDOWS
-  arm_sdk_install: ARM_SDK_URL  := https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-win32.zip
+  arm_sdk_install: ARM_SDK_URL  := https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-win32.zip
 endif
 
 arm_sdk_install: ARM_SDK_FILE := $(notdir $(ARM_SDK_URL))
@@ -38,7 +38,7 @@ ifneq ($(OSFAMILY), windows)
 	$(V1) tar -C $(TOOLS_DIR) -xjf "$(DL_DIR)/$(ARM_SDK_FILE)"
 else
 	$(V1) curl --continue - --location --insecure --output "$(DL_DIR)/$(ARM_SDK_FILE)" "$(ARM_SDK_URL)"
-	$(V1) powershell -noprofile -command Expand-Archive -DestinationPath $(ARM_SDK_DIR) -LiteralPath "$(DL_DIR)/$(ARM_SDK_FILE)"
+	$(V1) powershell -noprofile -command Expand-Archive -DestinationPath $(TOOLS_DIR) -LiteralPath "$(DL_DIR)/$(ARM_SDK_FILE)"
 
 endif
 


### PR DESCRIPTION
Some tools have depreciated the older version of gdb we use and the issue causing https://github.com/vedderb/bldc/issues/210 on newer versions of gcc have been fixed. So it may be worth upgrading toolchains now.

Tested with vesc 6.0 mk4  in windows. Detecting and running a motor works.
Also successfully tested compilation in wsl linux. Mac not tested.

One things with the newer gcc version is it throws a lot more warnings about casts and implicit conversions.