### PR TITLE
Updated VESC_IF()->get_ppm() to now respect pulse_center

### DIFF
--- a/lispBM/lispif_c_lib.c
+++ b/lispBM/lispif_c_lib.c
@@ -589,7 +589,20 @@ static float lib_get_ppm(void) {
 	const ppm_config* cfg = &(app_get_configuration()->app_ppm_conf);
 	servodec_set_pulse_options(cfg->pulse_start, cfg->pulse_end, cfg->median_filter);
 
-	return servodec_get_servo(0);
+	float servo_val = servodec_get_servo(0);
+	float servo_ms = utils_map(servo_val, -1.0, 1.0, cfg->pulse_start, cfg->pulse_end);
+
+	// Mapping with respect to center pulsewidth
+	if (servo_ms < cfg->pulse_center) {
+		servo_val = utils_map(servo_ms, cfg->pulse_start,
+				cfg->pulse_center, -1.0, 0.0);
+	} else {
+		servo_val = utils_map(servo_ms, cfg->pulse_center,
+				cfg->pulse_end, 0.0, 1.0);
+	}
+	float input_val = servo_val;
+
+	return input_val;
 }
 
 static float lib_get_ppm_age(void) {


### PR DESCRIPTION
Returned value is now mapped with respect to pulse_center, rather than just pulse_start and pulse_end linearly mapped.

The current implementation does not map the PPM servo val around the configured pulse_center, just pulse_start and pulse_end, leaving the possibility (and likelihood) of it centering on a non-zero value at neutral. This PR modifies the original function, but if there are cases that may require this linear mapping start to end, maybe this should be a separate function? Should be simple to implement either way.