### PR TITLE
Fix SPI pins for encoder AD2S1205, update Axiom, add encoder errors info

### DIFF
--- a/encoder/enc_ad2s1205.h
+++ b/encoder/enc_ad2s1205.h
@@ -29,6 +29,7 @@
 bool enc_ad2s1205_init(AD2S1205_config_t *AD2S1205_config);
 void enc_ad2s1205_deinit(AD2S1205_config_t *cfg);
 void enc_ad2s1205_routine(AD2S1205_config_t *cfg);
+void enc_ad2s1205_reset_errors(AD2S1205_config_t *cfg);
 
 // Macros
 #define AD2S1205_LAST_ANGLE(cfg)		((cfg)->state.last_enc_angle)

--- a/encoder/encoder.c
+++ b/encoder/encoder.c
@@ -672,8 +672,8 @@ static void terminal_encoder(int argc, const char **argv) {
 
 	case SENSOR_PORT_MODE_AD2S1205:
 		commands_printf("Resolver Loss Of Tracking (>5%c error): errors: %d, error rate: %.3f %%", 0xB0,
-				encoder_cfg_ad2s1205.state.resolver_loss_of_signal_error_cnt,
-				(double)(encoder_cfg_ad2s1205.state.resolver_loss_of_signal_error_rate * 100.0));
+				encoder_cfg_ad2s1205.state.resolver_loss_of_tracking_error_cnt,
+				(double)(encoder_cfg_ad2s1205.state.resolver_loss_of_tracking_error_rate * 100.0));
 		commands_printf("Resolver Degradation Of Signal (>33%c error): errors: %d, error rate: %.3f %%", 0xB0,
 				encoder_cfg_ad2s1205.state.resolver_degradation_of_signal_error_cnt,
 				(double)(encoder_cfg_ad2s1205.state.resolver_degradation_of_signal_error_rate * 100.0));

