### PR TITLE
Zero vector frequency randomization

### DIFF
--- a/confgenerator.c
+++ b/confgenerator.c
@@ -64,6 +64,7 @@ int32_t confgenerator_serialize_mcconf(uint8_t *buffer, const mc_configuration *
 	buffer_append_float32_auto(buffer, conf->foc_current_kp, &ind);
 	buffer_append_float32_auto(buffer, conf->foc_current_ki, &ind);
 	buffer_append_float32_auto(buffer, conf->foc_f_zv, &ind);
+	buffer_append_uint32(buffer, conf->foc_f_zv_bandwidth_pct, &ind);
 	buffer_append_float32_auto(buffer, conf->foc_dt_us, &ind);
 	buffer[ind++] = conf->foc_encoder_inverted;
 	buffer_append_float32_auto(buffer, conf->foc_encoder_offset, &ind);
@@ -400,6 +401,7 @@ bool confgenerator_deserialize_mcconf(const uint8_t *buffer, mc_configuration *c
 	conf->foc_current_kp = buffer_get_float32_auto(buffer, &ind);
 	conf->foc_current_ki = buffer_get_float32_auto(buffer, &ind);
 	conf->foc_f_zv = buffer_get_float32_auto(buffer, &ind);
+	conf->foc_f_zv_bandwidth_pct = buffer_get_uint32(buffer, &ind);
 	conf->foc_dt_us = buffer_get_float32_auto(buffer, &ind);
 	conf->foc_encoder_inverted = buffer[ind++];
 	conf->foc_encoder_offset = buffer_get_float32_auto(buffer, &ind);
@@ -732,6 +734,7 @@ void confgenerator_set_defaults_mcconf(mc_configuration *conf) {
 	conf->foc_current_kp = MCCONF_FOC_CURRENT_KP;
 	conf->foc_current_ki = MCCONF_FOC_CURRENT_KI;
 	conf->foc_f_zv = MCCONF_FOC_F_ZV;
+	conf->foc_f_zv_bandwidth_pct = MCCONF_FOC_F_ZV_BANDWIDTH_PCT;
 	conf->foc_dt_us = MCCONF_FOC_DT_US;
 	conf->foc_encoder_inverted = MCCONF_FOC_ENCODER_INVERTED;
 	conf->foc_encoder_offset = MCCONF_FOC_ENCODER_OFFSET;

--- a/confgenerator.h
+++ b/confgenerator.h
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 
 // Constants
-#define MCCONF_SIGNATURE		1065524471
+#define MCCONF_SIGNATURE		2002097102
 #define APPCONF_SIGNATURE		2099347128
 
 // Functions

--- a/datatypes.h
+++ b/datatypes.h
@@ -425,6 +425,7 @@ typedef struct {
 	float foc_current_kp;
 	float foc_current_ki;
 	float foc_f_zv;
+	float foc_f_zv_bandwidth;
 	float foc_dt_us;
 	float foc_encoder_offset;
 	bool foc_encoder_inverted;

--- a/datatypes.h
+++ b/datatypes.h
@@ -425,7 +425,7 @@ typedef struct {
 	float foc_current_kp;
 	float foc_current_ki;
 	float foc_f_zv;
-	float foc_f_zv_bandwidth;
+	uint32_t foc_f_zv_bandwidth_pct;
 	float foc_dt_us;
 	float foc_encoder_offset;
 	bool foc_encoder_inverted;

--- a/motor/mcconf_default.h
+++ b/motor/mcconf_default.h
@@ -262,6 +262,9 @@
 #ifndef MCCONF_FOC_F_ZV
 #define MCCONF_FOC_F_ZV					25000.0
 #endif
+#ifndef MCCONF_FOC_F_ZV_BANDWIDTH_PCT
+#define MCCONF_FOC_F_ZV_BANDWIDTH_PCT	0
+#endif
 #ifndef MCCONF_FOC_DT_US
 #define MCCONF_FOC_DT_US				0.12 // Microseconds for dead time compensation
 #endif

--- a/motor/mcpwm_foc.c
+++ b/motor/mcpwm_foc.c
@@ -79,31 +79,35 @@ static volatile bool pid_thd_stop;
 
 // Macros
 #ifdef HW_HAS_3_SHUNTS
-#define TIMER_UPDATE_DUTY_M1(duty1, duty2, duty3) \
+#define TIMER_UPDATE_DUTY_M1(top, duty1, duty2, duty3) \
 		TIM1->CR1 |= TIM_CR1_UDIS; \
 		TIM1->CCR1 = duty1; \
 		TIM1->CCR2 = duty2; \
 		TIM1->CCR3 = duty3; \
+		TIM1->ARR = top; \
 		TIM1->CR1 &= ~TIM_CR1_UDIS;
 
-#define TIMER_UPDATE_DUTY_M2(duty1, duty2, duty3) \
+#define TIMER_UPDATE_DUTY_M2(top, duty1, duty2, duty3) \
 		TIM8->CR1 |= TIM_CR1_UDIS; \
 		TIM8->CCR1 = duty1; \
 		TIM8->CCR2 = duty2; \
 		TIM8->CCR3 = duty3; \
+		TIM8->ARR = top; \
 		TIM8->CR1 &= ~TIM_CR1_UDIS;
 #else
-#define TIMER_UPDATE_DUTY_M1(duty1, duty2, duty3) \
+#define TIMER_UPDATE_DUTY_M1(top, duty1, duty2, duty3) \
 		TIM1->CR1 |= TIM_CR1_UDIS; \
 		TIM1->CCR1 = duty1; \
 		TIM1->CCR2 = duty3; \
 		TIM1->CCR3 = duty2; \
+		TIM1->ARR = top; \
 		TIM1->CR1 &= ~TIM_CR1_UDIS;
-#define TIMER_UPDATE_DUTY_M2(duty1, duty2, duty3) \
+#define TIMER_UPDATE_DUTY_M2(top, duty1, duty2, duty3) \
 		TIM8->CR1 |= TIM_CR1_UDIS; \
 		TIM8->CCR1 = duty1; \
 		TIM8->CCR2 = duty3; \
 		TIM8->CCR3 = duty2; \
+		TIM8->ARR = top; \
 		TIM8->CR1 &= ~TIM_CR1_UDIS;
 #endif
 
@@ -2474,7 +2478,8 @@ int mcpwm_foc_dc_cal(bool cal_undriven) {
 	float current_sum[3] = {0.0, 0.0, 0.0};
 	float voltage_sum[3] = {0.0, 0.0, 0.0};
 
-	TIMER_UPDATE_DUTY_M1(TIM1->ARR / 2, TIM1->ARR / 2, TIM1->ARR / 2);
+	const uint32_t top = SYSTEM_CORE_CLOCK / (int)m_motor_1.m_conf->foc_f_zv;
+	TIMER_UPDATE_DUTY_M1(top, top / 2, top / 2, top / 2);
 
 	// Start PWM on phase 1
 	stop_pwm_hw((motor_all_state_t*)&m_motor_1);
@@ -2487,7 +2492,7 @@ int mcpwm_foc_dc_cal(bool cal_undriven) {
 #ifdef HW_HAS_DUAL_MOTORS
 	float current_sum_m2[3] = {0.0, 0.0, 0.0};
 	float voltage_sum_m2[3] = {0.0, 0.0, 0.0};
-	TIMER_UPDATE_DUTY_M2(TIM8->ARR / 2, TIM8->ARR / 2, TIM8->ARR / 2);
+	TIMER_UPDATE_DUTY_M2(top / 2, top / 2, top / 2);
 
 	stop_pwm_hw((motor_all_state_t*)&m_motor_2);
 	PHASE_FILTER_ON_M2();
@@ -2683,7 +2688,8 @@ int mcpwm_foc_dc_cal(bool cal_undriven) {
 	float current_sum[3] = {0.0, 0.0, 0.0};
 	float voltage_sum[3] = {0.0, 0.0, 0.0};
 
-	TIMER_UPDATE_DUTY_M1(TIM1->ARR / 2, TIM1->ARR / 2, TIM1->ARR / 2);
+	const uint32_t top = SYSTEM_CORE_CLOCK / (int)m_motor_1.m_conf->foc_f_zv;
+	TIMER_UPDATE_DUTY_M1(top, top / 2, top / 2, top / 2);
 
 	stop_pwm_hw((motor_all_state_t*)&m_motor_1);
 	PHASE_FILTER_ON();
@@ -2850,6 +2856,7 @@ void mcpwm_foc_adc_int_handler(void *p, uint32_t flags) {
 
 	mc_configuration *conf_now = motor_now->m_conf;
 	mc_configuration *conf_other = motor_other->m_conf;
+	const uint32_t top = SYSTEM_CORE_CLOCK / (int)conf_other->foc_f_zv;
 
 	bool skip_interpolation = motor_other->m_cc_was_hfi;
 
@@ -2874,9 +2881,9 @@ void mcpwm_foc_adc_int_handler(void *p, uint32_t flags) {
 		float curr0 = (GET_CURRENT1() - conf_other->foc_offsets_current[0]) * FAC_CURRENT1;
 		float curr1 = (GET_CURRENT2() - conf_other->foc_offsets_current[1]) * FAC_CURRENT2;
 
-		TIMER_UPDATE_DUTY_M1(motor_other->m_duty1_next, motor_other->m_duty2_next, motor_other->m_duty3_next);
+		TIMER_UPDATE_DUTY_M1(top, motor_other->m_duty1_next, motor_other->m_duty2_next, motor_other->m_duty3_next);
 #ifdef HW_HAS_DUAL_PARALLEL
-		TIMER_UPDATE_DUTY_M2(motor_other->m_duty1_next, motor_other->m_duty2_next, motor_other->m_duty3_next);
+		TIMER_UPDATE_DUTY_M2(top, motor_other->m_duty1_next, motor_other->m_duty2_next, motor_other->m_duty3_next);
 #endif
 #endif
 
@@ -2922,8 +2929,7 @@ void mcpwm_foc_adc_int_handler(void *p, uint32_t flags) {
 		state_m->mod_alpha_raw = c * state_m->mod_d - s * state_m->mod_q;
 		state_m->mod_beta_raw  = c * state_m->mod_q + s * state_m->mod_d;
 
-		uint32_t duty1, duty2, duty3, top;
-		top = TIM1->ARR;
+		uint32_t duty1, duty2, duty3;
 		foc_svm(state_m->mod_alpha_raw, state_m->mod_beta_raw,
 				top, &duty1, &duty2, &duty3, (uint32_t*)&state_m->svm_sector);
 
@@ -2939,7 +2945,7 @@ void mcpwm_foc_adc_int_handler(void *p, uint32_t flags) {
 #endif
 		}
 #else
-		TIMER_UPDATE_DUTY_M1(duty1, duty2, duty3);
+		TIMER_UPDATE_DUTY_M1(top, duty1, duty2, duty3);
 #endif
 	}
 
@@ -4652,11 +4658,11 @@ static void control_current(motor_all_state_t *motor, float dt) {
 				state_m->mod_beta_raw = mod_beta_v0;
 			}
 #endif
-
+			const uint32_t top = SYSTEM_CORE_CLOCK / (int)motor->m_conf->foc_f_zv;
 			// Delay adding the HFI voltage when not sampling in both 0 vectors, as it will cancel
 			// itself with the opposite pulse from the previous HFI sample. This makes more sense
 			// when drawing the SVM waveform.
-			foc_svm(mod_alpha_v7, mod_beta_v7, TIM1->ARR,
+			foc_svm(mod_alpha_v7, mod_beta_v7, top,
 				(uint32_t*)&motor->m_duty1_next,
 				(uint32_t*)&motor->m_duty2_next,
 				(uint32_t*)&motor->m_duty3_next,
@@ -4681,21 +4687,21 @@ static void control_current(motor_all_state_t *motor, float dt) {
 	}
 
 	// Set output (HW Dependent)
-	uint32_t duty1, duty2, duty3, top;
-	top = TIM1->ARR;
+	uint32_t duty1, duty2, duty3;
+	const uint32_t top = SYSTEM_CORE_CLOCK / (int)conf_now->foc_f_zv;
 
 	// Calculate the duty cycles for all the phases. This also injects a zero modulation signal to
 	// be able to fully utilize the bus voltage. See https://microchipdeveloper.com/mct5001:start
 	foc_svm(state_m->mod_alpha_raw, state_m->mod_beta_raw, top, &duty1, &duty2, &duty3, (uint32_t*)&state_m->svm_sector);
 
 	if (motor == &m_motor_1) {
-		TIMER_UPDATE_DUTY_M1(duty1, duty2, duty3);
+		TIMER_UPDATE_DUTY_M1(top, duty1, duty2, duty3);
 #ifdef HW_HAS_DUAL_PARALLEL
-		TIMER_UPDATE_DUTY_M2(duty1, duty2, duty3);
+		TIMER_UPDATE_DUTY_M2(top, duty1, duty2, duty3);
 #endif
 	} else {
 #ifndef HW_HAS_DUAL_PARALLEL
-		TIMER_UPDATE_DUTY_M2(duty1, duty2, duty3);
+		TIMER_UPDATE_DUTY_M2(top, duty1, duty2, duty3);
 #endif
 	}
 


### PR DESCRIPTION
Adds Zero vector randomization so the acoustic profile of FET switching is less annoying.

I tested this change on my Floatwheel and made sure that `all_fw` target builds without issues.

I don't have a good way of testing this change on a dual-motor setup, any tips on how to do this would be appreciated.