### PR TITLE
Unlock lbm if repl_buffer is already set on repl command

### DIFF
--- a/lispBM/lispif.c
+++ b/lispBM/lispif.c
@@ -413,6 +413,7 @@ void lispif_process_cmd(unsigned char *data, unsigned int len,
 				commands_printf_lisp("Verbose errors %s", verbose_now ? "Enabled" : "Disabled");
 			} else {
 				if (repl_buffer) {
+					lispif_unlock_lbm();
 					break;
 				}
 


### PR DESCRIPTION
This fixes a race condition where unlock was never called if multiple repl commands was issued in short sequence.