### PR TITLE
Package C-Interface: add APIs for HW/FW version/names

### DIFF
--- a/hwconf/hw.c
+++ b/hwconf/hw.c
@@ -40,6 +40,22 @@ uint8_t hw_id_from_uuid(void) {
 	return id;
 }
 
+const char *fw_name = FW_NAME;
+const char *hw_name = HW_NAME;
+
+void get_fw_version(int *vmajor, int *vminor, int *vtest) {
+	*vmajor = FW_VERSION_MAJOR;
+	*vminor = FW_VERSION_MINOR;
+	*vtest = FW_TEST_VERSION_NUMBER;
+}
+const char *get_fw_name() {
+	return fw_name;
+}
+const char *get_hw_name() {
+	return hw_name;
+}
+
+
 #if defined(HW_ID_PIN_GPIOS) && defined(HW_ID_PIN_PINS)
 uint8_t hw_id_from_pins(void) {
 	stm32_gpio_t *hw_id_ports[]={HW_ID_PIN_GPIOS};

--- a/hwconf/hw.h
+++ b/hwconf/hw.h
@@ -657,4 +657,8 @@ void hw_try_restore_i2c(void);
 uint8_t hw_id_from_uuid(void);
 uint8_t hw_id_from_pins(void);
 
+void get_fw_version(int *vmajor, int *vminor, int *vtest);
+const char *get_fw_name(void);
+const char *get_hw_name(void);
+
 #endif /* HW_H_ */

--- a/lispBM/c_libs/vesc_c_if.h
+++ b/lispBM/c_libs/vesc_c_if.h
@@ -593,6 +593,11 @@ typedef struct {
 	void (*foc_set_openloop_duty)(float dutyCycle, float rpm);
 	void (*foc_set_openloop_duty_phase)(float dutyCycle, float phase);
 
+	// FW/HW Info
+	void (*get_fw_version)(int *vmajor, int *vminor, int *vtest);
+	const char* (*get_fw_name)(void);
+	const char* (*get_hw_name)(void);
+
 	// Flat values
 	bool (*lbm_start_flatten)(lbm_flat_value_t *v, size_t buffer_size);
 	bool (*lbm_finish_flatten)(lbm_flat_value_t *v);

--- a/lispBM/lispif_c_lib.c
+++ b/lispBM/lispif_c_lib.c
@@ -903,6 +903,11 @@ lbm_value ext_load_native_lib(lbm_value *args, lbm_uint argn) {
 		cif.cif.foc_set_openloop_duty = mc_interface_set_openloop_duty;
 		cif.cif.foc_set_openloop_duty_phase = mc_interface_set_openloop_duty_phase;
 
+		// Firmware/hardware version
+		cif.cif.get_fw_version = get_fw_version;
+		cif.cif.get_fw_name = get_fw_name;
+		cif.cif.get_hw_name = get_hw_name;
+
 		// Flat values
 		cif.cif.lbm_start_flatten = lbm_start_flatten;
 		cif.cif.lbm_finish_flatten = lbm_finish_flatten;


### PR DESCRIPTION
This API has been inserted after "foc_set_openloop_duty_phase" in order to make it possible to safely identify v6.05 vs v6.02 firmware.