### PR TITLE
Add define to disable LEDs

### DIFF
--- a/conf_general.h
+++ b/conf_general.h
@@ -109,6 +109,18 @@
 #endif
 
 /*
+ * Enable green and red LED
+ */
+#ifndef LED_ENABLE
+#define LED_ENABLE					1
+#endif
+
+#ifdef HW_HAS_NO_LED
+#undef LED_ENABLE
+#define LED_ENABLE 					0
+#endif
+
+/*
  * Servo output driver
  */
 #define SERVO_OUT_PULSE_MIN_US		1000	// Minimum pulse length in microseconds

--- a/driver/ledpwm.c
+++ b/driver/ledpwm.c
@@ -78,6 +78,7 @@ void ledpwm_led_off(int led) {
  * Call this function as fast as possible, with a deterministic rate.
  */
 void ledpwm_update_pwm(void) {
+#if LED_ENABLE
 	static int cnt = 0;
 	cnt++;
 	if (cnt == LEDPWM_CNT_TOP) {
@@ -95,6 +96,7 @@ void ledpwm_update_pwm(void) {
 	} else {
 		LED_RED_ON();
 	}
+#endif
 
 #ifdef LED_PWM1_ON
 	if (cnt >= led_values[LED_HW1]) {

--- a/hwconf/hw.h
+++ b/hwconf/hw.h
@@ -168,6 +168,13 @@
  */
 
 /*
+ * #define HW_HAS_NO_LED
+ *
+ * The hardware is missing the green and red LED.
+ * TODO: Maybe split into two defines for green and red LED.
+ */
+
+/*
  * Define these to enable MPU9150 or MPU9250 support
  * on these pins.
  *

--- a/main.c
+++ b/main.c
@@ -29,9 +29,7 @@
 #include "mc_interface.h"
 #include "mcpwm.h"
 #include "mcpwm_foc.h"
-#include "ledpwm.h"
 #include "comm_usb.h"
-#include "ledpwm.h"
 #include "terminal.h"
 #include "hw.h"
 #include "app.h"
@@ -54,6 +52,9 @@
 #include "mempools.h"
 #include "events.h"
 #include "main.h"
+#ifdef LED_ENABLE
+#include "ledpwm.h"
+#endif
 #ifdef CAN_ENABLE
 #include "comm_can.h"
 
@@ -83,7 +84,9 @@
 
 // Private variables
 static THD_WORKING_AREA(periodic_thread_wa, 256);
+#if LED_ENABLE
 static THD_WORKING_AREA(led_thread_wa, 256);
+#endif
 static THD_WORKING_AREA(flash_integrity_check_thread_wa, 256);
 static volatile bool m_init_done = false;
 
@@ -102,6 +105,7 @@ static THD_FUNCTION(flash_integrity_check_thread, arg) {
 	}
 }
 
+#if LED_ENABLE
 static THD_FUNCTION(led_thread, arg) {
 	(void)arg;
 
@@ -147,6 +151,7 @@ static THD_FUNCTION(led_thread, arg) {
 		chThdSleepMilliseconds(10);
 	}
 }
+#endif
 
 static THD_FUNCTION(periodic_thread, arg) {
 	(void)arg;
@@ -238,8 +243,10 @@ int main(void) {
 	mempools_init();
 	events_init();
 	hw_init_gpio();
+#if LED_ENABLE
 	LED_RED_OFF();
 	LED_GREEN_OFF();
+#endif
 
 	timer_init();
 	conf_general_init();
@@ -248,9 +255,11 @@ int main(void) {
 		// Loop here, it is not safe to run any code
 		while (1) {
 			chThdSleepMilliseconds(100);
+		#if LED_ENABLE
 			LED_RED_ON();
 			chThdSleepMilliseconds(75);
 			LED_RED_OFF();
+		#endif
 		}
 	}
 
@@ -293,7 +302,9 @@ int main(void) {
 #endif
 
 	// Threads
+#if LED_ENABLE
 	chThdCreateStatic(led_thread_wa, sizeof(led_thread_wa), NORMALPRIO, led_thread, NULL);
+#endif
 	chThdCreateStatic(periodic_thread_wa, sizeof(periodic_thread_wa), NORMALPRIO, periodic_thread, NULL);
 	chThdCreateStatic(flash_integrity_check_thread_wa, sizeof(flash_integrity_check_thread_wa), LOWPRIO, flash_integrity_check_thread, NULL);
 

--- a/motor/gpdrive.c
+++ b/motor/gpdrive.c
@@ -620,7 +620,9 @@ static void adc_int_handler(void *p, uint32_t flags) {
 		}
 	}
 
+#if LED_ENABLE
 	ledpwm_update_pwm();
+#endif
 
 	m_last_adc_isr_duration = timer_seconds_elapsed_since(t_start);
 }

--- a/motor/mc_interface.c
+++ b/motor/mc_interface.c
@@ -1871,7 +1871,9 @@ void mc_interface_fault_stop(mc_fault_code fault, bool is_second_motor, bool is_
 }
 
 void mc_interface_mc_timer_isr(bool is_second_motor) {
+#if LED_ENABLE
 	ledpwm_update_pwm();
+#endif
 
 #ifdef HW_HAS_DUAL_MOTORS
 	motor_if_state_t *motor = is_second_motor ? (motor_if_state_t*)&m_motor_2 : (motor_if_state_t*)&m_motor_1;


### PR DESCRIPTION
I added a define to disable the use of LEDs if the hardware misses them. In my case there where none, in order to use all GPIOs as external inputs. I took `CAN_ENABLE` as example. Obviously by default `LED_ENABLE` defined as `1` and only set to `0`, if `HW_HAS_NO_LED` is set in the `hwconf/hw_xx.h`.