### PR TITLE
Duplicated include; improved shutdown.c; store data even without switch

### DIFF
--- a/comm/commands.c
+++ b/comm/commands.c
@@ -28,7 +28,6 @@
 #include "hw.h"
 #include "mcpwm.h"
 #include "mcpwm_foc.h"
-#include "mc_interface.h"
 #include "app.h"
 #include "timeout.h"
 #include "servo_dec.h"

--- a/hwconf/shutdown.c
+++ b/hwconf/shutdown.c
@@ -20,6 +20,7 @@
 #include "shutdown.h"
 #include "app.h"
 #include "conf_general.h"
+#include "mc_interface.h"
 
 #ifdef USE_LISPBM
 #include "lispif.h"
@@ -67,7 +68,11 @@ void shutdown_set_sampling_disabled(bool disabled) {
 }
 
 static bool do_shutdown(void) {
-	conf_general_store_backup_data();
+	// Store data if 1000m or more have been done to possibly reduce flash
+	// wear. Values could be lower than 1km, say 100m but suggested >500m.
+	if(mc_interface_get_distance_abs() >= 1000) {
+		conf_general_store_backup_data();
+	}
 #ifdef USE_LISPBM
 	lispif_process_shutdown();
 #endif
@@ -85,6 +90,7 @@ static THD_FUNCTION(shutdown_thread, arg) {
 	bool gates_disabled_here = false;
 	float gate_disable_time = 0.0;
 	systime_t last_iteration_time = chVTGetSystemTimeX();
+	uint64_t odometer_old = mc_interface_get_odometer();
 
 	for(;;) {
 		float dt = (float)chVTTimeElapsedSinceX(last_iteration_time) / (float)CH_CFG_ST_FREQUENCY;
@@ -117,7 +123,19 @@ static THD_FUNCTION(shutdown_thread, arg) {
 			break;
 
 		case SHUTDOWN_MODE_ALWAYS_ON:
+			m_inactivity_time += dt;
 			HW_SHUTDOWN_HOLD_ON();
+			// Without a shutdown switch use inactivity timer to estimate
+			// when device is stopped. Check also distance between store
+			// to prevent excessive flash write cycles.
+			if (m_inactivity_time >= SHUTDOWN_SAVE_BACKUPDATA_TIMEOUT) {
+				shutdown_reset_timer();
+				// If at least 1km was done then we can store data 
+				if((mc_interface_get_odometer()-odometer_old) >= 1000) {
+					conf_general_store_backup_data();
+					odometer_old = mc_interface_get_odometer();
+				}
+			}
 			break;
 
 		default:
@@ -157,12 +175,66 @@ static THD_FUNCTION(shutdown_thread, arg) {
 			if (m_inactivity_time >= shutdown_timeout && m_button_pressed) {
 				gates_disabled_here = do_shutdown();
 			}
-		} else {
-			m_inactivity_time = 0.0;
 		}
 
 		chThdSleepMilliseconds(10);
 	}
 }
 
+#else // HARDWARE WITHOUT POWER SWITCH 
+// just saving backup data, no actual shutdown
+
+// Private variables
+static volatile float m_inactivity_time = 0.0;
+static THD_WORKING_AREA(shutdown_thread_wa, 128);
+
+// Private functions
+static THD_FUNCTION(shutdown_thread, arg);
+
+void shutdown_init(void) {
+	chThdCreateStatic(shutdown_thread_wa, sizeof(shutdown_thread_wa), LOWPRIO, shutdown_thread, NULL);
+}
+
+void shutdown_reset_timer(void) {
+	m_inactivity_time = 0.0;
+}
+
+float shutdown_get_inactivity_time(void) {
+	return m_inactivity_time;
+}
+
+static THD_FUNCTION(shutdown_thread, arg) {
+	(void)arg;
+
+	chRegSetThreadName("Shutdown");
+
+	systime_t last_iteration_time = chVTGetSystemTimeX();
+	uint64_t odometer_old = mc_interface_get_odometer();
+
+	for(;;) {
+		float dt = (float)chVTTimeElapsedSinceX(last_iteration_time) / (float)CH_CFG_ST_FREQUENCY;
+		last_iteration_time = chVTGetSystemTimeX();
+
+		const app_configuration *conf = app_get_configuration();
+
+		//if set to always off don't store backup
+		if(conf->shutdown_mode != SHUTDOWN_MODE_ALWAYS_OFF) {
+			m_inactivity_time += dt;
+			if (m_inactivity_time >= SHUTDOWN_SAVE_BACKUPDATA_TIMEOUT) {
+				shutdown_reset_timer();
+				// Without a shutdown switch use inactivity time to measure
+				// when stopped. If timeout is passed and trip distance is
+				// greater than 1km store it to prevent excessive flash write.
+				// Example, i stop for 4 miutes after 3,4km and the firmware
+				// stores parameters, if i stop for 20s or after 600m no.
+				if((mc_interface_get_odometer()-odometer_old) >= 1000) {
+					conf_general_store_backup_data();
+					odometer_old = mc_interface_get_odometer();
+				}
+			}
+		}
+
+		chThdSleepMilliseconds(1000);
+	}
+}
 #endif

--- a/hwconf/shutdown.h
+++ b/hwconf/shutdown.h
@@ -24,15 +24,21 @@
 #include "hal.h"
 #include "conf_general.h"
 
-#ifdef HW_SHUTDOWN_HOLD_ON
 #define SHUTDOWN_RESET()					shutdown_reset_timer()
+
+#ifdef HW_SHUTDOWN_HOLD_ON
 #define SHUTDOWN_BUTTON_PRESSED				shutdown_button_pressed()
 #define SHUTDOWN_SET_SAMPLING_DISABLED(d)	shutdown_set_sampling_disabled(d)
 #else
-#define SHUTDOWN_RESET()
 #define SHUTDOWN_BUTTON_PRESSED				false
 #define SHUTDOWN_SET_SAMPLING_DISABLED(d)
 #endif
+
+#define SHUTDOWN_SAVE_BACKUPDATA_TIMEOUT 60*3 
+// time of inactivity after wich backup data (odometer, running time, ...) is
+// stored to emulated eeprom when not using power switch. Must be greater than
+// average stopping time, usually semaphores require 120s max, so 60*3s or 
+// more should be pretty safe 
 
 // Fucntions
 void shutdown_init(void);

--- a/main.c
+++ b/main.c
@@ -299,9 +299,7 @@ int main(void) {
 	bm_init();
 #endif
 
-#ifdef HW_SHUTDOWN_HOLD_ON
 	shutdown_init();
-#endif
 
 	imu_reset_orientation();
 


### PR DESCRIPTION
commands.c: 
- Delete duplicated include "mc_interface.h" 

shutdown.c / shutdown.h / main.c:
- Reducing possibility to write backup data frequently, now requires  minimum distance to be traveled before it enables storing, common condition if push to start is enabled with a low shutdown time, say 10s, or in any other condition where user turn on/off ESC a lot of times. Saves chip life at the cost of not having updated data during very short trips.
- Data is stored even when using "always on", basing storage condition on the inactivity time, this allower user that shutdown esc from the power source to keep data anyway or in case of a power loss.
- Introducing possibility to store data without a power-switch by using a combination of trip distance and inactivity timer, it estimates when the scooter it's stopped for a long period after a trip, now user to save trip data just need to leave the scooter still an X amount of time to make sure all data is stored. It can be **deactivated** by using "_always off_" in app setting  Shutdown Mode.

Compiled almost all version without issues, tested on my custom esc with different combinations (with power switch, without power switch) and it seems to work well.