### PR TITLE
Avoid comm_can dividing by 0 from unset appconf

### DIFF
--- a/main.c
+++ b/main.c
@@ -259,16 +259,17 @@ int main(void) {
 	comm_usb_init();
 #endif
 
-#if CAN_ENABLE
-	comm_can_init();
-#endif
-
 	app_uartcomm_initialize();
 	app_configuration *appconf = mempools_alloc_appconf();
 	conf_general_read_app_configuration(appconf);
 	app_set_configuration(appconf);
 	app_uartcomm_start(UART_PORT_BUILTIN);
 	app_uartcomm_start(UART_PORT_EXTRA_HEADER);
+
+	// This reads the appconf, that must be initialized first.
+#if CAN_ENABLE
+	comm_can_init();
+#endif
 
 #ifdef HW_HAS_PERMANENT_NRF
 	conf_general_permanent_nrf_found = nrf_driver_init();


### PR DESCRIPTION
cancom_status_thread divides by conf->send_can_status_rate_hz. If that's 0, this is undefined behavior. It will be 0 until app_set_configuration is called by main.

I have some custom hardware which ties CAN_RX high and reliably triggers this bug every time I start up. The same firmware binary usually starts up on a 75_300_R2, although occasionally it has the same symptom of resetting so I wonder if it happens sometimes with a real CAN transceiver too, depending on the exact timing of startup.