### PR TITLE
Add buf-resize extension and update LispBM docs

### DIFF
--- a/lispBM/lispif_vesc_extensions.c
+++ b/lispBM/lispif_vesc_extensions.c
@@ -56,6 +56,11 @@
 #include <ctype.h>
 #include <stdarg.h>
 
+/**
+ * Bytes per word in the LBM memory.
+ */
+#define LBM_WORD_SIZE 4
+
 typedef struct {
 	// BMS
 	lbm_uint v_tot;
@@ -557,6 +562,33 @@ static bool is_symbol_true_false(lbm_value v) {
 		lbm_set_error_reason("Argument must be t or nil (true or false)");
 	}
 	return res;
+}
+
+/**
+ * Wrapper around lbm_memory_shrink that takes number of bytes instead of number
+ * of words. Shrinks the size of an pointer allocated in LBM memory to the
+ * smallest possible size while still having capacity for the specified amount
+ * of bytes.
+ * 
+ * @param ptr Pointer to the allocated segment in LBM memory. Should have been
+ * obtained through lbm_malloc or other similar way at some point.
+ * @param size_bytes The new capacity of the allocation in bytes. Must be
+ * smaller or equal to the previous capacity.
+ * @return If the operation succeeded. The return value of lbm_memory_shrink is
+ * directly passed through, that is: false is returned either if ptr didn't
+ * point into the LBM memory/didn't point to the start of an allocated segment
+ * or if the new size was larger than the previous (note that since this
+ * function converts bytes to words, a larger size in bytes might not cause it
+ * to fail, as the size in words could still be the same). Otherwise true is
+ * returned. 
+*/
+static bool lbm_memory_shrink_bytes(void *array, lbm_uint size_bytes) {
+	lbm_uint size_words = size_bytes / LBM_WORD_SIZE;
+	if (size_bytes % LBM_WORD_SIZE != 0) {
+		size_words += 1;
+	}
+	
+	return lbm_memory_shrink((lbm_uint *)array, size_words) > 0;
 }
 
 // Various commands
@@ -4520,6 +4552,92 @@ static lbm_value ext_buf_find(lbm_value *args, lbm_uint argn) {
 	return lbm_enc_i(res);
 }
 
+/**
+ * signature: (buf-resize arr:array delta-size:number|nil [new-size:number])
+ * -> array
+ *
+ * If delta-size is passed, this extension calculates the new size by
+ * adding the relative size to the current size, otherwise new-size is simply
+ * used for the new size.
+ *
+ * If the new size is smaller than the current size, the array is just shrunk in
+ * place without allocating a new buffer. Either delta-size or new-size must not
+ * be nil.
+ * 
+ * Either way, the passed array is always resized mutably, with the returned
+ * reference only for convenience.
+ */
+static lbm_value ext_buf_resize(lbm_value *args, lbm_uint argn) {
+	if ((argn != 2 && argn != 3) || !lbm_is_array_rw(args[0])
+		|| (!lbm_is_number(args[1]) && !lbm_is_symbol_nil(args[1]))
+		|| (argn == 3 && !lbm_is_number(args[2]))) {
+		lbm_set_error_reason((char *)lbm_error_str_incorrect_arg);
+		return ENC_SYM_TERROR;
+	}
+
+	bool delta_size_passed = !lbm_is_symbol_nil(args[1]);
+	bool new_size_passed   = argn == 3;
+	if (!delta_size_passed && !new_size_passed) {
+		lbm_set_error_reason(
+			"delta-size (arg 2) was nil while new-size wasn't provided (arg 3)"
+		);
+		return ENC_SYM_EERROR;
+	}
+
+	lbm_array_header_t *header = (lbm_array_header_t *)lbm_car(args[0]);
+	if (header == NULL) {
+		// Should be impossible, unless it contained null pointer to header.
+		return ENC_SYM_FATAL_ERROR;
+	}
+	
+	uint32_t new_size;
+	{
+		int32_t new_size_signed;
+		if (delta_size_passed) {
+			new_size_signed = header->size + lbm_dec_as_i32(args[1]);
+		} else {
+			new_size_signed = lbm_dec_as_i32(args[2]);
+		}
+		
+		if (new_size_signed < 0) {
+			lbm_set_error_reason("resulting size was negative");
+			return ENC_SYM_EERROR;
+		}
+		new_size = (uint32_t)new_size_signed;
+	}
+	
+	if (new_size == header->size) {
+		return args[0];
+	} else if (new_size < header->size) {
+		uint32_t allocated_size = new_size;
+		if (new_size == 0) {
+			// arrays of size 0 still need some memory allocated for them.
+			allocated_size = 1;
+		}
+		// We sadly can't trust the return value, as it fails if the allocation
+		// was previously a single word long. So we just throw it away.
+		lbm_memory_shrink_bytes(header->data, allocated_size);
+		
+		header->size = new_size;
+
+		return args[0];
+	} else {
+		void *buffer = lbm_malloc_reserve(new_size);
+		if (buffer == NULL) {
+			return ENC_SYM_MERROR;
+		}
+
+		memcpy(buffer, header->data, header->size);
+		memset(buffer + header->size, 0, new_size - header->size);
+
+		lbm_memory_free(header->data);
+		header->data = buffer;
+		header->size = new_size;
+
+		return args[0];
+	}
+}
+
 static lbm_value ext_shutdown_hold(lbm_value *args, lbm_uint argn) {
 	if (argn != 1) {
 		lbm_set_error_reason((char*)lbm_error_str_num_args);
@@ -4684,6 +4802,7 @@ void lispif_load_vesc_extensions(void) {
 	lbm_add_extension("crc16", ext_crc16);
 	lbm_add_extension("crc32", ext_crc32);
 	lbm_add_extension("buf-find", ext_buf_find);
+	lbm_add_extension("buf-resize", ext_buf_resize);
 	lbm_add_extension("shutdown-hold", ext_shutdown_hold);
 
 	// APP commands


### PR DESCRIPTION
Added the extension `buf-resize`, and documented it in the LispBM docs.

This reflects the changes in my [pull request](https://github.com/vedderb/vesc_express/pull/14) to the VESC Express repository (exluding the `tcp-recv-to-char` extension as that one is exclusive to the Express platform).

Sorry that the [update lispBM docs](https://github.com/vedderb/bldc/commit/aeb80d68aa82fa7d38f52ed4b8d7cd51ba6f2056) commit got such a generic name, hopefully it's clear which sections were updated.