### PR TITLE
fixes detached ADC1 not being mapped

### DIFF
--- a/applications/app_adc.c
+++ b/applications/app_adc.c
@@ -201,6 +201,11 @@ static THD_FUNCTION(adc_thread, arg) {
 
 		range_ok = read_voltage >= config.voltage_min && read_voltage <= config.voltage_max;
 
+		// Override pwr value, when used from LISP
+		if (adc_detached == 1 || adc_detached == 2) {
+			pwr = adc1_override;
+		}
+
 		// Map the read voltage
 		switch (config.ctrl_type) {
 		case ADC_CTRL_TYPE_CURRENT_REV_CENTER:
@@ -222,11 +227,6 @@ static THD_FUNCTION(adc_thread, arg) {
 			// Linear mapping between the start and end voltage
 			pwr = utils_map(pwr, config.voltage_start, config.voltage_end, 0.0, 1.0);
 			break;
-		}
-
-		// Override pwr value, when used from LISP
-		if (adc_detached == 1 || adc_detached == 2) {
-			pwr = adc1_override;
 		}
 
 		// Optionally apply a filter


### PR DESCRIPTION
I have received multiple reports of the ADC not working correctly when the throttle input is disconnected by Lisp. After looking at the latest changes, I noticed that the pwr value was overridden after it was mapped, whereas before it was mapped. This only affected ADC1, as ADC2 had not been changed and was working as before.

I have now moved it up again and it should now work correctly. I have not tested it on my scooter yet, but will comment as soon as I do if the change has fixed it, but this is a very obvious logic flaw, so it should work.

Code changes: https://github.com/vedderb/bldc/compare/8c1e6c53de717b3feea6690d6b59f3c8d9e81a97...f08c8602fe1739fff4349d9ffc7989bf561c2229

from:
https://github.com/vedderb/bldc/blob/8c1e6c53de717b3feea6690d6b59f3c8d9e81a97/applications/app_adc.c#L202-L230
to:
https://github.com/vedderb/bldc/blob/f08c8602fe1739fff4349d9ffc7989bf561c2229/applications/app_adc.c#L202-L230