### PR TITLE
Add 5 milliohm shunt version for Flipsky 75100v2 Hardware

### DIFF
--- a/hwconf/flipsky/hw_75_100_V2_005ohm.h
+++ b/hwconf/flipsky/hw_75_100_V2_005ohm.h
@@ -1,0 +1,26 @@
+/*
+	Copyright 2015 Benjamin Vedder	benjamin@vedder.se
+
+	This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    */
+
+#ifndef HW_75_100_V2_005OHM_H_
+#define HW_75_100_V2_005OHM_H_
+
+#define HW_SOURCE_ALT 		"flipsky/hw_75_100_V2.c"
+#define CURRENT_SHUNT_RES	0.005
+
+#include "hw_75_100_V2.h"
+
+#endif /* HW_75_100_V2_005OHM_H_ */


### PR DESCRIPTION
For users of 5 milliohm shunts. Useful for large servo motors with lower currents.
A few people are using this for simracing wheels.