### PR TITLE
fix ZV freq for auto detection

### DIFF
--- a/conf_general.c
+++ b/conf_general.c
@@ -1818,7 +1818,7 @@ int conf_general_detect_apply_all_foc(float max_power_loss,
 #ifdef HW_HAS_DUAL_MOTORS
 	mcconf->foc_f_zv = 25000.0;
 #else
-	mcconf->foc_f_zv = 40000.0;
+	mcconf->foc_f_zv = 25000.0;
 #endif
 	mc_interface_set_configuration(mcconf);
 


### PR DESCRIPTION
lower the zv freq for flux linkage measurement as the hardwares with phase shunts and v0-v7 enabled will trigger watchdog reset as you cannot run more than 30khz with v0-v7 enabled.