### PR TITLE
HWCONF - JetFleet F6 Variants

### DIFF
--- a/hwconf/JetFleet/hw_JetFleetF6_20s.h
+++ b/hwconf/JetFleet/hw_JetFleetF6_20s.h
@@ -17,11 +17,21 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
     */
 
-#ifndef HW_JetFleetF6_H_
-#define HW_JetFleetF6_H_
+#ifndef HW_JetFleetF6_20s_H_
 
-#define HW_NAME					"JetFleetF6"
+#define HW_JetFleetF6_20s_H_
+
+#define HW_NAME					"JetFleetF6_20s"
+#define HW_JetFleetF6_20s
+
+#define VIN_R2				            4700.0
+#define MCCONF_L_MAX_VOLTAGE			90.0	// Maximum input voltage
+#define MCCONF_L_MAX_ABS_CURRENT		260.0	// The maximum absolute current above which a fault is generated
+#define HW_LIM_CURRENT			        -260.0, 260.0
+#define HW_LIM_CURRENT_ABS		        0.0, 320.0
+#define HW_LIM_VIN			            18.0, 90.0
+
 
 #include "hw_JetFleetF6_core.h"
 
-#endif
+#endif /* HW_JetFleetF6_20s_H_ */

--- a/hwconf/JetFleet/hw_JetFleetF6_24s.h
+++ b/hwconf/JetFleet/hw_JetFleetF6_24s.h
@@ -1,0 +1,37 @@
+/*
+	Copyright 2022 Benjamin Vedder	benjamin@vedder.se
+
+	This file is part of the VESC firmware.
+
+	The VESC firmware is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    The VESC firmware is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    */
+
+#ifndef HW_JetFleetF6_24s_H_
+
+#define HW_JetFleetF6_24s_H_
+
+#define HW_NAME					"JetFleetF6_24s"
+#define HW_JetFleetF6_24s
+
+#define VIN_R2				            4300.0
+#define MCCONF_L_MAX_VOLTAGE			110.0	// Maximum input voltage
+#define MCCONF_L_MAX_ABS_CURRENT		230.0	// The maximum absolute current above which a fault is generated
+#define HW_LIM_CURRENT			        -230.0, 230.0
+#define HW_LIM_CURRENT_ABS		        0.0, 300.0
+#define HW_LIM_VIN			            18.0, 110.0
+
+
+#include "hw_JetFleetF6_core.h"
+
+#endif /* HW_JetFleetF6_24s_H_ */

--- a/hwconf/JetFleet/hw_JetFleetF6_32s.h
+++ b/hwconf/JetFleet/hw_JetFleetF6_32s.h
@@ -1,0 +1,36 @@
+/*
+	Copyright 2022 Benjamin Vedder	benjamin@vedder.se
+
+	This file is part of the VESC firmware.
+
+	The VESC firmware is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    The VESC firmware is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    */
+
+#ifndef HW_JetFleetF6_32s_H_
+
+#define HW_JetFleetF6_32s_H_
+
+#define HW_NAME					"JetFleetF6_32s"
+#define HW_JetFleetF6_32s
+
+#define VIN_R2				    3300.0
+#define MCCONF_L_MAX_VOLTAGE			140.0	// Maximum input voltage
+#define MCCONF_L_MAX_ABS_CURRENT		180.0	// The maximum absolute current above which a fault is generated
+#define HW_LIM_CURRENT			-180.0, 180.0
+#define HW_LIM_CURRENT_ABS		0.0, 270.0
+#define HW_LIM_VIN			    18.0, 140.0
+
+#include "hw_JetFleetF6_core.h"
+
+#endif /* HW_JetFleetF6_32s_H_ */

--- a/hwconf/JetFleet/hw_JetFleetF6_core.h
+++ b/hwconf/JetFleet/hw_JetFleetF6_core.h
@@ -17,242 +17,246 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
     */
 
