### PR TITLE
Add regen cutoff to prevent overcharging the battery during braking

### DIFF
--- a/confgenerator.c
+++ b/confgenerator.c
@@ -28,6 +28,8 @@ int32_t confgenerator_serialize_mcconf(uint8_t *buffer, const mc_configuration *
 	buffer_append_float32_auto(buffer, conf->l_max_vin, &ind);
 	buffer_append_float32_auto(buffer, conf->l_battery_cut_start, &ind);
 	buffer_append_float32_auto(buffer, conf->l_battery_cut_end, &ind);
+	buffer_append_float32_auto(buffer, conf->l_battery_regen_cut_start, &ind);
+	buffer_append_float32_auto(buffer, conf->l_battery_regen_cut_end, &ind);
 	buffer[ind++] = conf->l_slow_abs_current;
 	buffer_append_float16(buffer, conf->l_temp_fet_start, 10, &ind);
 	buffer_append_float16(buffer, conf->l_temp_fet_end, 10, &ind);
@@ -426,6 +428,8 @@ bool confgenerator_deserialize_mcconf(const uint8_t *buffer, mc_configuration *c
 	conf->l_max_vin = buffer_get_float32_auto(buffer, &ind);
 	conf->l_battery_cut_start = buffer_get_float32_auto(buffer, &ind);
 	conf->l_battery_cut_end = buffer_get_float32_auto(buffer, &ind);
+	conf->l_battery_regen_cut_start = buffer_get_float32_auto(buffer, &ind);
+	conf->l_battery_regen_cut_end = buffer_get_float32_auto(buffer, &ind);
 	conf->l_slow_abs_current = buffer[ind++];
 	conf->l_temp_fet_start = buffer_get_float16(buffer, 10, &ind);
 	conf->l_temp_fet_end = buffer_get_float16(buffer, 10, &ind);
@@ -820,6 +824,8 @@ void confgenerator_set_defaults_mcconf(mc_configuration *conf) {
 	conf->l_max_vin = MCCONF_L_MAX_VOLTAGE;
 	conf->l_battery_cut_start = MCCONF_L_BATTERY_CUT_START;
 	conf->l_battery_cut_end = MCCONF_L_BATTERY_CUT_END;
+	conf->l_battery_regen_cut_start = MCCONF_L_BATTERY_REGEN_CUT_START;
+	conf->l_battery_regen_cut_end = MCCONF_L_BATTERY_REGEN_CUT_END;
 	conf->l_slow_abs_current = MCCONF_L_SLOW_ABS_OVERCURRENT;
 	conf->l_temp_fet_start = MCCONF_L_LIM_TEMP_FET_START;
 	conf->l_temp_fet_end = MCCONF_L_LIM_TEMP_FET_END;

--- a/confgenerator.h
+++ b/confgenerator.h
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 
 // Constants
-#define MCCONF_SIGNATURE		1102884264
+#define MCCONF_SIGNATURE		1802104632
 #define APPCONF_SIGNATURE		486554156
 
 // Functions

--- a/datatypes.h
+++ b/datatypes.h
@@ -358,6 +358,8 @@ typedef struct {
 	float l_max_vin;
 	float l_battery_cut_start;
 	float l_battery_cut_end;
+	float l_battery_regen_cut_start;
+	float l_battery_regen_cut_end;
 	bool l_slow_abs_current;
 	float l_temp_fet_start;
 	float l_temp_fet_end;

--- a/motor/mc_interface.c
+++ b/motor/mc_interface.c
@@ -2425,12 +2425,23 @@ static void update_override_limits(volatile motor_if_state_t *motor, volatile mc
 				conf->l_battery_cut_end, conf->l_in_current_max, 0.0);
 	}
 
+	// Regen overvoltage cutoff
+	float lo_in_min_batt = 0.0;
+	if (v_in < (conf->l_battery_regen_cut_start + 0.1)) {
+		lo_in_min_batt = conf->l_in_current_min;
+	} else if (v_in > (conf->l_battery_regen_cut_end - 0.1)) {
+		lo_in_min_batt = 0.0;
+	} else {
+		lo_in_min_batt = utils_map(v_in, conf->l_battery_regen_cut_start,
+				conf->l_battery_regen_cut_end, conf->l_in_current_min, 0.0);
+	}
+
 	// Wattage limits
 	const float lo_in_max_watt = conf->l_watt_max / v_in;
 	const float lo_in_min_watt = conf->l_watt_min / v_in;
 
 	float lo_in_max = utils_min_abs(lo_in_max_watt, lo_in_max_batt);
-	float lo_in_min = lo_in_min_watt;
+	float lo_in_min = utils_min_abs(lo_in_min_watt, lo_in_min_batt);
 
 	// BMS limits
 	bms_update_limits(&lo_in_min,  &lo_in_max, conf->l_in_current_min, conf->l_in_current_max);

--- a/motor/mcconf_default.h
+++ b/motor/mcconf_default.h
@@ -62,6 +62,12 @@
 #ifndef MCCONF_L_BATTERY_CUT_END
 #define MCCONF_L_BATTERY_CUT_END		8.0		// Limit the positive current completely at this voltage
 #endif
+#ifndef MCCONF_L_BATTERY_REGEN_CUT_START
+#define MCCONF_L_BATTERY_REGEN_CUT_START    55.0	// Start limiting the regen current at this voltage
+#endif
+#ifndef MCCONF_L_BATTERY_REGEN_CUT_END
+#define MCCONF_L_BATTERY_REGEN_CUT_END  57.0		// Limit the regen current completely at this voltage
+#endif
 #ifndef MCCONF_L_RPM_MAX
 #define MCCONF_L_RPM_MAX				100000.0	// The motor speed limit (Upper)
 #endif

--- a/motor/mcconf_default.h
+++ b/motor/mcconf_default.h
@@ -63,10 +63,10 @@
 #define MCCONF_L_BATTERY_CUT_END		8.0		// Limit the positive current completely at this voltage
 #endif
 #ifndef MCCONF_L_BATTERY_REGEN_CUT_START
-#define MCCONF_L_BATTERY_REGEN_CUT_START    55.0	// Start limiting the regen current at this voltage
+#define MCCONF_L_BATTERY_REGEN_CUT_START    1000.0	// Start limiting the regen current at this voltage
 #endif
 #ifndef MCCONF_L_BATTERY_REGEN_CUT_END
-#define MCCONF_L_BATTERY_REGEN_CUT_END  57.0		// Limit the regen current completely at this voltage
+#define MCCONF_L_BATTERY_REGEN_CUT_END  1100.0		// Limit the regen current completely at this voltage
 #endif
 #ifndef MCCONF_L_RPM_MAX
 #define MCCONF_L_RPM_MAX				100000.0	// The motor speed limit (Upper)


### PR DESCRIPTION
This change helps ensure that the battery remains in good condition, prolongs its overall lifespan and avoids hazardous scenarios of overcharge.

A soft cutoff for the regenerative braking is implemented, in which start and end thresholds should be set in VESC Tool. The end threshold should be set such that the cells don't exceed 4.2v in a typical Li-Ion battery.

The default values follow the default max voltage that was being used. This means that in setups with operating voltages above ~60V, these new fields with the default values will completely disable regenerative braking until the motor config is updated accordingly for the correct battery voltage.

The code is easy to test with power supplies, as it can now brake the motor without tripping an overvoltage. It was also tested with a 60v battery.

This commit needs its companion commit on vesc tool code, I'll make that PR now