### PR TITLE
support canbus error returns when transmitting

### DIFF
--- a/comm/comm_can.h
+++ b/comm/comm_can.h
@@ -30,10 +30,10 @@
 void comm_can_init(void);
 CAN_BAUD comm_can_kbits_to_baud(int kbits);
 void comm_can_set_baud(CAN_BAUD baud, int delay_msec);
-void comm_can_transmit_eid(uint32_t id, const uint8_t *data, uint8_t len);
-void comm_can_transmit_eid_if(uint32_t id, const uint8_t *data, uint8_t len, int interface);
-void comm_can_transmit_eid_replace(uint32_t id, const uint8_t *data, uint8_t len, bool replace, int interface);
-void comm_can_transmit_sid(uint32_t id, const uint8_t *data, uint8_t len);
+msg_t comm_can_transmit_eid(uint32_t id, const uint8_t *data, uint8_t len);
+msg_t comm_can_transmit_eid_if(uint32_t id, const uint8_t *data, uint8_t len, int interface);
+msg_t comm_can_transmit_eid_replace(uint32_t id, const uint8_t *data, uint8_t len, bool replace, int interface);
+msg_t comm_can_transmit_sid(uint32_t id, const uint8_t *data, uint8_t len);
 void comm_can_set_sid_rx_callback(bool (*p_func)(uint32_t id, uint8_t *data, uint8_t len));
 void comm_can_set_eid_rx_callback(bool (*p_func)(uint32_t id, uint8_t *data, uint8_t len));
 void comm_can_send_buffer(uint8_t controller_id, uint8_t *data, unsigned int len, uint8_t send);

--- a/lispBM/c_libs/vesc_c_if.h
+++ b/lispBM/c_libs/vesc_c_if.h
@@ -394,8 +394,8 @@ typedef struct {
 	// CAN
 	void (*can_set_sid_cb)(bool (*p_func)(uint32_t id, uint8_t *data, uint8_t len));
 	void (*can_set_eid_cb)(bool (*p_func)(uint32_t id, uint8_t *data, uint8_t len));
-	msg_t (*can_transmit_sid)(uint32_t id, const uint8_t *data, uint8_t len);
-	msg_t (*can_transmit_eid)(uint32_t id, const uint8_t *data, uint8_t len);
+	void (*can_transmit_sid)(uint32_t id, const uint8_t *data, uint8_t len);
+	void (*can_transmit_eid)(uint32_t id, const uint8_t *data, uint8_t len);
 	void (*can_send_buffer)(uint8_t controller_id, uint8_t *data, unsigned int len, uint8_t send);
 	void (*can_set_duty)(uint8_t controller_id, float duty);
 	void (*can_set_current)(uint8_t controller_id, float current);

--- a/lispBM/c_libs/vesc_c_if.h
+++ b/lispBM/c_libs/vesc_c_if.h
@@ -394,8 +394,8 @@ typedef struct {
 	// CAN
 	void (*can_set_sid_cb)(bool (*p_func)(uint32_t id, uint8_t *data, uint8_t len));
 	void (*can_set_eid_cb)(bool (*p_func)(uint32_t id, uint8_t *data, uint8_t len));
-	void (*can_transmit_sid)(uint32_t id, const uint8_t *data, uint8_t len);
-	void (*can_transmit_eid)(uint32_t id, const uint8_t *data, uint8_t len);
+	msg_t (*can_transmit_sid)(uint32_t id, const uint8_t *data, uint8_t len);
+	msg_t (*can_transmit_eid)(uint32_t id, const uint8_t *data, uint8_t len);
 	void (*can_send_buffer)(uint8_t controller_id, uint8_t *data, unsigned int len, uint8_t send);
 	void (*can_set_duty)(uint8_t controller_id, float duty);
 	void (*can_set_current)(uint8_t controller_id, float current);

--- a/lispBM/lispif_c_lib.c
+++ b/lispBM/lispif_c_lib.c
@@ -687,6 +687,14 @@ static int lib_lbm_set_error_reason(char *str) {
 	return 1;
 }
 
+static void comm_can_transmit_sid_wrapper(uint32_t id, const uint8_t *data, uint8_t len) {
+	comm_can_transmit_sid(id, data, len);
+}
+
+static void comm_can_transmit_eid_wrapper(uint32_t id, const uint8_t *data, uint8_t len) {
+	comm_can_transmit_eid(id, data, len);
+}
+
 lbm_value ext_load_native_lib(lbm_value *args, lbm_uint argn) {
 	lbm_value res = lbm_enc_sym(SYM_EERROR);
 
@@ -777,8 +785,8 @@ lbm_value ext_load_native_lib(lbm_value *args, lbm_uint argn) {
 		// CAN
 		cif.cif.can_set_sid_cb = comm_can_set_sid_rx_callback;
 		cif.cif.can_set_eid_cb = comm_can_set_eid_rx_callback;
-		cif.cif.can_transmit_sid = comm_can_transmit_sid;
-		cif.cif.can_transmit_eid = comm_can_transmit_eid;
+		cif.cif.can_transmit_sid = comm_can_transmit_sid_wrapper;
+		cif.cif.can_transmit_eid = comm_can_transmit_eid_wrapper;
 		cif.cif.can_send_buffer = comm_can_send_buffer;
 		cif.cif.can_set_duty = comm_can_set_duty;
 		cif.cif.can_set_current = comm_can_set_current;


### PR DESCRIPTION
return the results of the lower-level can_transmit functions so that calling code can check if a transmission error occurred