### PR TITLE
Adds vesc_c_if nvm access

### DIFF
--- a/flash_helper.c
+++ b/flash_helper.c
@@ -463,3 +463,35 @@ static void qmlui_check(int ind) {
 
 	code_checks[ind].check_done = true;
 }
+
+#define VESC_IF_NVM_REGION_SIZE	(ADDR_FLASH_SECTOR_9 - ADDR_FLASH_SECTOR_8)
+
+// reads len bytes from a given address in flash region 8
+bool if_read_nvm(uint8_t *v, unsigned int len, unsigned int address) {
+	if (address > VESC_IF_NVM_REGION_SIZE) {
+		return false;	// early return for address out of range
+	}
+	len = len > (VESC_IF_NVM_REGION_SIZE - address) ? VESC_IF_NVM_REGION_SIZE - address : len;
+	for (unsigned int i = 0; i < len; i++) {
+		v[i] = *(uint8_t*)(ADDR_FLASH_SECTOR_8 + address + i);
+	}
+	return true;
+}
+
+// writes len bytes to a given address in flash region 8
+bool if_write_nvm(uint8_t *v, unsigned int len, unsigned int address) {
+	if (address > VESC_IF_NVM_REGION_SIZE) {
+		return false;	// early return for address out of range
+	}
+
+	uint16_t res = write_data(address, v, len);
+
+	return (res == FLASH_COMPLETE);
+}
+
+// wipes flash region 8
+bool if_wipe_nvm(void) {
+	uint16_t res = erase_sector(flash_sector[8]);
+
+	return (res == FLASH_COMPLETE);
+}

