### PR TITLE
tools.mk: updated curl commands to replace (depricated?) flag --continue with -C

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -37,7 +37,7 @@ ifneq ($(OSFAMILY), windows)
 	# binary only release so just extract it
 	$(V1) tar -C $(TOOLS_DIR) -xjf "$(DL_DIR)/$(ARM_SDK_FILE)"
 else
-	$(V1) curl --continue - --location --insecure --output "$(DL_DIR)/$(ARM_SDK_FILE)" "$(ARM_SDK_URL)"
+	$(V1) curl -C - --location --insecure --output "$(DL_DIR)/$(ARM_SDK_FILE)" "$(ARM_SDK_URL)"
 	$(V1) powershell -noprofile -command Expand-Archive -DestinationPath $(ARM_SDK_DIR) -LiteralPath "$(DL_DIR)/$(ARM_SDK_FILE)"
 
 endif
@@ -203,7 +203,7 @@ ifneq ($(OSFAMILY), windows)
 	$(V1) $(MKDIR) "$(GTEST_DIR)"
 	$(V1) unzip -q -d "$(TOOLS_DIR)" "$(DL_DIR)/$(GTEST_FILE)"
 else
-	$(V1) curl --continue - --location --insecure --output "$(DL_DIR)/$(GTEST_FILE)" "$(GTEST_URL)"
+	$(V1) curl -C - --location --insecure --output "$(DL_DIR)/$(GTEST_FILE)" "$(GTEST_URL)"
 	$(V1) powershell -noprofile -command Expand-Archive -DestinationPath $(GTEST_DIR) -LiteralPath "$(DL_DIR)/$(GTEST_FILE)"
 endif
 


### PR DESCRIPTION
On curl 8.9.1 (Windows), `make arm_sdk_install` returned the following error:

```
make arm_sdk_install
...
curl: option --continue: is unknown
curl: try 'curl --help' for more information
make: *** [C:/Users/Tshud/Documents/GitHub/bldc/make/tools.mk:40: arm_sdk_install] Error 2
```

At some point, curl replaced --continue with --continue-at (shorthand -C, which appears to have stayed consistent between the change, thus replacing with -C in `tools.mk`)