-#ifndef HW_JetFleetF6_Core_H_
-#define HW_JetFleetF6_Core_H_
-
-// HW properties
-#define HW_HAS_3_SHUNTS
-#define HW_HAS_PHASE_FILTERS
-#define INVERTED_SHUNT_POLARITY
-#define SERVO_BUZZER
-
-// Macros
-#define LED_GREEN_GPIO			GPIOB
-#define LED_GREEN_PIN			2
-#define LED_RED_GPIO			GPIOA
-#define LED_RED_PIN			    15
-
-#define LED_GREEN_ON()			palSetPad(LED_GREEN_GPIO, LED_GREEN_PIN)
-#define LED_GREEN_OFF()			palClearPad(LED_GREEN_GPIO, LED_GREEN_PIN)
-#define LED_RED_ON()			palSetPad(LED_RED_GPIO, LED_RED_PIN)
-#define LED_RED_OFF()			palClearPad(LED_RED_GPIO, LED_RED_PIN)
-
-// Phase filter
-#define PHASE_FILTER_OFF()		palSetPad(GPIOC, 15); palSetPad(GPIOC, 14); palSetPad(GPIOC, 13)
-#define PHASE_FILTER_ON()		palClearPad(GPIOC, 15); palClearPad(GPIOC, 14); palClearPad(GPIOC, 13)
-
-// Shutdown pin
-#define HW_SHUTDOWN_GPIO		    GPIOB
-#define HW_SHUTDOWN_PIN			    0
-#define HW_SHUTDOWN_SENSE_GPIO		GPIOC
-#define HW_SHUTDOWN_SENSE_PIN		5
-#define HW_SHUTDOWN_HOLD_ON()		palSetPad(HW_SHUTDOWN_GPIO, HW_SHUTDOWN_PIN)
-#define HW_SHUTDOWN_HOLD_OFF()		palClearPad(HW_SHUTDOWN_GPIO, HW_SHUTDOWN_PIN)
-#define HW_SAMPLE_SHUTDOWN()		hw_sample_shutdown_button()
-
-// ADC Config
-#define HW_ADC_CHANNELS			18
-#define HW_ADC_INJ_CHANNELS		3
-#define HW_ADC_NBR_CONV			6
-
-// ADC Indexes
-#define ADC_IND_SENS1			3
-#define ADC_IND_SENS2			4
-#define ADC_IND_SENS3			5
-#define ADC_IND_CURR1			0
-#define ADC_IND_CURR2			1
-#define ADC_IND_CURR3			2
-#define ADC_IND_VIN_SENS		11
-#define ADC_IND_EXT			    6
-#define ADC_IND_EXT2			7
-#define ADC_IND_SHUTDOWN		10
-#define ADC_IND_TEMP_MOS		8
-//#define ADC_IND_TEMP_MOS_2    15
-#define ADC_IND_TEMP_MOS_3		16
-#define ADC_IND_TEMP_MOTOR		9
-#define ADC_IND_VREFINT			12
-
-// ADC macros and settings
-
-// Component parameters (can be overridden)
-#ifndef V_REG
-#define V_REG				    3.3
-#endif
-#ifndef VIN_R1
-#define VIN_R1				    150000.0
-#endif
-#ifndef VIN_R2
-#define VIN_R2				    3300.0
-#endif
-#ifndef CURRENT_AMP_GAIN
-#define CURRENT_AMP_GAIN		20.0
-#endif
-#ifndef CURRENT_SHUNT_RES
-#define CURRENT_SHUNT_RES		(0.0005 / 2.0)
-#endif
-
-// Input voltage
-#define GET_INPUT_VOLTAGE()		((V_REG / 4095.0) * (float)ADC_Value[ADC_IND_VIN_SENS] * ((VIN_R1 + VIN_R2) / VIN_R2))
-// NTC Termistors
-#define NTC_RES(adc_val)		(10000.0 / ((4095.0 / (float)adc_val) - 1.0))
-#define NTC_TEMP(adc_ind)		hw_JetFleet_get_temp()
-
-#define NTC_RES_MOTOR(adc_val)		(10000.0 / ((4095.0 / (float)adc_val) - 1.0))
-#define NTC_TEMP_MOTOR(beta)		(1.0 / ((logf(NTC_RES_MOTOR(ADC_Value[ADC_IND_TEMP_MOTOR]) / 10000.0) / beta) + (1.0 / 298.15)) - 273.15)
-
-#define NTC_TEMP_MOS1()			(1.0 / ((logf(NTC_RES(ADC_Value[ADC_IND_TEMP_MOS]) / 10000.0) / 3380.0) + (1.0 / 298.15)) - 273.15)
-//#define NTC_TEMP_MOS2()		(1.0 / ((logf(NTC_RES(ADC_Value[ADC_IND_TEMP_MOS_2]) / 10000.0) / 3380.0) + (1.0 / 298.15)) - 273.15)
-#define NTC_TEMP_MOS3()			(1.0 / ((logf(NTC_RES(ADC_Value[ADC_IND_TEMP_MOS_3]) / 10000.0) / 3380.0) + (1.0 / 298.15)) - 273.15)
-
-// Voltage on ADC channel
-#define ADC_VOLTS(ch)			((float)ADC_Value[ch] / 4096.0 * V_REG)
-
-// Double samples in beginning and end for positive current measurement.
-// Useful when the shunt sense traces have noise that causes offset.
-
-#ifndef CURR1_DOUBLE_SAMPLE
-#define CURR1_DOUBLE_SAMPLE		0
-#endif
-#ifndef CURR2_DOUBLE_SAMPLE
-#define CURR2_DOUBLE_SAMPLE		0
-#endif
-#ifndef CURR3_DOUBLE_SAMPLE
-#define CURR3_DOUBLE_SAMPLE		0
-#endif
-
-// COMM-port ADC GPIOs
-#define HW_ADC_EXT_GPIO			GPIOA
-#define HW_ADC_EXT_PIN			5
-#define HW_ADC_EXT2_GPIO		GPIOA
-#define HW_ADC_EXT2_PIN			6
-
-
-// ICU Peripheral for servo decoding
-#define HW_USE_SERVO_TIM4
-#define HW_ICU_TIMER			TIM4
-#define HW_ICU_TIM_CLK_EN()		RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM4, ENABLE)
-#define HW_ICU_DEV			    ICUD4
-#define HW_ICU_CHANNEL			ICU_CHANNEL_1
-#define HW_ICU_GPIO_AF			GPIO_AF_TIM4
-#define HW_ICU_GPIO			    GPIOB
-#define HW_ICU_PIN			    6
-
-// I2C Peripheral
-#define HW_I2C_DEV			    I2CD2
-#define HW_I2C_GPIO_AF			GPIO_AF_I2C2
-#define HW_I2C_SCL_PORT			GPIOB
-#define HW_I2C_SCL_PIN			12
-#define HW_I2C_SDA_PORT			GPIOC
-#define HW_I2C_SDA_PIN			5
-
-// Hall/encoder pins
-#define HW_HALL_ENC_GPIO1		GPIOC
-#define HW_HALL_ENC_PIN1		6
-#define HW_HALL_ENC_GPIO2		GPIOC
-#define HW_HALL_ENC_PIN2		7
-#define HW_HALL_ENC_GPIO3		GPIOC
-#define HW_HALL_ENC_PIN3		8
-#define HW_ENC_TIM			    TIM3
-#define HW_ENC_TIM_AF			GPIO_AF_TIM3
-#define HW_ENC_TIM_CLK_EN()		RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM3, ENABLE)
-#define HW_ENC_EXTI_PORTSRC		EXTI_PortSourceGPIOC
-#define HW_ENC_EXTI_PINSRC		EXTI_PinSource8
-#define HW_ENC_EXTI_CH			EXTI9_5_IRQn
-#define HW_ENC_EXTI_LINE		EXTI_Line8
-#define HW_ENC_EXTI_ISR_VEC		EXTI9_5_IRQHandler
-#define HW_ENC_TIM_ISR_CH		TIM3_IRQn
-#define HW_ENC_TIM_ISR_VEC		TIM3_IRQHandler
-
-// SPI pins
-#define HW_SPI_DEV			    SPID3
-#define HW_SPI_GPIO_AF			GPIO_AF_SPI3
-#define HW_SPI_PORT_NSS			GPIOA
-#define HW_SPI_PIN_NSS			4
-#define HW_SPI_PORT_SCK			GPIOC
-#define HW_SPI_PIN_SCK			10
-#define HW_SPI_PORT_MOSI		GPIOC
-#define HW_SPI_PIN_MOSI			12
-#define HW_SPI_PORT_MISO		GPIOC
-#define HW_SPI_PIN_MISO			11
-
-// I2C for IMU
-#define LSM6DS3_SDA_GPIO		GPIOB
-#define LSM6DS3_SDA_PIN			4
-#define LSM6DS3_SCL_GPIO		GPIOB
-#define LSM6DS3_SCL_PIN			5
-
-// UART Peripheral
-#define HW_UART_DEV		        SD4
-#define HW_UART_GPIO_AF		    GPIO_AF_UART4
-#define HW_UART_TX_PORT		    GPIOC
-#define HW_UART_TX_PIN		    10
-#define HW_UART_RX_PORT		    GPIOC
-#define HW_UART_RX_PIN		    11
-
-// Permanent UART Peripheral (for NRF52)
-#define HW_UART_P_BAUD		    115200
-#define HW_UART_P_DEV			SD3
-#define HW_UART_P_GPIO_AF		GPIO_AF_USART3
-#define HW_UART_P_TX_PORT		GPIOB
-#define HW_UART_P_TX_PIN		10
-#define HW_UART_P_RX_PORT	    GPIOB
-#define HW_UART_P_RX_PIN		11
-
-// Measurement macros
-#define ADC_V_L1				ADC_Value[ADC_IND_SENS1]
-#define ADC_V_L2				ADC_Value[ADC_IND_SENS2]
-#define ADC_V_L3				ADC_Value[ADC_IND_SENS3]
-#define ADC_V_ZERO				(ADC_Value[ADC_IND_VIN_SENS] / 2)
-
-// Macros
-#define READ_HALL1()			palReadPad(HW_HALL_ENC_GPIO1, HW_HALL_ENC_PIN1)
-#define READ_HALL2()			palReadPad(HW_HALL_ENC_GPIO2, HW_HALL_ENC_PIN2)
-#define READ_HALL3()			palReadPad(HW_HALL_ENC_GPIO3, HW_HALL_ENC_PIN3)
-
-// Override dead time. See the stm32f4 reference manual for calculating this value.
-#define HW_DEAD_TIME_NSEC		450.0
-
-// Default setting overrides
-#ifndef MCCONF_L_MIN_VOLTAGE
-#define MCCONF_L_MIN_VOLTAGE			20.0		// Minimum input voltage
-#endif
-#ifndef MCCONF_L_MAX_VOLTAGE
-#define MCCONF_L_MAX_VOLTAGE			140.0	// Maximum input voltage
-#endif
-#ifndef MCCONF_DEFAULT_MOTOR_TYPE
-#define MCCONF_DEFAULT_MOTOR_TYPE		MOTOR_TYPE_FOC
-#endif
-#ifndef MCCONF_FOC_F_ZV
-#define MCCONF_FOC_F_ZV				    30000.0
-#endif
-#ifndef MCCONF_L_MAX_ABS_CURRENT
-#define MCCONF_L_MAX_ABS_CURRENT		220.0	// The maximum absolute current above which a fault is generated
-#endif
-#ifndef MCCONF_FOC_SAMPLE_V0_V7
-#define MCCONF_FOC_SAMPLE_V0_V7			false	// Run control loop in both v0 and v7 (requires phase shunts)
-#endif
-#ifndef MCCONF_L_IN_CURRENT_MAX
-#define MCCONF_L_IN_CURRENT_MAX			100.0	// Input current limit in Amperes (Upper)
-#endif
-#ifndef MCCONF_L_IN_CURRENT_MIN
-#define MCCONF_L_IN_CURRENT_MIN			-50.0	// Input current limit in Amperes (Lower)
-#endif
-
-// Setting limits
-#define HW_LIM_CURRENT			-200.0, 200.0
-#define HW_LIM_CURRENT_IN		-150.0, 150.0
-#define HW_LIM_CURRENT_ABS		0.0, 300.0
-#define HW_LIM_VIN			    18.0, 140.0
-#define HW_LIM_ERPM			    -200e3, 200e3
-#define HW_LIM_DUTY_MIN			0.0, 0.1
-#define HW_LIM_DUTY_MAX			0.0, 0.95
-#define HW_LIM_TEMP_FET			-40.0, 100.0
-
-// Functions
-float hw_JetFleet_get_temp(void);
-bool hw_sample_shutdown_button(void);
-void buzzer_init(void);
-
-#define HW_EARLY_INIT()    buzzer_init()
-
-#endif /* HW_JetFleetF6_Core_H_ */
+    #ifndef HW_JetFleetF6_Core_H_
+    #define HW_JetFleetF6_Core_H_
+    
+    // HW properties
+    #define HW_HAS_3_SHUNTS
+    #define HW_HAS_PHASE_FILTERS
+    #define INVERTED_SHUNT_POLARITY
+    #define SERVO_BUZZER
+    #define HW_USE_BRK
+    #define BRK_HIGH
+    
+    // Macros
+    #define LED_GREEN_GPIO			GPIOB
+    #define LED_GREEN_PIN			2
+    #define LED_RED_GPIO			GPIOA
+    #define LED_RED_PIN			    15
+    
+    #define LED_GREEN_ON()			palSetPad(LED_GREEN_GPIO, LED_GREEN_PIN)
+    #define LED_GREEN_OFF()			palClearPad(LED_GREEN_GPIO, LED_GREEN_PIN)
+    #define LED_RED_ON()			palSetPad(LED_RED_GPIO, LED_RED_PIN)
+    #define LED_RED_OFF()			palClearPad(LED_RED_GPIO, LED_RED_PIN)
+    
+    // Phase filter
+    #define PHASE_FILTER_OFF()		palSetPad(GPIOC, 15); palSetPad(GPIOC, 14); palSetPad(GPIOC, 13)
+    #define PHASE_FILTER_ON()		palClearPad(GPIOC, 15); palClearPad(GPIOC, 14); palClearPad(GPIOC, 13)
+    
+    // AUX 
+    #define AUX_GPIO				GPIOC
+    #define AUX_PIN					9
+    #define AUX_ON()				palSetPad(AUX_GPIO, AUX_PIN)
+    #define AUX_OFF()				palClearPad(AUX_GPIO, AUX_PIN)
+    
+    // Shutdown pin
+    #define HW_SHUTDOWN_GPIO		    GPIOB
+    #define HW_SHUTDOWN_PIN			    0
+    #define HW_SHUTDOWN_SENSE_GPIO		GPIOC
+    #define HW_SHUTDOWN_SENSE_PIN		5
+    #define HW_SHUTDOWN_HOLD_ON()		palSetPad(HW_SHUTDOWN_GPIO, HW_SHUTDOWN_PIN)
+    #define HW_SHUTDOWN_HOLD_OFF()		palClearPad(HW_SHUTDOWN_GPIO, HW_SHUTDOWN_PIN)
+    #define HW_SAMPLE_SHUTDOWN()		hw_sample_shutdown_button()
+    
+    // ADC Config
+    #define HW_ADC_CHANNELS			18
+    #define HW_ADC_INJ_CHANNELS		3
+    #define HW_ADC_NBR_CONV			6
+    
+    // ADC Indexes
+    #define ADC_IND_SENS1			3
+    #define ADC_IND_SENS2			4
+    #define ADC_IND_SENS3			5
+    #define ADC_IND_CURR1			0
+    #define ADC_IND_CURR2			1
+    #define ADC_IND_CURR3			2
+    #define ADC_IND_VIN_SENS		11
+    #define ADC_IND_EXT			    6
+    #define ADC_IND_EXT2			7
+    #define ADC_IND_SHUTDOWN		10
+    #define ADC_IND_TEMP_MOS		8
+    //#define ADC_IND_TEMP_MOS_2    15
+    #define ADC_IND_TEMP_MOS_3		16
+    #define ADC_IND_TEMP_MOTOR		9
+    #define ADC_IND_VREFINT			12
+    
+    // ADC macros and settings
+    
+    // Component parameters (can be overridden)
+    #ifndef V_REG
+    #define V_REG				    3.3
+    #endif
+    #ifndef VIN_R1
+    #define VIN_R1				    150000.0
+    #endif
+    #ifndef CURRENT_AMP_GAIN
+    #define CURRENT_AMP_GAIN		20.0
+    #endif
+    #ifndef CURRENT_SHUNT_RES
+    #define CURRENT_SHUNT_RES		(0.0005 / 2.0)
+    #endif
+    
+    // Input voltage
+    #define GET_INPUT_VOLTAGE()		((V_REG / 4095.0) * (float)ADC_Value[ADC_IND_VIN_SENS] * ((VIN_R1 + VIN_R2) / VIN_R2))
+    // NTC Termistors
+    #define NTC_RES(adc_val)		(10000.0 / ((4095.0 / (float)adc_val) - 1.0))
+    #define NTC_TEMP(adc_ind)		hw_JetFleet_get_temp()
+    
+    #define NTC_RES_MOTOR(adc_val)		(10000.0 / ((4095.0 / (float)adc_val) - 1.0))
+    #define NTC_TEMP_MOTOR(beta)		(1.0 / ((logf(NTC_RES_MOTOR(ADC_Value[ADC_IND_TEMP_MOTOR]) / 10000.0) / beta) + (1.0 / 298.15)) - 273.15)
+    
+    #define NTC_TEMP_MOS1()			(1.0 / ((logf(NTC_RES(ADC_Value[ADC_IND_TEMP_MOS]) / 10000.0) / 3380.0) + (1.0 / 298.15)) - 273.15)
+    //#define NTC_TEMP_MOS2()		(1.0 / ((logf(NTC_RES(ADC_Value[ADC_IND_TEMP_MOS_2]) / 10000.0) / 3380.0) + (1.0 / 298.15)) - 273.15)
+    #define NTC_TEMP_MOS3()			(1.0 / ((logf(NTC_RES(ADC_Value[ADC_IND_TEMP_MOS_3]) / 10000.0) / 3380.0) + (1.0 / 298.15)) - 273.15)
+    
+    // Voltage on ADC channel
+    #define ADC_VOLTS(ch)			((float)ADC_Value[ch] / 4096.0 * V_REG)
+    
+    // Double samples in beginning and end for positive current measurement.
+    // Useful when the shunt sense traces have noise that causes offset.
+    
+    #ifndef CURR1_DOUBLE_SAMPLE
+    #define CURR1_DOUBLE_SAMPLE		0
+    #endif
+    #ifndef CURR2_DOUBLE_SAMPLE
+    #define CURR2_DOUBLE_SAMPLE		0
+    #endif
+    #ifndef CURR3_DOUBLE_SAMPLE
+    #define CURR3_DOUBLE_SAMPLE		0
+    #endif
+    
+    // COMM-port ADC GPIOs
+    #define HW_ADC_EXT_GPIO			GPIOA
+    #define HW_ADC_EXT_PIN			5
+    #define HW_ADC_EXT2_GPIO		GPIOA
+    #define HW_ADC_EXT2_PIN			6
+    
+    
+    // ICU Peripheral for servo decoding
+    #define HW_USE_SERVO_TIM4
+    #define HW_ICU_TIMER			TIM4
+    #define HW_ICU_TIM_CLK_EN()		RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM4, ENABLE)
+    #define HW_ICU_DEV			    ICUD4
+    #define HW_ICU_CHANNEL			ICU_CHANNEL_1
+    #define HW_ICU_GPIO_AF			GPIO_AF_TIM4
+    #define HW_ICU_GPIO			    GPIOB
+    #define HW_ICU_PIN			    6
+    
+    // I2C Peripheral
+    #define HW_I2C_DEV			    I2CD2
+    #define HW_I2C_GPIO_AF			GPIO_AF_I2C2
+    #define HW_I2C_SCL_PORT			GPIOB
+    #define HW_I2C_SCL_PIN			12
+    #define HW_I2C_SDA_PORT			GPIOC
+    #define HW_I2C_SDA_PIN			5
+    
+    // Hall/encoder pins
+    #define HW_HALL_ENC_GPIO1		GPIOC
+    #define HW_HALL_ENC_PIN1		6
+    #define HW_HALL_ENC_GPIO2		GPIOC
+    #define HW_HALL_ENC_PIN2		7
+    #define HW_HALL_ENC_GPIO3		GPIOC
+    #define HW_HALL_ENC_PIN3		8
+    #define HW_ENC_TIM			    TIM3
+    #define HW_ENC_TIM_AF			GPIO_AF_TIM3
+    #define HW_ENC_TIM_CLK_EN()		RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM3, ENABLE)
+    #define HW_ENC_EXTI_PORTSRC		EXTI_PortSourceGPIOC
+    #define HW_ENC_EXTI_PINSRC		EXTI_PinSource8
+    #define HW_ENC_EXTI_CH			EXTI9_5_IRQn
+    #define HW_ENC_EXTI_LINE		EXTI_Line8
+    #define HW_ENC_EXTI_ISR_VEC		EXTI9_5_IRQHandler
+    #define HW_ENC_TIM_ISR_CH		TIM3_IRQn
+    #define HW_ENC_TIM_ISR_VEC		TIM3_IRQHandler
+    
+    // SPI pins
+    #define HW_SPI_DEV			    SPID3
+    #define HW_SPI_GPIO_AF			GPIO_AF_SPI3
+    #define HW_SPI_PORT_NSS			GPIOA
+    #define HW_SPI_PIN_NSS			4
+    #define HW_SPI_PORT_SCK			GPIOC
+    #define HW_SPI_PIN_SCK			10
+    #define HW_SPI_PORT_MOSI		GPIOC
+    #define HW_SPI_PIN_MOSI			12
+    #define HW_SPI_PORT_MISO		GPIOC
+    #define HW_SPI_PIN_MISO			11
+    
+    // I2C for IMU
+    #define LSM6DS3_SDA_GPIO		GPIOB
+    #define LSM6DS3_SDA_PIN			4
+    #define LSM6DS3_SCL_GPIO		GPIOB
+    #define LSM6DS3_SCL_PIN			5
+    
+    //BRK
+    #define BRK_GPIO				GPIOB
+    #define BRK_PIN					12
+    
+    // UART Peripheral
+    #define HW_UART_DEV		        SD4
+    #define HW_UART_GPIO_AF		    GPIO_AF_UART4
+    #define HW_UART_TX_PORT		    GPIOC
+    #define HW_UART_TX_PIN		    10
+    #define HW_UART_RX_PORT		    GPIOC
+    #define HW_UART_RX_PIN		    11
+    
+    // Permanent UART Peripheral (for NRF52)
+    #define HW_UART_P_BAUD		    115200
+    #define HW_UART_P_DEV			SD3
+    #define HW_UART_P_GPIO_AF		GPIO_AF_USART3
+    #define HW_UART_P_TX_PORT		GPIOB
+    #define HW_UART_P_TX_PIN		10
+    #define HW_UART_P_RX_PORT	    GPIOB
+    #define HW_UART_P_RX_PIN		11
+    
+    // Measurement macros
+    #define ADC_V_L1				ADC_Value[ADC_IND_SENS1]
+    #define ADC_V_L2				ADC_Value[ADC_IND_SENS2]
+    #define ADC_V_L3				ADC_Value[ADC_IND_SENS3]
+    #define ADC_V_ZERO				(ADC_Value[ADC_IND_VIN_SENS] / 2)
+    
+    // Macros
+    #define READ_HALL1()			palReadPad(HW_HALL_ENC_GPIO1, HW_HALL_ENC_PIN1)
+    #define READ_HALL2()			palReadPad(HW_HALL_ENC_GPIO2, HW_HALL_ENC_PIN2)
+    #define READ_HALL3()			palReadPad(HW_HALL_ENC_GPIO3, HW_HALL_ENC_PIN3)
+    
+    // Override dead time. See the stm32f4 reference manual for calculating this value.
+    #define HW_DEAD_TIME_NSEC		450.0
+    
+    // Default setting overrides
+    #ifndef MCCONF_L_MIN_VOLTAGE
+    #define MCCONF_L_MIN_VOLTAGE			20.0		// Minimum input voltage
+    #endif
+    
+    #ifndef MCCONF_DEFAULT_MOTOR_TYPE
+    #define MCCONF_DEFAULT_MOTOR_TYPE		MOTOR_TYPE_FOC
+    #endif
+    #ifndef MCCONF_FOC_F_ZV
+    #define MCCONF_FOC_F_ZV				    30000.0
+    #endif
+    
+    #ifndef MCCONF_FOC_SAMPLE_V0_V7
+    #define MCCONF_FOC_SAMPLE_V0_V7			false	// Run control loop in both v0 and v7 (requires phase shunts)
+    #endif
+    #ifndef MCCONF_L_IN_CURRENT_MAX
+    #define MCCONF_L_IN_CURRENT_MAX			50.0	// Input current limit in Amperes (Upper)
+    #endif
+    #ifndef MCCONF_L_IN_CURRENT_MIN
+    #define MCCONF_L_IN_CURRENT_MIN			-20.0	// Input current limit in Amperes (Lower)
+    #endif
+    
+    // Setting limits
+    #define HW_LIM_CURRENT_IN		-150.0, 150.0
+    
+    
+    #define HW_LIM_ERPM			    -200e3, 200e3
+    #define HW_LIM_DUTY_MIN			0.0, 0.1
+    #define HW_LIM_DUTY_MAX			0.0, 0.95
+    #define HW_LIM_TEMP_FET			-40.0, 100.0
+    
+    // Functions
+    float hw_JetFleet_get_temp(void);
+    bool hw_sample_shutdown_button(void);
+    void buzzer_init(void);
+    
+    #define HW_EARLY_INIT()    buzzer_init()
+    
+    #endif /* HW_JetFleetF6_Core_H_ */

