### PR TITLE
Luna M600 and BBSHD: app to use define

### DIFF
--- a/hwconf/luna/bbshd/appconf_luna_bbshd.h
+++ b/hwconf/luna/bbshd/appconf_luna_bbshd.h
@@ -40,7 +40,7 @@
 #define APPCONF_UAVCAN_RAW_MODE 0
 
 // APP to Use
-#define APPCONF_APP_TO_USE 11
+#define APPCONF_APP_TO_USE 10
 
 // Control Type
 #define APPCONF_PPM_CTRL_TYPE 0

--- a/hwconf/luna/bbshd/hw_luna_bbshd.h
+++ b/hwconf/luna/bbshd/hw_luna_bbshd.h
@@ -21,7 +21,7 @@
 #ifndef HW_LUNA_BBSHD_H_
 #define HW_LUNA_BBSHD_H_
 
-#define FW_NAME				"2023.04.21"
+#define FW_NAME				"2023.06.29"
 #define HW_NAME				"LUNA_BBSHD"
 #include "mcconf_luna_bbshd.h"
 #include "appconf_luna_bbshd.h"

--- a/hwconf/luna/m600/appconf_luna_m600.h
+++ b/hwconf/luna/m600/appconf_luna_m600.h
@@ -43,7 +43,7 @@
 #define APPCONF_SERVO_OUT_ENABLE 0
 
 // APP to Use
-#define APPCONF_APP_TO_USE 11
+#define APPCONF_APP_TO_USE 10
 
 // Control Type
 #define APPCONF_PPM_CTRL_TYPE 0

--- a/hwconf/luna/m600/hw_luna_m600.h
+++ b/hwconf/luna/m600/hw_luna_m600.h
@@ -21,7 +21,7 @@
 #ifndef HW_LUNA_M600_H_
 #define HW_LUNA_M600_H_
 
-#define FW_NAME					"2022.11.25"
+#define FW_NAME					"2023.06.27"
 
 #include "mcconf_luna_m600.h"
 #include "appconf_luna_m600.h"


### PR DESCRIPTION
After APP_BALANCE was removed, the numerical values of the enum where shifted and the defaults for Luna M600 and BBSHD no longer work