### PR TITLE
Perform FOC offsets calibration when running FOC detection

### DIFF
--- a/conf_general.c
+++ b/conf_general.c
@@ -1652,7 +1652,7 @@ int conf_general_detect_apply_all_foc(float max_power_loss,
 	int faultM1 = FAULT_CODE_NONE;
 	int faultM2 = FAULT_CODE_NONE;
 
-	// Measure DC offsets including undriven (ignore returned status)
+	// Measure DC offsets including undriven
 	// Needs to be done before getting the motor configuration
 	if(mcpwm_foc_dc_cal(true) == -1) {
 		return mc_interface_get_fault() - 100; // Offset fault by -100

--- a/conf_general.c
+++ b/conf_general.c
@@ -1652,6 +1652,12 @@ int conf_general_detect_apply_all_foc(float max_power_loss,
 	int faultM1 = FAULT_CODE_NONE;
 	int faultM2 = FAULT_CODE_NONE;
 
+	// Measure DC offsets including undriven (ignore returned status)
+	// Needs to be done before getting the motor configuration
+	if(mcpwm_foc_dc_cal(true) == -1) {
+		return mc_interface_get_fault() - 100; // Offset fault by -100
+	}
+
 	int motor_last = mc_interface_get_motor_thread();
 	mc_interface_select_motor_thread(1);
 

--- a/conf_general.c
+++ b/conf_general.c
@@ -1652,9 +1652,9 @@ int conf_general_detect_apply_all_foc(float max_power_loss,
 	int faultM1 = FAULT_CODE_NONE;
 	int faultM2 = FAULT_CODE_NONE;
 
-	// Measure DC offsets including undriven
+	// Measure DC offsets
 	// Needs to be done before getting the motor configuration
-	if(mcpwm_foc_dc_cal(true) == -1) {
+	if(mcpwm_foc_dc_cal(false) == -1) {
 		return mc_interface_get_fault() - 100; // Offset fault by -100
 	}
 


### PR DESCRIPTION
Undriven offsets are not measured on startup as the motor might be spinning (reboot from crash, etc) So the only time undriven was measured was manually in VESC Tool.
This runs the full offset calibration before detecting the motor to improve detection and make sure the undriven offsets are measured.