### PR TITLE
Add dedicated adc app hwconf pin defines for reverse and cruise switches

### DIFF
--- a/hwconf/trampa/75_300/hw_75_300_core.h
+++ b/hwconf/trampa/75_300/hw_75_300_core.h
@@ -182,6 +182,13 @@
 #define HW_ADC_EXT2_GPIO		GPIOA
 #define HW_ADC_EXT2_PIN			6
 
+// Hardcoded adc app pins that won't override uart port or ppm inputs. On swd pins for example
+// #define HW_HARDWARE_ADC_APP_PINS
+// #define HW_CRUISE_SWITCH_PORT 			GPIOA
+// #define HW_CRUISE_SWITCH_PIN 			  14
+// #define HW_REVERSE_SWITCH_PORT	 		GPIOA
+// #define HW_REVERSE_SWITCH_PIN 			13
+
 // UART Peripheral
 #define HW_UART_DEV				SD3
 #define HW_UART_GPIO_AF			GPIO_AF_USART3

--- a/hwconf/trampa/75_300/hw_75_300_core.h
+++ b/hwconf/trampa/75_300/hw_75_300_core.h
@@ -184,10 +184,10 @@
 
 // Hardcoded adc app pins that won't override uart port or ppm inputs. On swd pins for example
 // #define HW_HARDWARE_ADC_APP_PINS
-// #define HW_CRUISE_SWITCH_PORT 			GPIOA
-// #define HW_CRUISE_SWITCH_PIN 			  14
 // #define HW_REVERSE_SWITCH_PORT	 		GPIOA
 // #define HW_REVERSE_SWITCH_PIN 			13
+// #define HW_CRUISE_SWITCH_PORT 			GPIOA
+// #define HW_CRUISE_SWITCH_PIN 			  14
 
 // UART Peripheral
 #define HW_UART_DEV				SD3


### PR DESCRIPTION
Adds defines for hwconf specified adc app reverse and cruise pins that don't clobber uart or ppm inputs. 

For hardware that implements these dedicated inputs.

Without a hardware config ready to commit that actually uses these. I added the commented out config as an example to the trampa75/300 hwconf using the swd pins. 