### PR TITLE
hwconf/*: disable DAC buffer to increase accuracy

### DIFF
--- a/hwconf/other/hw_uxv_sr.c
+++ b/hwconf/other/hw_uxv_sr.c
@@ -265,7 +265,7 @@ THD_FUNCTION(dac_thread, arg) {
 	chRegSetThreadName("DAC");
 	chThdSleepMilliseconds(3000);
 	RCC_APB1PeriphClockCmd(RCC_APB1Periph_DAC, ENABLE);
-	DAC->CR |= DAC_CR_EN2;
+	DAC->CR |= DAC_CR_EN2 | DAC_CR_BOFF2;
 	//DAC->CR |= DAC_CR_BOFF2;
 	
 

--- a/hwconf/trampa/100_250_MKIII/hw_100_250_mkiii_core.c
+++ b/hwconf/trampa/100_250_MKIII/hw_100_250_mkiii_core.c
@@ -118,7 +118,7 @@ void hw_init_gpio(void) {
 	// DAC as voltage reference for shunt amps
 	palSetPadMode(GPIOA, 4, PAL_MODE_INPUT_ANALOG);
 	RCC_APB1PeriphClockCmd(RCC_APB1Periph_DAC, ENABLE);
-	DAC->CR |= DAC_CR_EN1;
+	DAC->CR |= DAC_CR_EN1 | DAC_CR_BOFF1;
 	DAC->DHR12R1 = 2047;
 }
 

--- a/hwconf/trampa/rb/hw_rb_core.c
+++ b/hwconf/trampa/rb/hw_rb_core.c
@@ -140,7 +140,7 @@ void hw_init_gpio(void) {
 	// DAC as voltage reference for shunt amps
 	palSetPadMode(GPIOA, 4, PAL_MODE_INPUT_ANALOG);
 	RCC_APB1PeriphClockCmd(RCC_APB1Periph_DAC, ENABLE);
-	DAC->CR |= DAC_CR_EN1;
+	DAC->CR |= DAC_CR_EN1 | DAC_CR_BOFF1;
 	DAC->DHR12R1 = 2047;
 
 	palSetPadMode(BRAKE_SW_GPIO, BRAKE_SW_PIN, PAL_MODE_INPUT);

--- a/hwconf/trampa/sparkf/hw_sparkf_core.c
+++ b/hwconf/trampa/sparkf/hw_sparkf_core.c
@@ -126,7 +126,7 @@ void hw_init_gpio(void) {
 	// DAC as voltage reference for shunt amps
 	palSetPadMode(GPIOA, 4, PAL_MODE_INPUT_ANALOG);
 	RCC_APB1PeriphClockCmd(RCC_APB1Periph_DAC, ENABLE);
-	DAC->CR |= DAC_CR_EN1;
+	DAC->CR |= DAC_CR_EN1 | DAC_CR_BOFF1;
 	DAC->DHR12R1 = 2047;
 
 	lispif_add_ext_load_callback(load_extensions);

--- a/hwconf/trampa/str500/hw_str500_core.c
+++ b/hwconf/trampa/str500/hw_str500_core.c
@@ -119,7 +119,7 @@ void hw_init_gpio(void) {
 	// DAC as voltage reference for shunt amps
 	palSetPadMode(GPIOA, 4, PAL_MODE_INPUT_ANALOG);
 	RCC_APB1PeriphClockCmd(RCC_APB1Periph_DAC, ENABLE);
-	DAC->CR |= DAC_CR_EN1;
+	DAC->CR |= DAC_CR_EN1 | DAC_CR_BOFF1;
 	DAC->DHR12R1 = 2047;
 }
 

--- a/hwconf/trampa/vesc6/hw_60_core.c
+++ b/hwconf/trampa/vesc6/hw_60_core.c
@@ -149,7 +149,7 @@ void hw_init_gpio(void) {
 	// DAC as voltage reference for shunt amps
 	palSetPadMode(GPIOA, 4, PAL_MODE_INPUT_ANALOG);
 	RCC_APB1PeriphClockCmd(RCC_APB1Periph_DAC, ENABLE);
-	DAC->CR |= DAC_CR_EN1;
+	DAC->CR |= DAC_CR_EN1 | DAC_CR_BOFF1;
 	DAC->DHR12R1 = 2047;
 #endif
 

--- a/hwconf/trampa/vesc_edu/hw_edu_core.c
+++ b/hwconf/trampa/vesc_edu/hw_edu_core.c
@@ -124,7 +124,7 @@ void hw_init_gpio(void) {
 	// DAC as voltage reference for shunt amps
 	palSetPadMode(GPIOA, 4, PAL_MODE_INPUT_ANALOG);
 	RCC_APB1PeriphClockCmd(RCC_APB1Periph_DAC, ENABLE);
-	DAC->CR |= DAC_CR_EN1;
+	DAC->CR |= DAC_CR_EN1 | DAC_CR_BOFF1;
 	DAC->DHR12R1 = 2047;
 
 	terminal_register_command_callback(

--- a/hwconf/trampa/vesc_gp/hw_gp_core.c
+++ b/hwconf/trampa/vesc_gp/hw_gp_core.c
@@ -113,7 +113,7 @@ void hw_init_gpio(void) {
 	// DAC as voltage reference for shunt amps
 	palSetPadMode(GPIOA, 4, PAL_MODE_INPUT_ANALOG);
 	RCC_APB1PeriphClockCmd(RCC_APB1Periph_DAC, ENABLE);
-	DAC->CR |= DAC_CR_EN1;
+	DAC->CR |= DAC_CR_EN1 | DAC_CR_BOFF1;
 	DAC->DHR12R1 = 2047;
 }
 

--- a/hwconf/vesc/basic/hw_basic_core.c
+++ b/hwconf/vesc/basic/hw_basic_core.c
@@ -157,7 +157,7 @@ void hw_init_gpio(void) {
 	// DAC as voltage reference for shunt amps
 	palSetPadMode(GPIOA, 4, PAL_MODE_INPUT_ANALOG);
 	RCC_APB1PeriphClockCmd(RCC_APB1Periph_DAC, ENABLE);
-	DAC->CR |= DAC_CR_EN1;
+	DAC->CR |= DAC_CR_EN1 | DAC_CR_BOFF1;
 	DAC->DHR12R1 = 2047;
 
 	palSetPadMode(OUT_1_GPIO, OUT_1_PIN, PAL_MODE_OUTPUT_PUSHPULL | PAL_STM32_OSPEED_HIGHEST);

--- a/hwconf/vesc/str365/hw_str365_core.c
+++ b/hwconf/vesc/str365/hw_str365_core.c
@@ -175,12 +175,12 @@ void hw_init_gpio(void) {
 	// DAC as voltage reference for shunt amps
 	palSetPadMode(GPIOA, 4, PAL_MODE_INPUT_ANALOG);
 	RCC_APB1PeriphClockCmd(RCC_APB1Periph_DAC, ENABLE);
-	DAC->CR |= DAC_CR_EN1;
+	DAC->CR |= DAC_CR_EN1 | DAC_CR_BOFF1;
 	DAC->DHR12R1 = 2047;
 
 	// Regulator
 	palSetPadMode(GPIOA, 5, PAL_MODE_INPUT_ANALOG);
-	DAC->CR |= DAC_CR_EN2;
+	DAC->CR |= DAC_CR_EN2 | DAC_CR_BOFF2;
 	DAC->DHR12R2 = 4095;
 
 	REG_OFF();


### PR DESCRIPTION
According to the STM32F4 datasheet, the ADC is equipped with a buffer for being able to drive external loads directly. This buffer negatively impacts accuracy, though. The offset can be as high as 0.2V.

Thus, disable the buffer by setting the BOFFx flag.

This was verified on a STM32 nucleo64 F446RE by reading the DAC voltage back via ADC and comparing results with and without BOFFx=1. The output voltage was verified (calibrated DMM BM789) to be correct with BOFFx=1.

Reference:
STM DS8626 STM32F40xxx Rev 9
 - 5.3.25 DAC electrical characteristics
 - Figure 53. 12-bit buffered non-buffered DAC