### PR TITLE
"Fix critical shutdown bug in spintend ubox"

### DIFF
--- a/hwconf/Ubox/100v/hw_ubox_100_core.h
+++ b/hwconf/Ubox/100v/hw_ubox_100_core.h
@@ -22,6 +22,8 @@
 #ifndef HW_UBOX_V2_100_CORE_H_
 #define HW_UBOX_V2_100_CORE_H_
 
+#define HW_SHUTDOWN_CUSTOM
+
 #ifdef HW_UBOX_V2_100
 #define HW_NAME					"UBOX_V2_100"
 #elif defined (HW_UBOX_SINGLE_100)

--- a/hwconf/shutdown.c
+++ b/hwconf/shutdown.c
@@ -26,7 +26,9 @@
 #include "lispif.h"
 #endif
 
-#ifdef HW_SHUTDOWN_HOLD_ON
+#ifdef HW_SHUTDOWN_CUSTOM
+// Do nothing. All shutdown functionality is handled in the hardware file.
+#elif defined(HW_SHUTDOWN_HOLD_ON)
 
 // Private variables
 bool volatile m_button_pressed = false;


### PR DESCRIPTION
In 6.02 there was #ifdef HW_SHUTDOWN_HOLD_ON in shutdown.c. In hw_ubox_100_core.h we do not define HW_SHUTDOWN_HOLD_ON so none of that shutdown code is included.

In 6.05 this was changed to split up sections in shutdown.c for HW_SHUTDOWN_HOLD_ON and then an else statement for latching switches (to support COMM_SHUTDOWN I assume).

Therefore in 6.05, the ubox still doesn’t have HW_SHUTDOWN_HOLD_ON defined, but since there’s an else statement in  shutdown.c it will now include that code which completely fucks up the ubox implementation.

I have resolved this by Including a #ifdef HW_SHUTDOWN_CUSTOM in shutdown.c and then refactoring a few functions in hw_ubox_100_core.c so they are compatible with how shutdown_init() and do_shutdown() are called now in the rest of the code to support COMM_SHUTDOWN.