### PR TITLE
Clean servo input

### DIFF
--- a/driver/servo_dec.c
+++ b/driver/servo_dec.c
@@ -43,8 +43,11 @@ static volatile bool is_running = false;
 static void(*done_func)(void) = 0;
 
 static void icuwidthcb(ICUDriver *icup) {
-	last_len_received[0] = ((float)icuGetWidthX(icup) / ((float)TIMER_FREQ / 1000.0));
-	float len = last_len_received[0] - pulse_start;
+	float len_received = ((float)icuGetWidthX(icup) / ((float)TIMER_FREQ / 1000.0));
+#ifndef HW_VALIDATE_SERVO_INPUT
+	last_len_received[0] = len_received;
+#endif
+	float len = len_received - pulse_start;
 	const float len_set = (pulse_end - pulse_start);
 
 	if (len > len_set) {
@@ -78,6 +81,9 @@ static void icuwidthcb(ICUDriver *icup) {
 			servo_pos[0] = (len * 2.0 - len_set) / len_set;
 		}
 
+#ifdef HW_VALIDATE_SERVO_INPUT
+		last_len_received[0] = len_received; // Stop noisy lengths from going to vesc tool
+#endif
 		last_update_time = chVTGetSystemTime();
 
 		if (done_func) {

--- a/hwconf/hw.h
+++ b/hwconf/hw.h
@@ -576,6 +576,10 @@
 #endif
 #endif
 
+#ifndef HW_TRIM_HSI
+#define HW_TRIM_HSI()
+#endif
+
 #ifndef HW_RESET_DRV_FAULTS
 #define HW_RESET_DRV_FAULTS()
 #endif

--- a/hwconf/teamtriforceuk/a50s/hw_a50s_core.c
+++ b/hwconf/teamtriforceuk/a50s/hw_a50s_core.c
@@ -23,6 +23,7 @@
 #include "utils_math.h"
 #include <math.h>
 #include "mc_interface.h"
+#include "stm32f4xx_rcc.h"
 
 // Variables
 static volatile bool i2c_running = false;
@@ -242,4 +243,11 @@ void hw_try_restore_i2c(void) {
 
 		i2cReleaseBus(&HW_I2C_DEV);
 	}
+}
+
+// Trim the HSI to reduce affect of temperature
+void hw_a50s_trim_hsi(void){
+	int temp = NTC_TEMP(ADC_IND_TEMP_MOS);
+	uint8_t hsi_trim = utils_map(temp, -30, 80, 21, 9); // Make sure it is at 15 for 25C	
+	RCC_AdjustHSICalibrationValue(hsi_trim);
 }

--- a/hwconf/teamtriforceuk/a50s/hw_a50s_core.c
+++ b/hwconf/teamtriforceuk/a50s/hw_a50s_core.c
@@ -248,6 +248,10 @@ void hw_try_restore_i2c(void) {
 // Trim the HSI to reduce affect of temperature
 void hw_a50s_trim_hsi(void){
 	int temp = NTC_TEMP(ADC_IND_TEMP_MOS);
-	uint8_t hsi_trim = utils_map(temp, -30, 80, 21, 9); // Make sure it is at 15 for 25C	
+	uint8_t hsi_trim = 15;
+	if (temp > 25)
+		hsi_trim = utils_map(temp, 25, 80, 15, 9); // above calibrated
+	else if (temp < 25)
+		hsi_trim = utils_map(temp, -40, 25, 31, 15); // below calibrated	
 	RCC_AdjustHSICalibrationValue(hsi_trim);
 }

--- a/hwconf/teamtriforceuk/a50s/hw_a50s_core.h
+++ b/hwconf/teamtriforceuk/a50s/hw_a50s_core.h
@@ -24,6 +24,10 @@
 #define HW_USE_INTERNAL_RC
 #define HW_HAS_PHASE_FILTERS
 
+// Used to remove ground noise from servo input. 
+// Which causes VESC Tool PPM wizard to not work.
+#define HW_VALIDATE_SERVO_INPUT 
+
 // Macros
 /*
  * ADC Vector
@@ -258,5 +262,11 @@
 #else
 #error "Must define a hardware type"
 #endif
+
+// Trim HSI oscillator to compensate for temperature.
+#define HW_TRIM_HSI() hw_a50s_trim_hsi()
+
+// HW-specific functions
+void hw_a50s_trim_hsi(void);
 
 #endif /* HW_A50S_CORE_H_ */

--- a/main.c
+++ b/main.c
@@ -191,6 +191,8 @@ static THD_FUNCTION(periodic_thread, arg) {
 				break;
 			}
 		}
+	 
+		HW_TRIM_HSI(); // Compensate HSI for temperature
 
 		chThdSleepMilliseconds(10);
 	}


### PR DESCRIPTION
Option to only send back valid servo pulse lengths to VESC Tool. This stops ground noise that triggers the timer from making the PPM mapping wizard unusable. (Will see 0ms or >20ms pulses occasionally which ruins the max and min values, meaning the user has to manually enter them)

Add temperature compensation for HSI oscillator to 10ms loop. Fairly simple map at the moment but seems to work well. 
Could be added as a generic call for all hardware using internal RC oscillator but it might not work that well if the temperature sensor is not close to the STM32.