### PR TITLE
custom IMU adjustments function

### DIFF
--- a/imu/imu.c
+++ b/imu/imu.c
@@ -517,6 +517,22 @@ static void imu_read_callback(float *accel, float *gyro, float *mag) {
 		imu_ready = true;
 	}
 
+#ifdef IMU_CUSTOM_FUNC
+	IMU_CUSTOM_FUNC;
+#endif // IMU_CUSTOM_FUNC
+
+#ifdef IMU_ROT_Y_270
+	float a2_old = accel[2];
+	float g2_old = gyro[2];
+	float m2_old = mag[2];
+	accel[2] = accel[0];
+	accel[0] = -a2_old;
+	gyro[2] = gyro[0];
+	gyro[0] = -g2_old;
+	mag[2] = mag[0];
+	mag[0] = -m2_old;
+#endif
+
 #ifdef IMU_FLIP
 	accel[0] *= -1.0;
 	accel[2] *= -1.0;


### PR DESCRIPTION
Feature addition to imu.c to add the following:
An optional define, IMU_ROT_Y_270, which can be set in the board file to rotate the IMU outputs by 270deg along the y axis
An optional define, IMU_CUSTOM_FUNC, which can be set in the board file as a function which performs a runtime adjustment of IMU output, without needing to use the IMU appconfig.

This allows a system of VESC motors, with their IMU's set in different orientations (say a PCB rotated 90deg along an axis), to have the same orientation result to the user/VESCTool, or, for a runtime-adjustable transformation depending on (for example) hardware pin straps.
