### PR TITLE
Add support for hwconf env variables and user git commit details in `fw_info`

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -243,4 +243,3 @@ endif
 GIT_BRANCH_NAME := $(shell git rev-parse --abbrev-ref HEAD)
 GIT_COMMIT_HASH := $(shell git rev-parse --short HEAD)
 GIT_DIRTY_LABEL := $(shell git diff --quiet || echo -dirty)
-

--- a/terminal.c
+++ b/terminal.c
@@ -1127,10 +1127,17 @@ void terminal_process_string(char *str) {
 				commands_printf("Invalid arguments\n");
 			}
 		}
-	} else if (strcmp(argv[0], "fwinfo") == 0) {
-		commands_printf("GIT Branch: %s", GIT_BRANCH_NAME);
-		commands_printf("GIT Hash  : %s", GIT_COMMIT_HASH);
-		commands_printf("Compiler  : %s\n", ARM_GCC_VERSION);
+	} else if (strcmp(argv[0], "fw_info") == 0) {
+		commands_printf("Git Branch: %s", GIT_BRANCH_NAME);
+		commands_printf("Git Hash  : %s", GIT_COMMIT_HASH);
+		commands_printf("Compiler  : %s", ARM_GCC_VERSION);
+#ifdef USER_GIT_BRANCH_NAME
+		commands_printf("User Git Branch: %s", USER_GIT_BRANCH_NAME);
+#endif
+#ifdef USER_GIT_COMMIT_HASH
+		commands_printf("User Git Hash  : %s", USER_GIT_COMMIT_HASH);
+#endif
+		commands_printf(" ");
 	} else if (strcmp(argv[0], "rebootwdt") == 0) {
 		chSysLock();
 		for (;;) {__NOP();}
@@ -1246,7 +1253,7 @@ void terminal_process_string(char *str) {
 		commands_printf("update_pid_pos_offset [angle_now] [store]");
 		commands_printf("  Update position PID offset.");
 
-		commands_printf("fwinfo");
+		commands_printf("fw_info");
 		commands_printf("  Print detailed firmware info.");
 
 		commands_printf("rebootwdt");


### PR DESCRIPTION
Added support for supplying custom hw configuration files through environment variables `HW_SRC` and `HW_HEADER`, avoiding the need to modify the tree content.

Also renamed the `fwinfo` command to `fw_info` to make it consistent with other commands. There is now also an option to specify user git commit details when building meant for projects with their own repo which use bldc. These are then also printed by `fw_info`.

I've also opened similar PRs for the other VESC firmwares:
- https://github.com/vedderb/vesc_bms_fw/pull/21
- https://github.com/vedderb/vesc_gpstm/pull/1
- https://github.com/vedderb/vesc_express/pull/44
