### PR TITLE
Support for IMU_FILTER_MEDIUM/HIGH in LSM6DS3TR-C IMUs

### DIFF
--- a/imu/lsm6ds3.h
+++ b/imu/lsm6ds3.h
@@ -800,7 +800,7 @@ typedef enum {
 } LSM6DS3_ACC_GYRO_BOOT_t;
 
 /*******************************************************************************
-* Register      : CTRL4_C
+* Register      : CTRL4_C (Non TR-C Variant!)
 * Address       : 0X13
 * Bit Group Name: STOP_ON_FTH
 * Permission    : RW
@@ -811,7 +811,7 @@ typedef enum {
 } LSM6DS3_ACC_GYRO_STOP_ON_FTH_t;
 
 /*******************************************************************************
-* Register      : CTRL4_C
+* Register      : CTRL4_C (Non TR-C Variant!)
 * Address       : 0X13
 * Bit Group Name: MODE3_EN
 * Permission    : RW
@@ -820,6 +820,17 @@ typedef enum {
 	LSM6DS3_ACC_GYRO_MODE3_EN_DISABLED 		 = 0x00,
 	LSM6DS3_ACC_GYRO_MODE3_EN_ENABLED 		 = 0x02,
 } LSM6DS3_ACC_GYRO_MODE3_EN_t;
+
+/*******************************************************************************
+* Register      : CTRL4_C TR-C Variant ONLY!
+* Address       : 0X13
+* Bit Group Name: LPF1_SEL_G (Enable gyroscope digital lowpass filter LPF1)
+* Permission    : RW
+*******************************************************************************/
+typedef enum {
+	LSM6DS3_ACC_GYRO_LPF1_SEL_G_DISABLED		 = 0x00,
+	LSM6DS3_ACC_GYRO_LPF1_SEL_G_ENABLED 		 = 0x02,
+} LSM6DS3_ACC_GYRO_LPF1_SEL_G_t;
 
 /*******************************************************************************
 * Register      : CTRL4_C
@@ -844,7 +855,7 @@ typedef enum {
 } LSM6DS3_ACC_GYRO_DRDY_MSK_t;
 
 /*******************************************************************************
-* Register      : CTRL4_C
+* Register      : CTRL4_C (Non TR-C Variant!)
 * Address       : 0X13
 * Bit Group Name: FIFO_TEMP_EN
 * Permission    : RW
@@ -877,7 +888,7 @@ typedef enum {
 } LSM6DS3_ACC_GYRO_SLEEP_G_t;
 
 /*******************************************************************************
-* Register      : CTRL4_C
+* Register      : CTRL4_C (Non TR-C Variant!)
 * Address       : 0X13
 * Bit Group Name: BW_SCAL_ODR
 * Permission    : RW


### PR DESCRIPTION
Hardware filtering functionality imported from tested 5.3v6 release. TR-C variant has highly configurable filtering, this patch implements a basic ODR/4 or ODR/9 filtering for the common IMU sampling rates (400Hz..1600Hz)

IMU_FILTER_LOW: ODR/2 (same as standard fw6.0 behavior)
IMU_FILTER_MEDIUM: ODR/4 lowpass filtering
IMu_FILTER_HIGH: ODR/9 filtering (default in fw5.3v6 release)