### PR TITLE
Make it possible to disable LispBM by setting "USE_LISPBM=0"

### DIFF
--- a/make/fw.mk
+++ b/make/fw.mk
@@ -3,7 +3,7 @@
 # NOTE: Can be overridden externally.
 #
 
-USE_LISPBM=1
+USE_LISPBM ?= 1
 
 # Compiler options here.
 ifeq ($(USE_OPT),)


### PR DESCRIPTION
I have a custom application that is too large to large if LispBM is included