### PR TITLE
Make the command for getting the Python version quite

### DIFF
--- a/make/linux.mk
+++ b/make/linux.mk
@@ -11,7 +11,7 @@
 
 
 # Get Python version, separate major/minor/patch, then put into wordlist
-PYTHON_VERSION_=$(wordlist 2,4,$(subst ., ,$(shell python -V 2>&1)))
+PYTHON_VERSION_=$(wordlist 2,4,$(subst ., ,$(shell python -V 2>/dev/null)))
 
 # Get major version from aforementioned list
 PYTHON_MAJOR_VERSION_=$(word 1,$(PYTHON_VERSION_))


### PR DESCRIPTION
"python" is not available on my system only "python3", so this will cause output stderr even though the Makefile later checks if "python3" exist