### PR TITLE
BRK Polarity

### DIFF
--- a/motor/mcpwm_foc.c
+++ b/motor/mcpwm_foc.c
@@ -245,10 +245,19 @@ static void timer_reinit(int f_zv) {
 	// external fault signal. PWM outputs remain disabled until MCU is reset.
 	// software will catch the BRK flag to report the fault code
 	TIM_BDTRInitStructure.TIM_Break = TIM_Break_Enable;
+	#ifdef BRK_HIGH
+	TIM_BDTRInitStructure.TIM_BreakPolarity = TIM_BreakPolarity_High;
+	#else
 	TIM_BDTRInitStructure.TIM_BreakPolarity = TIM_BreakPolarity_Low;
+	#endif
+	
 #else
 	TIM_BDTRInitStructure.TIM_Break = TIM_Break_Disable;
+	#ifdef BRK_HIGH
+	TIM_BDTRInitStructure.TIM_BreakPolarity = TIM_BreakPolarity_Low;
+	#else
 	TIM_BDTRInitStructure.TIM_BreakPolarity = TIM_BreakPolarity_High;
+	#endif
 #endif
 
 	TIM_BDTRConfig(TIM1, &TIM_BDTRInitStructure);


### PR DESCRIPTION
TIM_BreakPolarity set to HIGH when BRK_HIGH is defined. 

JetFleet HW uses this polarity when BRK is enabled, with this change we allow the polarity to be set by defining BRK_HIGH on the HW files. Any HW can benefit from this change and it defaults to LOW so that it is not a breaking change.