### PR TITLE
VESC_IF: Sprinkle with const

### DIFF
--- a/comm/commands.c
+++ b/comm/commands.c
@@ -1961,7 +1961,7 @@ void commands_apply_mcconf_hw_limits(mc_configuration *mcconf) {
 #endif
 }
 
-void commands_init_plot(char *namex, char *namey) {
+void commands_init_plot(const char *namex, const char *namey) {
 	int ind = 0;
 	uint8_t *send_buffer_global = mempools_get_packet_buffer();
 	send_buffer_global[ind++] = COMM_PLOT_INIT;
@@ -1975,7 +1975,7 @@ void commands_init_plot(char *namex, char *namey) {
 	mempools_free_packet_buffer(send_buffer_global);
 }
 
-void commands_plot_add_graph(char *name) {
+void commands_plot_add_graph(const char *name) {
 	int ind = 0;
 	uint8_t *send_buffer_global = mempools_get_packet_buffer();
 	send_buffer_global[ind++] = COMM_PLOT_ADD_GRAPH;

--- a/comm/commands.h
+++ b/comm/commands.h
@@ -48,8 +48,8 @@ void commands_send_mcconf(COMM_PACKET_ID packet_id, mc_configuration* mcconf,
 void commands_send_appconf(COMM_PACKET_ID packet_id, app_configuration* appconf,
     void(*reply_func)(unsigned char* data, unsigned int len));
 void commands_apply_mcconf_hw_limits(mc_configuration *mcconf);
-void commands_init_plot(char *namex, char *namey);
-void commands_plot_add_graph(char *name);
+void commands_init_plot(const char *namex, const char *namey);
+void commands_plot_add_graph(const char *name);
 void commands_plot_set_graph(int graph);
 void commands_send_plot_points(float x, float y);
 int commands_get_fw_version_sent_cnt(void);

--- a/imu/ahrs.c
+++ b/imu/ahrs.c
@@ -56,7 +56,7 @@ void ahrs_init_attitude_info(ATTITUDE_INFO *att) {
 	att->initialUpdateDone = 0;
 }
 
-void ahrs_update_initial_orientation(float *accelXYZ, float *magXYZ, ATTITUDE_INFO *att) {
+void ahrs_update_initial_orientation(const float *accelXYZ, const float *magXYZ, ATTITUDE_INFO *att) {
 	// See https://cache.freescale.com/files/sensors/doc/app_note/AN4248.pdf
 	// and http://sedris.org/wg8home/Documents/WG80485.pdf
 
@@ -94,7 +94,7 @@ void ahrs_update_initial_orientation(float *accelXYZ, float *magXYZ, ATTITUDE_IN
 	att->q3 = cr * cp * sy - sr * sp * cy;
 }
 
-void ahrs_update_mahony_imu(float *gyroXYZ, float *accelXYZ, float dt, ATTITUDE_INFO *att) {
+void ahrs_update_mahony_imu(const float *gyroXYZ, const float *accelXYZ, float dt, ATTITUDE_INFO *att) {
 	float accelNorm, recipNorm;
 	float qa, qb, qc;
 
@@ -178,7 +178,7 @@ void ahrs_update_mahony_imu(float *gyroXYZ, float *accelXYZ, float dt, ATTITUDE_
 	att->q3 *= recipNorm;
 }
 
-void ahrs_update_madgwick_imu(float *gyroXYZ, float *accelXYZ, float dt, ATTITUDE_INFO *att) {
+void ahrs_update_madgwick_imu(const float *gyroXYZ, const float *accelXYZ, float dt, ATTITUDE_INFO *att) {
 	float accelNorm, recipNorm;
 	float qDot1, qDot2, qDot3, qDot4;
 
@@ -269,7 +269,7 @@ void ahrs_update_madgwick_imu(float *gyroXYZ, float *accelXYZ, float dt, ATTITUD
 	att->q3 = q3;
 }
 
-float ahrs_get_roll(ATTITUDE_INFO *att) {
+float ahrs_get_roll(const ATTITUDE_INFO *att) {
 	const float q0 = att->q0;
 	const float q1 = att->q1;
 	const float q2 = att->q2;
@@ -278,7 +278,7 @@ float ahrs_get_roll(ATTITUDE_INFO *att) {
 	return -atan2f(q0 * q1 + q2 * q3, 0.5 - (q1 * q1 + q2 * q2));
 }
 
-float ahrs_get_pitch(ATTITUDE_INFO *att) {
+float ahrs_get_pitch(const ATTITUDE_INFO *att) {
 	const float q0 = att->q0;
 	const float q1 = att->q1;
 	const float q2 = att->q2;
@@ -287,7 +287,7 @@ float ahrs_get_pitch(ATTITUDE_INFO *att) {
 	return asinf(-2.0 * (q1 * q3 - q0 * q2));
 }
 
-float ahrs_get_yaw(ATTITUDE_INFO *att) {
+float ahrs_get_yaw(const ATTITUDE_INFO *att) {
 	const float q0 = att->q0;
 	const float q1 = att->q1;
 	const float q2 = att->q2;
@@ -296,7 +296,7 @@ float ahrs_get_yaw(ATTITUDE_INFO *att) {
 	return -atan2f(q0 * q3 + q1 * q2, 0.5 - (q2 * q2 + q3 * q3));
 }
 
-void ahrs_get_roll_pitch_yaw(float *rpy, ATTITUDE_INFO *att) {
+void ahrs_get_roll_pitch_yaw(float *rpy, const ATTITUDE_INFO *att) {
 	// See http://math.stackexchange.com/questions/687964/getting-euler-tait-bryan-angles-from-quaternion-representation
 	const float q0 = att->q0;
 	const float q1 = att->q1;

--- a/imu/ahrs.h
+++ b/imu/ahrs.h
@@ -18,14 +18,14 @@
 // Function declarations
 void ahrs_init_attitude_info(ATTITUDE_INFO *att);
 void ahrs_update_all_parameters(ATTITUDE_INFO *att, float confidence_decay, float kp, float ki, float beta);
-void ahrs_update_initial_orientation(float *accelXYZ, float *magXYZ, ATTITUDE_INFO *att);
+void ahrs_update_initial_orientation(const float *accelXYZ, const float *magXYZ, ATTITUDE_INFO *att);
 
-void ahrs_update_mahony_imu(float *gyroXYZ, float *accelXYZ, float dt, ATTITUDE_INFO *att);
-void ahrs_update_madgwick_imu(float *gyroXYZ, float *accelXYZ, float dt, ATTITUDE_INFO *att);
+void ahrs_update_mahony_imu(const float *gyroXYZ, const float *accelXYZ, float dt, ATTITUDE_INFO *att);
+void ahrs_update_madgwick_imu(const float *gyroXYZ, const float *accelXYZ, float dt, ATTITUDE_INFO *att);
 
-float ahrs_get_roll(ATTITUDE_INFO *att);
-float ahrs_get_pitch(ATTITUDE_INFO *att);
-float ahrs_get_yaw(ATTITUDE_INFO *att);
-void ahrs_get_roll_pitch_yaw(float *rpy, ATTITUDE_INFO *att);
+float ahrs_get_roll(const ATTITUDE_INFO *att);
+float ahrs_get_pitch(const ATTITUDE_INFO *att);
+float ahrs_get_yaw(const ATTITUDE_INFO *att);
+void ahrs_get_roll_pitch_yaw(float *rpy, const ATTITUDE_INFO *att);
 
 #endif

--- a/imu/imu.c
+++ b/imu/imu.c
@@ -313,7 +313,7 @@ void imu_get_mag(float *mag) {
 	memcpy(mag, m_mag, sizeof(m_mag));
 }
 
-void imu_derotate(float *input, float *output) {
+void imu_derotate(const float *input, float *output) {
 	float rpy[3];
 	imu_get_rpy(rpy);
 

--- a/imu/imu.h
+++ b/imu/imu.h
@@ -50,7 +50,7 @@ void imu_get_rpy(float *rpy);
 void imu_get_accel(float *accel);
 void imu_get_gyro(float *gyro);
 void imu_get_mag(float *mag);
-void imu_derotate(float *input, float *output);
+void imu_derotate(const float *input, float *output);
 void imu_get_accel_derotated(float *accel);
 void imu_get_gyro_derotated(float *gyro);
 void imu_get_quaternions(float *q);

--- a/lispBM/c_libs/vesc_c_if.h
+++ b/lispBM/c_libs/vesc_c_if.h
@@ -374,7 +374,7 @@ typedef struct {
 	int (*printf)(const char *str, ...);
 	void* (*malloc)(size_t bytes);
 	void (*free)(void *prt);
-	lib_thread (*spawn)(void (*fun)(void *arg), size_t stack_size, char *name, void *arg);
+	lib_thread (*spawn)(void (*fun)(void *arg), size_t stack_size, const char *name, void *arg);
 	void (*request_terminate)(lib_thread thd);
 	bool (*should_terminate)(void);
 	void** (*get_arg)(uint32_t prog_addr);
@@ -490,7 +490,7 @@ typedef struct {
 
 	// UART
 	bool (*uart_start)(uint32_t baudrate, bool half_duplex);
-	bool (*uart_write)(uint8_t *data, uint32_t size);
+	bool (*uart_write)(const uint8_t *data, uint32_t size);
 	int32_t (*uart_read)(void);
 
 	// Packets
@@ -510,7 +510,7 @@ typedef struct {
 	void (*imu_get_accel)(float *accel);
 	void (*imu_get_gyro)(float *gyro);
 	void (*imu_get_mag)(float *mag);
-	void (*imu_derotate)(float *input, float *output);
+	void (*imu_derotate)(const float *input, float *output);
 	void (*imu_get_accel_derotated)(float *accel);
 	void (*imu_get_gyro_derotated)(float *gyro);
 	void (*imu_get_quaternions)(float *q);
@@ -535,8 +535,8 @@ typedef struct {
 	float (*timeout_secs_since_update)(void);
 
 	// Plot
-	void (*plot_init)(char *namex, char *namey);
-	void (*plot_add_graph)(char *name);
+	void (*plot_init)(const char *namex, const char *namey);
+	void (*plot_add_graph)(const char *name);
 	void (*plot_set_graph)(int graph);
 	void (*plot_send_points)(float x, float y);
 
@@ -580,12 +580,12 @@ typedef struct {
 	// IMU AHRS functions and read callback
 	void (*imu_set_read_callback)(void (*func)(float *acc, float *gyro, float *mag, float dt));
 	void (*ahrs_init_attitude_info)(ATTITUDE_INFO *att);
-	void (*ahrs_update_initial_orientation)(float *accelXYZ, float *magXYZ, ATTITUDE_INFO *att);
-	void (*ahrs_update_mahony_imu)(float *gyroXYZ, float *accelXYZ, float dt, ATTITUDE_INFO *att);
-	void (*ahrs_update_madgwick_imu)(float *gyroXYZ, float *accelXYZ, float dt, ATTITUDE_INFO *att);
-	float (*ahrs_get_roll)(ATTITUDE_INFO *att);
-	float (*ahrs_get_pitch)(ATTITUDE_INFO *att);
-	float (*ahrs_get_yaw)(ATTITUDE_INFO *att);
+	void (*ahrs_update_initial_orientation)(const float *accelXYZ, const float *magXYZ, ATTITUDE_INFO *att);
+	void (*ahrs_update_mahony_imu)(const float *gyroXYZ, const float *accelXYZ, float dt, ATTITUDE_INFO *att);
+	void (*ahrs_update_madgwick_imu)(const float *gyroXYZ, const float *accelXYZ, float dt, ATTITUDE_INFO *att);
+	float (*ahrs_get_roll)(const ATTITUDE_INFO *att);
+	float (*ahrs_get_pitch)(const ATTITUDE_INFO *att);
+	float (*ahrs_get_yaw)(const ATTITUDE_INFO *att);
 
 	// Set custom encoder callbacks
 	void (*encoder_set_custom_callbacks)(
@@ -646,7 +646,7 @@ typedef struct {
 	bool (*foc_beep)(float freq, float time, float voltage);
 	bool (*foc_play_tone)(int channel, float freq, float voltage);
 	void (*foc_stop_audio)(bool reset);
-	bool (*foc_set_audio_sample_table)(int channel, float *samples, int len);
+	bool (*foc_set_audio_sample_table)(int channel, const float *samples, int len);
 	const float* (*foc_get_audio_sample_table)(int channel);
 	bool (*foc_play_audio_samples)(const int8_t *samples, int num_samp, float f_samp, float voltage);
 

--- a/lispBM/lispif.h
+++ b/lispBM/lispif.h
@@ -50,6 +50,6 @@ void lispif_process_rmsg(int slot, unsigned char *data, unsigned int len);
 
 void lispif_load_vesc_extensions(void);
 char* lispif_print_prefix(void);
-lib_thread lispif_spawn(void (*func)(void*), size_t stack_size, char *name, void *arg);
+lib_thread lispif_spawn(void (*func)(void*), size_t stack_size, const char *name, void *arg);
 
 #endif /* LISPBM_LISPIF_H_ */

--- a/lispBM/lispif_c_lib.c
+++ b/lispBM/lispif_c_lib.c
@@ -55,7 +55,7 @@ void packet_process_byte(uint8_t rx_data, PACKET_STATE_t *state);
 void packet_send_packet(unsigned char *data, unsigned int len, PACKET_STATE_t *state);
 
 typedef struct {
-	char *name;
+	const char *name;
 	void *arg;
 	void (*func)(void*);
 	void *w_mem;
@@ -94,7 +94,7 @@ static THD_FUNCTION(lib_thd, arg) {
 	lbm_free(t);
 }
 
-lib_thread lispif_spawn(void (*func)(void*), size_t stack_size, char *name, void *arg) {
+lib_thread lispif_spawn(void (*func)(void*), size_t stack_size, const char *name, void *arg) {
 	if (!utils_is_func_valid(func)) {
 		commands_printf_lisp("Invalid function address. Make sure that the function is static.");
 		return 0;
@@ -395,7 +395,7 @@ static void wait_uart_tx_task(void *arg) {
 	HW_UART_DEV.usart->CR1 |= USART_CR1_RE;
 }
 
-static bool lib_uart_write(uint8_t *data, uint32_t size) {
+static bool lib_uart_write(const uint8_t *data, uint32_t size) {
 	if (uart_cfg.cr3 & USART_CR3_HDSEL) {
 		HW_UART_DEV.usart->CR1 &= ~USART_CR1_RE;
 		sdWrite(&HW_UART_DEV, data, size);

--- a/motor/mcpwm_foc.c
+++ b/motor/mcpwm_foc.c
@@ -2180,7 +2180,7 @@ void mcpwm_foc_stop_audio(bool reset) {
 	}
 }
 
-bool mcpwm_foc_set_audio_sample_table(int channel, float *samples, int len) {
+bool mcpwm_foc_set_audio_sample_table(int channel, const float *samples, int len) {
 	if (channel < 0 || channel >= MC_AUDIO_CHANNELS) {
 		return false;
 	}

--- a/motor/mcpwm_foc.h
+++ b/motor/mcpwm_foc.h
@@ -99,7 +99,7 @@ int mcpwm_foc_measure_inductance_current(float curr_goal, int samples, float *cu
 bool mcpwm_foc_beep(float freq, float time, float voltage);
 bool mcpwm_foc_play_tone(int channel, float freq, float voltage);
 void mcpwm_foc_stop_audio(bool reset);
-bool mcpwm_foc_set_audio_sample_table(int channel, float *samples, int len);
+bool mcpwm_foc_set_audio_sample_table(int channel, const float *samples, int len);
 const float *mcpwm_foc_get_audio_sample_table(int channel);
 bool mcpwm_foc_play_audio_samples(const int8_t *samples, int num_samp, float f_samp, float voltage);
 


### PR DESCRIPTION
Add consts to API function arguments which aren't meant to be changed. This is important on the interface so that const correctness can be preserved on the API usage site.

I had a temporary need for this a while ago (forgot which particular functions I needed this on), ended up not needing it in the end, but when using the API, when one has a const pointer to some data, it gets really awkward if needing to pass it to a VESC_IF function that clearly doesn't modify it but doesn't have it as `const`.

I wasn't entirely thorough with adding the `const`s, but I tried to add all the simple and obvious ones. There are some other pointers where the situation wasn't clear at first glance and I didn't dig deeper.