--- a/flash_helper.c
+++ b/flash_helper.c
@@ -466,7 +466,13 @@ static void qmlui_check(int ind) {
 
 #define VESC_IF_NVM_REGION_SIZE	(ADDR_FLASH_SECTOR_9 - ADDR_FLASH_SECTOR_8)
 
-// reads len bytes from a given address in flash region 8
+/**
+  * @brief  Package function - Reads len bytes to v from nvm at address
+  * @param	v: array of bytes to which the result will be written
+  * @param	len: number of bytes to read
+  * @param	address: address of the first byte
+  * @retval Boolean indicating success or failure
+  */
 bool if_read_nvm(uint8_t *v, unsigned int len, unsigned int address) {
 	if (VESC_IF_NVM_REGION_SIZE - address <= 0) {
 		return false;	// early return for address out of range
@@ -479,7 +485,13 @@ bool if_read_nvm(uint8_t *v, unsigned int len, unsigned int address) {
 	return true;
 }
 
-// writes len bytes to a given address in flash region 8
+/**
+  * @brief  Package function - Writes len bytes from v to nvm at address
+  * @param	v: array of bytes to write
+  * @param	len: number of bytes to write
+  * @param	address: address of the first byte
+  * @retval Boolean indicating success or failure
+  */
 bool if_write_nvm(uint8_t *v, unsigned int len, unsigned int address) {
 	if (address > VESC_IF_NVM_REGION_SIZE) {
 		return false;	// early return for address out of range
@@ -490,7 +502,10 @@ bool if_write_nvm(uint8_t *v, unsigned int len, unsigned int address) {
 	return (res == FLASH_COMPLETE);
 }
 
-// wipes flash region 8
+/**
+  * @brief  Package function - Erase region of NVM used by packages.
+  * @retval Boolean indicating success or failure
+  */
 bool if_wipe_nvm(void) {
 	uint16_t res = erase_sector(flash_sector[8]);
 

--- a/flash_helper.c
+++ b/flash_helper.c
@@ -484,7 +484,7 @@ bool if_write_nvm(uint8_t *v, unsigned int len, unsigned int address) {
 		return false;	// early return for address out of range
 	}
 
-	uint16_t res = write_data(address, v, len);
+	uint16_t res = write_data(address + ADDR_FLASH_SECTOR_8, v, len);
 
 	return (res == FLASH_COMPLETE);
 }

--- a/flash_helper.c
+++ b/flash_helper.c
@@ -473,7 +473,7 @@ static void qmlui_check(int ind) {
   * @param	address: address of the first byte
   * @retval Boolean indicating success or failure
   */
-bool if_read_nvm(uint8_t *v, unsigned int len, unsigned int address) {
+bool flash_helper_read_nvm(uint8_t *v, unsigned int len, unsigned int address) {
 	if (VESC_IF_NVM_REGION_SIZE - address <= 0) {
 		return false;	// early return for address out of range
 	}
@@ -492,7 +492,7 @@ bool if_read_nvm(uint8_t *v, unsigned int len, unsigned int address) {
   * @param	address: address of the first byte
   * @retval Boolean indicating success or failure
   */
-bool if_write_nvm(uint8_t *v, unsigned int len, unsigned int address) {
+bool flash_helper_write_nvm(uint8_t *v, unsigned int len, unsigned int address) {
 	if (address > VESC_IF_NVM_REGION_SIZE) {
 		return false;	// early return for address out of range
 	}
@@ -506,7 +506,7 @@ bool if_write_nvm(uint8_t *v, unsigned int len, unsigned int address) {
   * @brief  Package function - Erase region of NVM used by packages.
   * @retval Boolean indicating success or failure
   */
-bool if_wipe_nvm(void) {
+bool flash_helper_wipe_nvm(void) {
 	uint16_t res = erase_sector(flash_sector[8]);
 
 	return (res == FLASH_COMPLETE);

--- a/flash_helper.c
+++ b/flash_helper.c
@@ -468,10 +468,11 @@ static void qmlui_check(int ind) {
 
 // reads len bytes from a given address in flash region 8
 bool if_read_nvm(uint8_t *v, unsigned int len, unsigned int address) {
-	if (address > VESC_IF_NVM_REGION_SIZE) {
+	if (VESC_IF_NVM_REGION_SIZE - address <= 0) {
 		return false;	// early return for address out of range
 	}
-	len = len > (VESC_IF_NVM_REGION_SIZE - address) ? VESC_IF_NVM_REGION_SIZE - address : len;
+	unsigned int remaining_space = VESC_IF_NVM_REGION_SIZE - address;
+	len = len > remaining_space ? remaining_space : len;
 	for (unsigned int i = 0; i < len; i++) {
 		v[i] = *(uint8_t*)(ADDR_FLASH_SECTOR_8 + address + i);
 	}

--- a/flash_helper.h
+++ b/flash_helper.h
@@ -42,8 +42,8 @@ uint32_t flash_helper_verify_flash_memory(void);
 uint32_t flash_helper_verify_flash_memory_chunk(void);
 
 // functions used in vesc_c_if.h and therefore accessible to packages
-bool if_read_nvm(uint8_t *v, unsigned int len, unsigned int address);
-bool if_write_nvm(uint8_t *v, unsigned int len, unsigned int address);
-bool if_wipe_nvm(void);
+bool flash_helper_read_nvm(uint8_t *v, unsigned int len, unsigned int address);
+bool flash_helper_write_nvm(uint8_t *v, unsigned int len, unsigned int address);
+bool flash_helper_wipe_nvm(void);
 
 #endif /* FLASH_HELPER_H_ */

--- a/flash_helper.h
+++ b/flash_helper.h
@@ -41,4 +41,9 @@ uint8_t* flash_helper_get_sector_address(uint32_t fsector);
 uint32_t flash_helper_verify_flash_memory(void);
 uint32_t flash_helper_verify_flash_memory_chunk(void);
 
+// functions used in vesc_c_if.h and therefore accessible to packages
+bool if_read_nvm(uint8_t *v, unsigned int len, unsigned int address);
+bool if_write_nvm(uint8_t *v, unsigned int len, unsigned int address);
+bool if_wipe_nvm(void);
+
 #endif /* FLASH_HELPER_H_ */

--- a/lispBM/c_libs/vesc_c_if.h
+++ b/lispBM/c_libs/vesc_c_if.h
@@ -502,7 +502,7 @@ typedef struct {
 	// NVM
 	bool (*read_nvm_byte)(uint8_t *v, int address);
 	bool (*write_nvm_byte)(uint8_t v, int address);
-	bool (*wipe_nvm)();
+	bool (*wipe_nvm)(void);
 
 	// Timeout
 	void (*timeout_reset)(void);

--- a/lispBM/c_libs/vesc_c_if.h
+++ b/lispBM/c_libs/vesc_c_if.h
@@ -573,8 +573,8 @@ typedef struct {
 	bool (*app_is_output_disabled)(void); // True if apps should disable their output.
 
 	// NVM
-	bool (*read_nvm_byte)(uint8_t *v, int address);
-	bool (*write_nvm_byte)(uint8_t v, int address);
+	bool (*read_nvm_byte)(uint8_t *v, unsigned int len, unsigned int address);
+	bool (*write_nvm_byte)(uint8_t *v, unsigned int len, unsigned int address);
 	bool (*wipe_nvm)(void);
 } vesc_c_if;
 

--- a/lispBM/c_libs/vesc_c_if.h
+++ b/lispBM/c_libs/vesc_c_if.h
@@ -573,8 +573,8 @@ typedef struct {
 	bool (*app_is_output_disabled)(void); // True if apps should disable their output.
 
 	// NVM
-	bool (*read_nvm_byte)(uint8_t *v, unsigned int len, unsigned int address);
-	bool (*write_nvm_byte)(uint8_t *v, unsigned int len, unsigned int address);
+	bool (*read_nvm)(uint8_t *v, unsigned int len, unsigned int address);
+	bool (*write_nvm)(uint8_t *v, unsigned int len, unsigned int address);
 	bool (*wipe_nvm)(void);
 } vesc_c_if;
 

--- a/lispBM/c_libs/vesc_c_if.h
+++ b/lispBM/c_libs/vesc_c_if.h
@@ -499,11 +499,6 @@ typedef struct {
 	bool (*read_eeprom_var)(eeprom_var *v, int address);
 	bool (*store_eeprom_var)(eeprom_var *v, int address);
 
-	// NVM
-	bool (*read_nvm_byte)(uint8_t *v, int address);
-	bool (*write_nvm_byte)(uint8_t v, int address);
-	bool (*wipe_nvm)(void);
-
 	// Timeout
 	void (*timeout_reset)(void);
 	bool (*timeout_has_timeout)(void);
@@ -576,6 +571,11 @@ typedef struct {
 	float (*get_ppm)(void); // Get decoded PPM, range -1.0 to 1.0. If the decoder is not running it will be started.
 	float (*get_ppm_age)(void); // Get time since a pulse was decoded in seconds
 	bool (*app_is_output_disabled)(void); // True if apps should disable their output.
+
+	// NVM
+	bool (*read_nvm_byte)(uint8_t *v, int address);
+	bool (*write_nvm_byte)(uint8_t v, int address);
+	bool (*wipe_nvm)(void);
 } vesc_c_if;
 
 typedef struct {

--- a/lispBM/c_libs/vesc_c_if.h
+++ b/lispBM/c_libs/vesc_c_if.h
@@ -499,6 +499,11 @@ typedef struct {
 	bool (*read_eeprom_var)(eeprom_var *v, int address);
 	bool (*store_eeprom_var)(eeprom_var *v, int address);
 
+	// NVM
+	bool (*read_nvm_byte)(uint8_t *v, int address);
+	bool (*write_nvm_byte)(uint8_t v, int address);
+	bool (*wipe_nvm)();
+
 	// Timeout
 	void (*timeout_reset)(void);
 	bool (*timeout_has_timeout)(void);

--- a/lispBM/lispif_c_lib.c
+++ b/lispBM/lispif_c_lib.c
@@ -823,8 +823,8 @@ lbm_value ext_load_native_lib(lbm_value *args, lbm_uint argn) {
 		cif.cif.store_eeprom_var = conf_general_store_eeprom_var_custom;
 
 		// NVM
-		cif.cif.read_nvm_byte = if_read_nvm;
-		cif.cif.write_nvm_byte = if_write_nvm;
+		cif.cif.read_nvm = if_read_nvm;
+		cif.cif.write_nvm = if_write_nvm;
 		cif.cif.wipe_nvm = if_wipe_nvm;
 
 		// Timeout

--- a/lispBM/lispif_c_lib.c
+++ b/lispBM/lispif_c_lib.c
@@ -42,22 +42,6 @@
 #include "servo_dec.h"
 #include "servo_simple.h"
 #include "flash_helper.h"
-//#include "stm32f4xx_conf.h"
-//#include "nrf_driver.h"
-
-// Base address of the Flash sectors
-#define ADDR_FLASH_SECTOR_0    					((uint32_t)0x08000000) // Base @ of Sector 0, 16 Kbytes
-#define ADDR_FLASH_SECTOR_1    					((uint32_t)0x08004000) // Base @ of Sector 1, 16 Kbytes
-#define ADDR_FLASH_SECTOR_2    					((uint32_t)0x08008000) // Base @ of Sector 2, 16 Kbytes
-#define ADDR_FLASH_SECTOR_3						((uint32_t)0x0800C000) // Base @ of Sector 3, 16 Kbytes
-#define ADDR_FLASH_SECTOR_4    					((uint32_t)0x08010000) // Base @ of Sector 4, 64 Kbytes
-#define ADDR_FLASH_SECTOR_5    					((uint32_t)0x08020000) // Base @ of Sector 5, 128 Kbytes
-#define ADDR_FLASH_SECTOR_6     				((uint32_t)0x08040000) // Base @ of Sector 6, 128 Kbytes
-#define ADDR_FLASH_SECTOR_7     				((uint32_t)0x08060000) // Base @ of Sector 7, 128 Kbytes
-#define ADDR_FLASH_SECTOR_8     				((uint32_t)0x08080000) // Base @ of Sector 8, 128 Kbytes
-#define ADDR_FLASH_SECTOR_9 				    ((uint32_t)0x080A0000) // Base @ of Sector 9, 128 Kbytes
-#define ADDR_FLASH_SECTOR_10				    ((uint32_t)0x080C0000) // Base @ of Sector 10, 128 Kbytes
-#define ADDR_FLASH_SECTOR_11				    ((uint32_t)0x080E0000) // Base @ of Sector 11, 128 Kbytes
 
 // Function prototypes otherwise missing
 void packet_init(void (*s_func)(unsigned char *data, unsigned int len),

--- a/lispBM/lispif_c_lib.c
+++ b/lispBM/lispif_c_lib.c
@@ -807,9 +807,9 @@ lbm_value ext_load_native_lib(lbm_value *args, lbm_uint argn) {
 		cif.cif.store_eeprom_var = conf_general_store_eeprom_var_custom;
 
 		// NVM
-		cif.cif.read_nvm = if_read_nvm;
-		cif.cif.write_nvm = if_write_nvm;
-		cif.cif.wipe_nvm = if_wipe_nvm;
+		cif.cif.read_nvm = 	flash_helper_read_nvm;
+		cif.cif.write_nvm = 	flash_helper_write_nvm;
+		cif.cif.wipe_nvm = 	flash_helper_wipe_nvm;
 
 		// Timeout
 		cif.cif.timeout_reset = timeout_reset;

--- a/lispBM/lispif_c_lib.c
+++ b/lispBM/lispif_c_lib.c
@@ -299,7 +299,7 @@ static bool if_write_nvm_byte(uint8_t v, int address) {
 }
 
 // wipes flash region 8
-static bool if_wipe_nvm() {
+static bool if_wipe_nvm(void) {
 	FLASH_Unlock();
 	FLASH_ClearFlag(FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR |
 			FLASH_FLAG_PGPERR | FLASH_FLAG_PGSERR);


### PR DESCRIPTION
Adds a way for packages to edit sector 8 of flash memory.
The reasoning for choosing sector 8 is that this sector seems to only be used when downloading a new app, in which case it is probably fine to wipe a package's memory.

TODO:

- [x] test operations with a specific package
- [x] ensure code style compliance
- [x] make assorted PR for vesc_pkg (https://github.com/vedderb/vesc_pkg/pull/11)