### PR TITLE
Adding passive (shorted) brake to FOC

### DIFF
--- a/lispBM/lispif_vesc_extensions.c
+++ b/lispBM/lispif_vesc_extensions.c
@@ -1252,6 +1252,13 @@ static lbm_value ext_set_brake_rel(lbm_value *args, lbm_uint argn) {
 	return ENC_SYM_TRUE;
 }
 
+static lbm_value ext_set_passive_brake(lbm_value *args, lbm_uint argn) {
+	(void)args; (void)argn;
+	timeout_reset();
+	mc_interface_set_passive_brake();
+	return ENC_SYM_TRUE;
+}
+
 static lbm_value ext_set_handbrake(lbm_value *args, lbm_uint argn) {
 	LBM_CHECK_ARGN_NUMBER(1);
 	timeout_reset();
@@ -4385,6 +4392,7 @@ void lispif_load_vesc_extensions(void) {
 	lbm_add_extension("set-duty", ext_set_duty);
 	lbm_add_extension("set-brake", ext_set_brake);
 	lbm_add_extension("set-brake-rel", ext_set_brake_rel);
+	lbm_add_extension("set-passive-brake", ext_set_passive_brake);
 	lbm_add_extension("set-handbrake", ext_set_handbrake);
 	lbm_add_extension("set-handbrake-rel", ext_set_handbrake_rel);
 	lbm_add_extension("set-rpm", ext_set_rpm);

--- a/motor/foc_math.h
+++ b/motor/foc_math.h
@@ -45,6 +45,8 @@ typedef struct {
 	float i_beta;
 	float i_abs;
 	float i_abs_filter;
+	float i_abs_passive_brake;
+	float i_abs_passive_brake_filtered;
 	float i_bus;
 	float v_bus;
 	float v_alpha;

--- a/motor/mc_interface.c
+++ b/motor/mc_interface.c
@@ -702,6 +702,20 @@ void mc_interface_set_brake_current(float current) {
 	events_add("set_current_brake", current);
 }
 
+void mc_interface_set_passive_brake(void) {
+	
+	if (mc_interface_try_input()) {
+		return;
+	}
+	
+	if (motor_now()->m_conf.motor_type == MOTOR_TYPE_FOC) {
+		mcpwm_foc_set_passive_brake();
+	}
+	
+	events_add("set_passive_brake", 0.0);
+}
+
+
 /**
  * Set current relative to the minimum and maximum current limits.
  *
@@ -762,6 +776,7 @@ void mc_interface_set_handbrake(float current) {
 
 	events_add("set_handbrake", current);
 }
+
 
 /**
  * Set handbrake brake current relative to the minimum current limit.

--- a/motor/mc_interface.h
+++ b/motor/mc_interface.h
@@ -49,6 +49,7 @@ void mc_interface_set_current(float current);
 void mc_interface_set_brake_current(float current);
 void mc_interface_set_current_rel(float val);
 void mc_interface_set_brake_current_rel(float val);
+void mc_interface_set_passive_brake(void);
 void mc_interface_set_handbrake(float current);
 void mc_interface_set_handbrake_rel(float val);
 void mc_interface_set_openloop_current(float current, float rpm);

--- a/motor/mcpwm_foc.h
+++ b/motor/mcpwm_foc.h
@@ -42,6 +42,7 @@ void mcpwm_foc_set_current(float current);
 void mcpwm_foc_release_motor(void);
 void mcpwm_foc_set_brake_current(float current);
 void mcpwm_foc_set_handbrake(float current);
+void mcpwm_foc_set_passive_brake(void);
 void mcpwm_foc_set_openloop_current(float current, float rpm);
 void mcpwm_foc_set_openloop_phase(float current, float phase);
 void mcpwm_foc_set_openloop_duty(float dutyCycle, float rpm);


### PR DESCRIPTION
Added new low level  FOC function ` mcpwm_foc_set_passive_brake() ` that shorts all phases through low side FETs, braking the motor. Intention is to use this for continuing to brake a propeller using zero power after actively stopping it using negative iq or other brake methods. If used at speed the braking effect maybe violent. It attempts to respect ABS_MAX_CURRENT and will raise a fault if exceeded.

The new function is exposed through lisp only at the moment.