### PR TITLE
Pin lock - RFQ

### DIFF
--- a/comm/comm_usb.c
+++ b/comm/comm_usb.c
@@ -90,7 +90,10 @@ static THD_FUNCTION(serial_process_thread, arg) {
 }
 
 static void process_packet(unsigned char *data, unsigned int len) {
+	commands_lock_writes(false);
+	// USB commands are not subject to PIN based write lock
 	commands_process_packet(data, len, comm_usb_send_packet);
+	commands_lock_writes(true);
 }
 
 static void send_packet_raw(unsigned char *buffer, unsigned int len) {

--- a/comm/commands.c
+++ b/comm/commands.c
@@ -240,12 +240,24 @@ void commands_process_packet(unsigned char *data, unsigned int len,
 			(packet_id != COMM_GET_DECODED_BALANCE) &&
 			(packet_id != COMM_GET_STATS) &&
 			(packet_id != COMM_RESET_STATS) &&
+			(packet_id != COMM_SET_ODOMETER) &&
 			(packet_id != COMM_GET_CUSTOM_CONFIG) &&
 			(packet_id != COMM_CUSTOM_APP_DATA) &&
 			(packet_id != COMM_LOCK_STATUS) &&
 			(packet_id != COMM_WRITE_LOCK)) {
 			//commands_printf("Blocked command: ID %d\n", packet_id);
 			return;
+		}
+		if (writelock && (packet_id == COMM_SET_ODOMETER)) {
+		  // Temporary back door, to allow unlocking from older VESC Tools...
+		  int32_t ind = 0;
+		  uint32_t odo_new = buffer_get_uint32(data, &ind);
+		  uint32_t odo_now = mc_interface_get_odometer();
+		  // Writing the current odometer value removes the writelock
+		  if (odo_now == odo_new) {
+		    writelock = false;
+		  }
+		  return;
 		}
 		if ((packet_id == COMM_CUSTOM_APP_DATA) && (len > 2)) {
 			unsigned char magicnr = data[0];

--- a/comm/commands.h
+++ b/comm/commands.h
@@ -53,5 +53,7 @@ void commands_plot_add_graph(char *name);
 void commands_plot_set_graph(int graph);
 void commands_send_plot_points(float x, float y);
 int commands_get_fw_version_sent_cnt(void);
+void commands_lock_writes(bool lock);
+bool commands_check_writelock(void);
 
 #endif /* COMMANDS_H_ */

--- a/conf_general.h
+++ b/conf_general.h
@@ -192,6 +192,8 @@ int conf_general_detect_apply_all_foc_can(bool detect_can, float max_power_loss,
 										  float min_current_in, float max_current_in,
 										  float openloop_rpm, float sl_erpm,
 										  void(*reply_func)(unsigned char* data, unsigned int len));
-
+uint16_t conf_general_get_writelock_pin(void);
+bool conf_general_is_locked_on_boot(void);
+void conf_general_set_writelock_pin(uint16_t pin, bool lock_on_boot);
 
 #endif /* CONF_GENERAL_H_ */

--- a/datatypes.h
+++ b/datatypes.h
@@ -1152,6 +1152,11 @@ typedef enum {
 	COMM_GET_GNSS,
 
 	COMM_LOG_DATA_F64,
+
+	// PIN Lock to write-protect firmware
+	COMM_LOCK_SETPIN,
+	COMM_WRITE_LOCK,
+	COMM_LOCK_STATUS,
 } COMM_PACKET_ID;
 
 // CAN commands
@@ -1459,6 +1464,9 @@ typedef struct __attribute__((packed)) {
 	// HW-specific data
 	uint32_t hw_config_init_flag;
 	uint8_t hw_config[128];
+
+	uint32_t writelock_pin_init_flag;
+	uint32_t writelock_pin_code;
 } backup_data;
 
 #endif /* DATATYPES_H_ */


### PR DESCRIPTION
This isn't meant to be merged yet, mainly posted it for people to comment on or test independently.

Basic idea is to introduce a simple method to prevent accidental writes to the wrong VESC by using a 4-digit PIN to write-lock your firmware. Unlike pairing it is actually enforced by the firmware, so rogue 3rd party apps cannot circumvent it. Also, a 4-digit PIN is easy to remember.

PIN is stored in EEPROM just like the Odometer, however this implementation does clear the PIN during firmware writes.

Functionality is fully described here:
https://pev.dev/t/new-feature-spec-pin-locking/815/4