--- a/encoder/encoder.c
+++ b/encoder/encoder.c
@@ -271,7 +271,7 @@ bool encoder_init(volatile mc_configuration *conf) {
 
 	terminal_register_command_callback(
 			"encoder_clear_errors",
-			"Clear error of the TS5700N8501 encoder.",
+			"Clear error of the TS5700N8501 encoder, AD2S1205 resolver.",
 			0,
 			terminal_encoder_clear_errors);
 
@@ -434,6 +434,9 @@ void encoder_reset_errors(void) {
 	if (m_encoder_type_now == ENCODER_TYPE_TS5700N8501) {
 		enc_ts5700n8501_reset_errors(&encoder_cfg_TS5700N8501);
 	}
+	if (m_encoder_type_now == ENCODER_TYPE_AD2S1205_SPI) {
+		enc_ad2s1205_reset_errors(&encoder_cfg_ad2s1205);
+	}
 }
 
 float encoder_get_error_rate(void) {
@@ -545,6 +548,15 @@ void encoder_check_faults(volatile mc_configuration *m_conf, bool is_second_moto
 			}
 			if (encoder_cfg_ad2s1205.state.resolver_loss_of_signal_error_rate > 0.04) {
 				mc_interface_fault_stop(FAULT_CODE_RESOLVER_LOS, is_second_motor, false);
+			}
+			if (encoder_cfg_ad2s1205.state.resolver_void_packet_error_rate > 0.05){
+				mc_interface_fault_stop(FAULT_CODE_ENCODER_SPI, is_second_motor, false);
+			}
+			if (encoder_cfg_ad2s1205.state.resolver_vel_packet_error_rate  > 0.05){
+				mc_interface_fault_stop( FAULT_CODE_ENCODER_SPI, is_second_motor, false);
+			}
+			if (encoder_cfg_ad2s1205.state.spi_error_rate > 0.05){
+				mc_interface_fault_stop( FAULT_CODE_ENCODER_SPI, is_second_motor, false);
 			}
 			break;
 
@@ -671,15 +683,39 @@ static void terminal_encoder(int argc, const char **argv) {
 		break;
 
 	case SENSOR_PORT_MODE_AD2S1205:
+		commands_printf("SPI encoder value: %d, errors: %d, error rate: %.3f %%",
+				encoder_cfg_ad2s1205.state.spi_val,
+				encoder_cfg_ad2s1205.state.spi_error_cnt,
+				(double)(encoder_cfg_ad2s1205.state.spi_error_rate * 100.0));
+		commands_printf("SPI encoder peak error rate: %.3f %%",
+					(double)encoder_cfg_ad2s1205.state.resolver_SPI_peak_error_rate * (double)100.0);
 		commands_printf("Resolver Loss Of Tracking (>5%c error): errors: %d, error rate: %.3f %%", 0xB0,
 				encoder_cfg_ad2s1205.state.resolver_loss_of_tracking_error_cnt,
 				(double)(encoder_cfg_ad2s1205.state.resolver_loss_of_tracking_error_rate * 100.0));
+		commands_printf("Resolver Loss Of Tracking peak error rate: %.3f %%",
+				(double)encoder_cfg_ad2s1205.state.resolver_LOT_peak_error_rate * (double)100.0);
 		commands_printf("Resolver Degradation Of Signal (>33%c error): errors: %d, error rate: %.3f %%", 0xB0,
 				encoder_cfg_ad2s1205.state.resolver_degradation_of_signal_error_cnt,
 				(double)(encoder_cfg_ad2s1205.state.resolver_degradation_of_signal_error_rate * 100.0));
+		commands_printf("Resolver Degradation Of Signal peak error rate: %.3f %%",
+				(double)encoder_cfg_ad2s1205.state.resolver_DOS_peak_error_rate * (double)100.0);
 		commands_printf("Resolver Loss Of Signal (>57%c error): errors: %d, error rate: %.3f %%", 0xB0,
 				encoder_cfg_ad2s1205.state.resolver_loss_of_signal_error_cnt,
 				(double)(encoder_cfg_ad2s1205.state.resolver_loss_of_signal_error_rate * 100.0));
+		commands_printf("Resolver Loss Of Signal peak error rate: %.3f %%",
+				(double)encoder_cfg_ad2s1205.state.resolver_LOS_peak_error_rate * (double)100.0);
+		commands_printf("Resolver SPI empty packet: errors: %d, error rate: %.3f %%",
+				encoder_cfg_ad2s1205.state.resolver_void_packet_cnt,
+				(double)encoder_cfg_ad2s1205.state.resolver_void_packet_error_rate * (double)100.0);
+		commands_printf("Resolver SPI empty packet peak error rate: %.3f %%",
+				(double)encoder_cfg_ad2s1205.state.resolver_VOIDspi_peak_error_rate * (double)100.0);
+		commands_printf("Resolver angle velocity readings: errors: %d, error rate: %.3f %%",
+				encoder_cfg_ad2s1205.state.resolver_vel_packet_cnt,
+				(double)encoder_cfg_ad2s1205.state.resolver_vel_packet_error_rate * (double)100.0);
+		commands_printf("Resolver angle velocity readings peak error rate: %.3f %%",
+				(double)encoder_cfg_ad2s1205.state.resolver_VELread_peak_error_rate * (double)100.0);
+		commands_printf("\n");
+
 		break;
 
 	case SENSOR_PORT_MODE_ABI:

--- a/encoder/encoder_cfg.c
+++ b/encoder/encoder_cfg.c
@@ -54,14 +54,14 @@ AS504x_config_t encoder_cfg_as504x = {
 
 AD2S1205_config_t encoder_cfg_ad2s1205 = {
 		{ // BB_SPI
-				HW_HALL_ENC_GPIO3, HW_HALL_ENC_PIN3,
-				HW_HALL_ENC_GPIO1, HW_HALL_ENC_PIN1,
+				HW_SPI_PORT_NSS, HW_SPI_PIN_NSS,
+				HW_SPI_PORT_SCK, HW_SPI_PIN_SCK,
 #if defined(HW_SPI_PORT_MOSI) && AS504x_USE_SW_MOSI_PIN
 				HW_SPI_PORT_MOSI, HW_SPI_PIN_MOSI,
 #else
 				0, 0,
 #endif
-				HW_HALL_ENC_GPIO2, HW_HALL_ENC_PIN2,
+				HW_SPI_PORT_MISO, HW_SPI_PIN_MISO,
 				{{NULL, NULL}, NULL, NULL} // Mutex
 		},
 		{0},

--- a/encoder/encoder_datatype.h
+++ b/encoder/encoder_datatype.h
@@ -53,6 +53,16 @@ typedef struct {
 	float spi_error_rate;
 	float last_enc_angle;
 	uint32_t last_update_time;
+	uint32_t resolver_void_packet_cnt;
+	uint32_t resolver_vel_packet_cnt;
+	float resolver_void_packet_error_rate;
+	float resolver_vel_packet_error_rate;
+	float resolver_LOT_peak_error_rate;
+	float resolver_LOS_peak_error_rate;
+	float resolver_DOS_peak_error_rate;
+	float resolver_SPI_peak_error_rate;
+	float resolver_VELread_peak_error_rate;
+	float resolver_VOIDspi_peak_error_rate;
 } AD2S1205_state;
 
 typedef struct {

--- a/hwconf/hw.h
+++ b/hwconf/hw.h
@@ -593,6 +593,30 @@
 #endif
 #endif
 
+#ifndef HW_SPI_PORT_NSS
+#define HW_SPI_PORT_NSS HW_HALL_ENC_GPIO3
+#endif
+
+#ifndef HW_SPI_PIN_NSS
+#define HW_SPI_PIN_NSS HW_HALL_ENC_PIN3
+#endif
+
+#ifndef HW_SPI_PORT_SCK
+#define HW_SPI_PORT_SCK HW_HALL_ENC_GPIO1
+#endif
+
+#ifndef HW_SPI_PIN_SCK
+#define HW_SPI_PIN_SCK HW_HALL_ENC_PIN1
+#endif
+
+#ifndef HW_SPI_PORT_MISO
+#define HW_SPI_PORT_MISO HW_HALL_ENC_GPIO2
+#endif
+
+#ifndef HW_SPI_PIN_MISO
+#define HW_SPI_PIN_MISO HW_HALL_ENC_PIN2
+#endif
+
 // Functions
 void hw_init_gpio(void);
 void hw_setup_adc_channels(void);

--- a/hwconf/other/hw_axiom.c
+++ b/hwconf/other/hw_axiom.c
@@ -833,5 +833,10 @@ void terminal_cmd_axiom_print_log(int argc, const char **argv){
 	commands_printf("- 2023-06-22 Update axiom HW constants");
 	commands_printf("- 2023-06-22 Add temps filter and temp info terminal command");
 	commands_printf("- 2023-06-22 Add change log print");
+	commands_printf("- 2023-06-22 Add empty SPI message and angle velocity error, add peak values for error rates");
+	commands_printf("	Empty SPI message occurs when the resolver IC is not respoding");
+	commands_printf("	Angular velocity error occurs when resolver IC is reading angular velocity instead of angle position");
+	commands_printf("	Add info of the peak values for resolver errors");
+	commands_printf("	Add clear error function, type encoder_clear_errors in terminal to clear the counters ratio and peak values of the resolver errors");
 
 }

--- a/hwconf/other/hw_axiom.c
+++ b/hwconf/other/hw_axiom.c
@@ -97,6 +97,7 @@ float hw_axiom_read_input_current_sensor_gain(void);
 inline float hw_axiom_get_current_sensor_gain(void);
 static void terminal_cmd_axiom_print_temp_status(int argc, const char **argv);
 static void terminal_cmd_axiom_clear_temp_status(int argc, const char **argv);
+static void terminal_cmd_axiom_print_log(int argc, const char **argv);
 
 void hw_init_gpio(void) {
 
@@ -237,7 +238,13 @@ void hw_init_gpio(void) {
 			"Clear highest mosfet temp",
 			0,
 			terminal_cmd_axiom_clear_temp_status);
-    
+
+     terminal_register_command_callback(
+			"axiom_change_log",
+			"Print change log",
+			0,
+			terminal_cmd_axiom_print_log);
+
     // Send bitstream over SPI to configure FPGA
 	hw_axiom_configure_FPGA();
 
@@ -813,5 +820,18 @@ void terminal_cmd_axiom_clear_temp_status(int argc, const char **argv){
 	(void)argv;
 	commands_printf("Mosfet temp cleared");
 	highest_mos_temp = -100.0;
+
+}
+
+void terminal_cmd_axiom_print_log(int argc, const char **argv){
+	(void)argc;
+	(void)argv;
+
+	commands_printf("Axiom FW %d.%d BETA %d", FW_VERSION_MAJOR,FW_VERSION_MINOR,FW_TEST_VERSION_NUMBER);
+	commands_printf("Change log: ");
+	commands_printf("- 2023-06-22 Fix ad2s1205 spi pin configuration, fix resolver LOT errors info");
+	commands_printf("- 2023-06-22 Update axiom HW constants");
+	commands_printf("- 2023-06-22 Add temps filter and temp info terminal command");
+	commands_printf("- 2023-06-22 Add change log print");
 
 }

--- a/hwconf/other/hw_axiom.c
+++ b/hwconf/other/hw_axiom.c
@@ -95,6 +95,8 @@ void hw_axiom_configure_VDD_undervoltage(void);
 float hw_axiom_read_current_sensor_gain(void);
 float hw_axiom_read_input_current_sensor_gain(void);
 inline float hw_axiom_get_current_sensor_gain(void);
+static void terminal_cmd_axiom_print_temp_status(int argc, const char **argv);
+static void terminal_cmd_axiom_clear_temp_status(int argc, const char **argv);
 
 void hw_init_gpio(void) {
 
@@ -223,6 +225,18 @@ void hw_init_gpio(void) {
 			"Read current sensor gain.",
 			0,
 			terminal_cmd_read_current_sensor_gain);
+
+	terminal_register_command_callback(
+			"axiom_temp_status",
+			"Print the highest temperature reached",
+			0,
+			terminal_cmd_axiom_print_temp_status);
+
+	terminal_register_command_callback(
+			"axiom_temp_clear",
+			"Clear highest mosfet temp",
+			0,
+			terminal_cmd_axiom_clear_temp_status);
     
     // Send bitstream over SPI to configure FPGA
 	hw_axiom_configure_FPGA();
@@ -731,4 +745,73 @@ void hw_axiom_start_input_current_sensor_offset_measurement(void){
 	current_input_sensor_offset_start_measurement = true;
 	input_current_sensor_offset_samples = 0;
 	input_current_sensor_offset_sum = 0;
+}
+
+float highest_mos_temp = -100.0;
+float hw_axiom_temp_sensor_filter(uint8_t temp_sensor){
+	static float temp1 = 0.0;
+	static float temp2 = 0.0;
+	static float temp3 = 0.0;
+	switch (temp_sensor)
+	{
+	case 1:
+		UTILS_LP_FAST(temp1,
+			(1.0 / ((logf(NTC_RES_IGBT(ADC_Value[ADC_IND_TEMP_IGBT_1]) / 5000.0) / 3433.0) + (1.0 / 298.15)) - 273.15),
+			 0.01);
+
+		if(temp1 > highest_mos_temp){
+			highest_mos_temp = temp1;
+		}
+
+		return temp1;
+		break;
+	case 2:
+		UTILS_LP_FAST(temp2,
+			(1.0 / ((logf(NTC_RES_IGBT(ADC_Value[ADC_IND_TEMP_IGBT_2]) / 5000.0) / 3433.0) + (1.0 / 298.15)) - 273.15),
+			 0.01);
+
+		if(temp2 > highest_mos_temp){
+			highest_mos_temp = temp2;
+		}
+
+		return temp2;
+		break;
+	case 3:
+		UTILS_LP_FAST(temp3,
+			(1.0 / ((logf(NTC_RES_IGBT(ADC_Value[ADC_IND_TEMP_IGBT_3]) / 5000.0) / 3433.0) + (1.0 / 298.15)) - 273.15),
+			 0.01);
+
+		if(temp3 > highest_mos_temp){
+			highest_mos_temp = temp3;
+		}
+
+		return temp3;
+		break;
+
+	default:
+		return 0.0;
+		break;
+	}
+}
+
+float hw_axiom_NTC_res_motor_filter(uint16_t adc_val){
+	static float adc_val_filtered = 0.0;
+
+	UTILS_LP_FAST(adc_val_filtered, adc_val, 0.01);
+	return ((4095.0 * 8870.0 * 2) / adc_val_filtered - 18870.0);
+}
+
+void terminal_cmd_axiom_print_temp_status(int argc, const char **argv){
+	(void)argc;
+	(void)argv;
+	commands_printf("The highest mosfets temperature was: %.2f", (double)highest_mos_temp);
+
+}
+
+void terminal_cmd_axiom_clear_temp_status(int argc, const char **argv){
+	(void)argc;
+	(void)argv;
+	commands_printf("Mosfet temp cleared");
+	highest_mos_temp = -100.0;
+
 }

--- a/hwconf/other/hw_axiom.h
+++ b/hwconf/other/hw_axiom.h
@@ -27,7 +27,7 @@
 
 //#define HW_AXIOM_USE_DAC
 //#define HW_AXIOM_USE_MOTOR_TEMP
-//#define HW_HAS_INPUT_CURRENT_SENSOR
+#define HW_HAS_INPUT_CURRENT_SENSOR
 #define HW_USE_LINE_TO_LINE
 #define	HW_AXIOM_FORCE_HIGH_CURRENT_MEASUREMENTS
 #define HW_VERSION_AXIOM
@@ -38,8 +38,8 @@
 #define HW_HAS_GATE_DRIVER_SUPPLY_MONITOR
 
 // Macros
-#define ENABLE_GATE()			palSetPad(GPIOC, 14)
-#define DISABLE_GATE()			palClearPad(GPIOC, 14)
+#define ENABLE_GATE()			palSetPad(GPIOH, 14)
+#define DISABLE_GATE()			palClearPad(GPIOH, 14)
 #define DCCAL_ON()
 #define DCCAL_OFF()
 #define IS_DRV_FAULT()			(!palReadPad(GPIOB, 12))
@@ -110,16 +110,17 @@
 #define HVDC_TRANSFER_FUNCTION			112.15			//[V/V]
 #define PHASE_VOLTAGE_TRANSFER_FUNCTION	112.15			//[V/V]
 #else
-#define HVDC_TRANSFER_FUNCTION			185.0			//[V/V]
+#define HVDC_TRANSFER_FUNCTION			196.0			//[V/V]
 #define PHASE_VOLTAGE_TRANSFER_FUNCTION	367.7			//[V/V]
 #endif
-#define DEFAULT_CURRENT_AMP_GAIN		0.003761	//Transfer Function [V/A] for ISB-425-A
+#define DEFAULT_CURRENT_AMP_GAIN		0.001035	//Transfer Function [V/A]
+//#define DEFAULT_CURRENT_AMP_GAIN		0.003761	//Transfer Function [V/A] for ISB-425-A
 //#define DEFAULT_CURRENT_AMP_GAIN		0.001249	//Transfer Function [V/A] for HTFS 800-P
 //#define DEFAULT_CURRENT_AMP_GAIN		0.004994	//Transfer Function [V/A] for HASS 100-S
 //#define DEFAULT_CURRENT_AMP_GAIN		0.001249	//Transfer Function [V/A] for HASS 400-S
 //#define DEFAULT_CURRENT_AMP_GAIN		0.0008324	//Transfer Function [V/A] for HASS 600-S
 
-#define DEFAULT_INPUT_CURRENT_AMP_GAIN		0.004	//Transfer Function [V/A] for 4mv/A
+#define DEFAULT_INPUT_CURRENT_AMP_GAIN		0.00104069	//Transfer Function [V/A] 
 
 // Component parameters (can be overridden)
 #ifndef V_REG
@@ -152,11 +153,11 @@
 
 // NTC Termistors
 #define NTC_RES(adc_val)				((4095.0 * 10000.0) / adc_val - 10000.0)
-#define NTC_RES_IGBT(adc_val)			((4095.0 * 5000.0) / adc_val - 5000.0)
+#define NTC_RES_IGBT(adc_val)			((4095.0 * 8870.0 * 2) / adc_val - 18870.0)
 #define NTC_TEMP(adc_ind)				hw_axiom_get_highest_IGBT_temp()
 //#define NTC_TEMP(adc_ind)				(1.0 / ((logf(NTC_RES(ADC_Value[adc_ind]) / 10000.0) / 3434.0) + (1.0 / 298.15)) - 273.15)
 
-#define NTC_RES_MOTOR(adc_val)			((4095.0 * 10000.0) / adc_val - 10000.0)
+#define NTC_RES_MOTOR(adc_val)			((4095.0 * 8870.0 * 2) / adc_val - 18870.0)
 
 // If DAC enabled, only IGBT_TEMP_3 is available
 #ifdef HW_AXIOM_USE_DAC
@@ -256,6 +257,8 @@
 // Resolver interface pins
 #define AD2S1205_SAMPLE_GPIO	GPIOB
 #define AD2S1205_SAMPLE_PIN		3
+#define AD2S1205_RDVEL_GPIO     GPIOC
+#define AD2S1205_RDVEL_PIN      14
 
 // NRF pins
 #define NRF_PORT_CSN			GPIOB
@@ -311,15 +314,15 @@
 #define FOC_CONTROL_LOOP_FREQ_DIVIDER	1
 
 // Setting limits
-#define HW_LIM_CURRENT					-425.0, 425.0
-#define HW_LIM_CURRENT_IN				-400.0, 400.0
-#define HW_LIM_CURRENT_ABS				0.0, 400.0
-#define HW_LIM_VIN						0.0, 420.0
+#define HW_LIM_CURRENT					-600.0, 600.0
+#define HW_LIM_CURRENT_IN				-500.0, 500.0
+#define HW_LIM_CURRENT_ABS				0.0, 800.0
+#define HW_LIM_VIN						0.0, 525.0
 #define HW_LIM_ERPM						-100e3, 100e3
 #define HW_LIM_DUTY_MIN					0.0, 0.1
 #define HW_LIM_DUTY_MAX					0.0, 1.0
 #define HW_LIM_TEMP_FET					-40.0, 110.0
-#define HW_LIM_FOC_CTRL_LOOP_FREQ		5000.0, 30000.0	//at around 38kHz the RTOS starts crashing (26us FOC ISR)
+#define HW_LIM_FOC_CTRL_LOOP_FREQ		5000.0, 24000.0	//at around 38kHz the RTOS starts crashing (26us FOC ISR)
 
 // HW-specific functions
 char hw_axiom_configure_FPGA(void);

--- a/hwconf/other/hw_axiom.h
+++ b/hwconf/other/hw_axiom.h
@@ -157,18 +157,18 @@
 #define NTC_TEMP(adc_ind)				hw_axiom_get_highest_IGBT_temp()
 //#define NTC_TEMP(adc_ind)				(1.0 / ((logf(NTC_RES(ADC_Value[adc_ind]) / 10000.0) / 3434.0) + (1.0 / 298.15)) - 273.15)
 
-#define NTC_RES_MOTOR(adc_val)			((4095.0 * 8870.0 * 2) / adc_val - 18870.0)
+#define NTC_RES_MOTOR(adc_val)			hw_axiom_NTC_res_motor_filter(adc_val)
 
 // If DAC enabled, only IGBT_TEMP_3 is available
 #ifdef HW_AXIOM_USE_DAC
 #define NTC_TEMP_MOS1()			(25.0)
 #define NTC_TEMP_MOS2()			(25.0)
-#define NTC_TEMP_MOS3()			(1.0 / ((logf(NTC_RES_IGBT(ADC_Value[ADC_IND_TEMP_IGBT_3]) / 5000.0) / 3433.0) + (1.0 / 298.15)) - 273.15)
+#define NTC_TEMP_MOS3()			hw_axiom_temp_sensor_filter(3)
 #else
 // Individual IGBT Temperature sensing
-#define NTC_TEMP_MOS1()			(1.0 / ((logf(NTC_RES_IGBT(ADC_Value[ADC_IND_TEMP_IGBT_1]) / 5000.0) / 3433.0) + (1.0 / 298.15)) - 273.15)
-#define NTC_TEMP_MOS2()			(1.0 / ((logf(NTC_RES_IGBT(ADC_Value[ADC_IND_TEMP_IGBT_2]) / 5000.0) / 3433.0) + (1.0 / 298.15)) - 273.15)
-#define NTC_TEMP_MOS3()			(1.0 / ((logf(NTC_RES_IGBT(ADC_Value[ADC_IND_TEMP_IGBT_3]) / 5000.0) / 3433.0) + (1.0 / 298.15)) - 273.15)
+#define NTC_TEMP_MOS1()			hw_axiom_temp_sensor_filter(1)
+#define NTC_TEMP_MOS2()			hw_axiom_temp_sensor_filter(2)
+#define NTC_TEMP_MOS3()			hw_axiom_temp_sensor_filter(3)
 #endif
 
 #ifdef HW_AXIOM_USE_MOTOR_TEMP
@@ -333,5 +333,7 @@ float hw_axiom_get_highest_IGBT_temp(void);
 float hw_axiom_read_input_current(void);
 void hw_axiom_get_input_current_offset(void);
 void hw_axiom_start_input_current_sensor_offset_measurement(void);
+float hw_axiom_temp_sensor_filter(uint8_t);
+float hw_axiom_NTC_res_motor_filter(uint16_t);
 
 #endif /* HW_AXIOM_H_ */


### PR DESCRIPTION
The following changed where introduced under @nitrousnrg and @maxicor88 supervision

Encoder (6635f14): Wrong SPI pins configuration in encoder_cfg_ad2s1205 structure initialization.

Axiom(779cd02): Update axiom.h hardware constant according Axiom rev2.

Axiom(db6e4b2): add filters for IGBTs and motor temperature measurement and log the highest that can be consulted using a terminal command, also add a clear function for this logging. 

Axiom(a4734e2): add change log to visualize in VESC terminal code modifications made by Powerdesign team for Axiom.
![image](https://github.com/vedderb/bldc/assets/106331120/c58283cc-adcd-4801-8ec1-bf908e4a3b4c)

Encoder(8f612c1): add more info of encoder errors in terminal.
    - SPI encoder peak error rate: shows the SPI parity peak error reached
    - Loss of tracking peak error rate: shows loss of tracking the peak error reached
    - Degradation of signal peak error rate: shows the degradation of signal peak error reached
    - Loss of signal peak error rate: shows the lost of signal peak error reached
    - SPI empty packet error counter: shows the quantity of empty packets received from the resolver IC.
    - SPI empty packet error rate: show the rate of empty packet received from the resolver IC
    - SPI empty peak error: shows the peak error rate for empty SPI packet received from the resolver IC.
    - Angle velocity error counter: shows the quantity of angle velocity instead of angle position packets sent by resolver IC.
    - Angle velocity error rate: shows the rate of angle velocity instead of angle position packets sent by resolver IC.
    - Angle velocity peak error: shows the peak  rate of angle velocity instead of angle position packets sent by resolver IC.

The peak rate info is useful to know how close was the error rate to reach the maximum or how high it was.
SPI empty packet info is useful to know if the resolver IC is not responding and trip FAULT_CODE_ENCODER_SPI.
Angle velocity error is used to know if resolver IC configuration was unintentionally changed to velocity instead of angle position and trip FAULT_CODE_ENCODER_SPI.

![image](https://github.com/vedderb/bldc/assets/106331120/6dce7a7d-c9ff-4f52-987c-a292a4e7d16c)

Axiom(ed4f323): Complete axiom change log with new features.


