### PR TITLE
Fixup for commit b8e8952e - use reasonable defaults for imu filters

### DIFF
--- a/imu/imu.c
+++ b/imu/imu.c
@@ -179,7 +179,7 @@ void imu_reset_orientation(void) {
 	init_time = chVTGetSystemTimeX();
 	ahrs_init_attitude_info(&m_att);
 	FusionAhrsInitialise(&m_fusionAhrs, 10.0, 1.0);
-	ahrs_update_all_parameters(&m_att, 1.0, 10.0, 0.0, 2.0);
+	ahrs_update_all_parameters(&m_att, 1.0, 0.3, 0.0, 0.1);
 }
 
 i2c_bb_state *imu_get_i2c(void) {


### PR DESCRIPTION
The default values should be kp=0.3 and beta=0.1 (just like they used to be in 5.3 and before)

Signed-off-by: Dado Mista <dadomista@gmail.com>