--- a/package_firmware.py
+++ b/package_firmware.py
@@ -105,9 +105,9 @@ package_dict["TRONIC_250R"] = [['TRONIC_250R', default_name]]
 package_dict["X12_PRO24"] = [['x12_pro24', default_name]]
 package_dict["X12_PRO30"] = [['x12_pro30', default_name]]
 package_dict["Thor300"] = [['Thor300_20s', default_name]]
-package_dict["JetFleetF6"] = [['JetFleetF6_20s', default_name],
-                    ['JetFleetF6_24s', default_name],
-                    ['JetFleetF6_32s', default_name]]
+package_dict["JetFleetF6_20s"] = [['JetFleetF6_20s', default_name]]
+package_dict["JetFleetF6_24s"] = [['JetFleetF6_24s', default_name]]
+package_dict["JetFleetF6_32s"] = [['JetFleetF6_32s', default_name]]
 package_dict["UXV_SR"] = [['uxv_sr', default_name]]
 package_dict["GESC"] = [['gesc', default_name]]
 package_dict["Warrior6"] = [['warrior6', default_name]]

--- a/package_firmware.py
+++ b/package_firmware.py
@@ -105,7 +105,9 @@ package_dict["TRONIC_250R"] = [['TRONIC_250R', default_name]]
 package_dict["X12_PRO24"] = [['x12_pro24', default_name]]
 package_dict["X12_PRO30"] = [['x12_pro30', default_name]]
 package_dict["Thor300"] = [['Thor300_20s', default_name]]
-package_dict["JetFleetF6"] = [['JetFleetF6', default_name]]
+package_dict["JetFleetF6"] = [['JetFleetF6_20s', default_name],
+                    ['JetFleetF6_24s', default_name],
+                    ['JetFleetF6_32s', default_name]]
 package_dict["UXV_SR"] = [['uxv_sr', default_name]]
 package_dict["GESC"] = [['gesc', default_name]]
 package_dict["Warrior6"] = [['warrior6', default_name]]


### PR DESCRIPTION
- Added JetFleet HW confs for the 20s, 24s, and 32s variants.
- Modified package_firmware.py to add all the variants under JetFleetF6 