### PR TITLE
Pas torque sensor safety improvement

### DIFF
--- a/applications/app_pas.c
+++ b/applications/app_pas.c
@@ -35,7 +35,8 @@
 
 // Settings
 #define PEDAL_INPUT_TIMEOUT				0.2
-#define MAX_MS_WITHOUT_CADENCE			5000
+#define MAX_MS_WITHOUT_CADENCE_OR_TORQUE	5000
+#define MAX_MS_WITHOUT_CADENCE			1000
 #define MIN_MS_WITHOUT_POWER			500
 #define FILTER_SAMPLES					5
 #define RPM_FILTER_SAMPLES				8
@@ -164,6 +165,7 @@ void pas_event_handler(void) {
 		pedal_rpm = 60.0 / period_filtered;
 		pedal_rpm *= (direction_conf * (float)direction_qem);
 		inactivity_time = 0.0;
+		correct_direction_counter = 0;
 	}
 	else {
 		inactivity_time += 1.0 / (float)config.update_rate_hz;
@@ -253,9 +255,20 @@ static THD_FUNCTION(pas_thread, arg) {
 					ms_without_cadence_or_torque = 0.0;
 				} else {
 					ms_without_cadence_or_torque += (1000.0 * (float)sleep_time) / (float)CH_CFG_ST_FREQUENCY;
-					if(ms_without_cadence_or_torque > MAX_MS_WITHOUT_CADENCE) {
+					if(ms_without_cadence_or_torque > MAX_MS_WITHOUT_CADENCE_OR_TORQUE) {
 						output = 0.0;
 					}
+				}
+				// if cranks are not moving, there should not be any output. This covers the case of a torque sensor
+				// stuck with a non-zero signal.
+				static float ms_without_cadence = 0.0;
+				if(pedal_rpm < 0.01) {
+					ms_without_cadence += (1000.0 * (float)sleep_time) / (float)CH_CFG_ST_FREQUENCY;
+					if(ms_without_cadence > MAX_MS_WITHOUT_CADENCE) {
+						output = 0.0;
+					}
+				} else {
+					ms_without_cadence = 0.0;
 				}
 			}
 #endif

--- a/hwconf/luna/m600/appconf_luna_m600.h
+++ b/hwconf/luna/m600/appconf_luna_m600.h
@@ -280,7 +280,7 @@
 #define APPCONF_PAS_INVERT_PEDAL_DIRECTION 0
 
 // Sensor Magnets
-#define APPCONF_PAS_MAGNETS 12
+#define APPCONF_PAS_MAGNETS 48
 
 // Use Filter
 #define APPCONF_PAS_USE_FILTER 1

--- a/hwconf/luna/m600/hw_luna_m600.h
+++ b/hwconf/luna/m600/hw_luna_m600.h
@@ -21,7 +21,7 @@
 #ifndef HW_LUNA_M600_H_
 #define HW_LUNA_M600_H_
 
-#define FW_NAME					"2023.12.13"
+#define FW_NAME					"2024.05.08"
 
 #ifdef M600_60V_BATTERY
 #include "mcconf_luna_m600_60V.h"

--- a/hwconf/luna/m600/luna_m600_display.c
+++ b/hwconf/luna/m600/luna_m600_display.c
@@ -37,7 +37,7 @@
 #include "mcpwm_foc.h" // for encoder angle error
 
 #define LUNA_TORQUE_SENSOR_DEFAULT_TORQUE	0x02EE
-#define LUNA_TORQUE_SENSOR_MINIMUM_TORQUE	0x0360
+#define LUNA_TORQUE_SENSOR_MINIMUM_TORQUE	0x044C
 #define LUNA_TORQUE_SENSOR_MAXIMUM_TORQUE	0x0600
 
 typedef enum {


### PR DESCRIPTION
Implement cadence input check to ensure the output is forced to zero
when the cranks are not spinning.

This addresses a specific failure mode where a torque sensor could
incorrectly produce a non-zero output even when the rider is not pedaling.
