### PR TITLE
VESC_IF: Add Motor Resistance, Inductance and Flux Linkage to config

### DIFF
--- a/lispBM/c_libs/vesc_c_if.h
+++ b/lispBM/c_libs/vesc_c_if.h
@@ -297,6 +297,11 @@ typedef enum {
 	CFG_PARAM_si_battery_cells,
 	CFG_PARAM_si_battery_ah,
 	CFG_PARAM_si_motor_nl_current,
+
+	// Motor FOC Parameters
+	CFG_PARAM_foc_motor_r,
+	CFG_PARAM_foc_motor_l,
+	CFG_PARAM_foc_motor_flux_linkage,
 } CFG_PARAM;
 
 typedef struct {

--- a/lispBM/lispif_c_lib.c
+++ b/lispBM/lispif_c_lib.c
@@ -463,6 +463,10 @@ static float lib_get_cfg_float(CFG_PARAM p) {
 		case CFG_PARAM_si_battery_ah: res = mcconf->si_battery_ah; break;
 		case CFG_PARAM_si_motor_nl_current: res = mcconf->si_motor_nl_current; break;
 
+		case CFG_PARAM_foc_motor_r: res = mcconf->foc_motor_r; break;
+		case CFG_PARAM_foc_motor_l: res = mcconf->foc_motor_l; break;
+		case CFG_PARAM_foc_motor_flux_linkage: res = mcconf->foc_motor_flux_linkage; break;
+
 		default: break;
 	}
 
@@ -545,6 +549,10 @@ static bool lib_set_cfg_float(CFG_PARAM p, float value) {
 		case CFG_PARAM_si_wheel_diameter: mcconf->si_wheel_diameter = value; changed_mc = 1; res = true; break;
 		case CFG_PARAM_si_battery_ah: mcconf->si_battery_ah = value; changed_mc = 1; res = true; break;
 		case CFG_PARAM_si_motor_nl_current: mcconf->si_motor_nl_current = value; changed_mc = 1; res = true; break;
+
+		case CFG_PARAM_foc_motor_r: mcconf->foc_motor_r = value; changed_mc = 1; res = true; break;
+		case CFG_PARAM_foc_motor_l: mcconf->foc_motor_r = value; changed_mc = 1; res = true; break;
+		case CFG_PARAM_foc_motor_flux_linkage: mcconf->foc_motor_flux_linkage = value; changed_mc = 1; res = true; break;
 		default: break;
 	}
 


### PR DESCRIPTION
Flux Linkage is an important parameter that can be used to estimate the motor power. Also adding R and L as those can be used to calculate the resulting current of foc_play_tone() if that is needed (although, this should not be needed on the package side).