### PR TITLE
typo fix for custom encoder read callback

### DIFF
--- a/encoder/encoder.c
+++ b/encoder/encoder.c
@@ -370,7 +370,7 @@ float encoder_read_deg(void) {
 		return AS5x47U_LAST_ANGLE(&encoder_cfg_as5x47u);
 	} else if (m_encoder_type_now == ENCODER_TYPE_BISSC) {
 		return BISSC_LAST_ANGLE(&encoder_cfg_bissc);
-	} else if (m_encoder_type_now == ENCODER_TYPE_BISSC) {
+	} else if (m_encoder_type_now == ENCODER_TYPE_CUSTOM) {
 		if (m_enc_custom_read_deg) {
 			return m_enc_custom_read_deg();
 		} else {


### PR DESCRIPTION
I believe there is a typo in encoder.c for the encoder read callback. The type needs to change to allow custom implementation