### PR TITLE
store data after shutdown_hold

### DIFF
--- a/hwconf/shutdown.c
+++ b/hwconf/shutdown.c
@@ -73,15 +73,16 @@ void shutdown_hold(bool hold) {
 }
 
 bool do_shutdown(bool resample) {
-	conf_general_store_backup_data();
 #ifdef USE_LISPBM
 	lispif_process_shutdown();
 #endif
-	chThdSleepMilliseconds(100);
 
 	while (m_shutdown_hold) {
 		chThdSleepMilliseconds(5);
 	}
+
+	conf_general_store_backup_data();
+	chThdSleepMilliseconds(100);
 
 	bool disable_gates = true;
 	if (resample) {


### PR DESCRIPTION
Store data only after shutdown hold has been disabled, this ensure all data to be stored, otherwise some data could be missed if we hold the shutdown for a long period of time.