### PR TITLE
fix(doc): wrong command id for CAN_PACKET_STATUS_6

### DIFF
--- a/documentation/comm_can.md
+++ b/documentation/comm_can.md
@@ -207,7 +207,7 @@ There are 6 different status messages available with the following data:
 | CAN_PACKET_STATUS_3 | 15 | Wh Used, Wh Charged |
 | CAN_PACKET_STATUS_4 | 16 | Temp Fet, Temp Motor, Current In, PID position |
 | CAN_PACKET_STATUS_5 | 27 | Tachometer, Voltage In |
-| CAN_PACKET_STATUS_6 | 28 | ADC1, ADC2, ADC3, PPM |
+| CAN_PACKET_STATUS_6 | 58 | ADC1, ADC2, ADC3, PPM |
 
 The content of the status messages is encoded as follows:
 


### PR DESCRIPTION
In the can communications documentation the `command id` of the `CAN_PACKET_STATUS_6` can frame is noted as `28` but when looking in the [code](https://github.com/vedderb/bldc/blob/96132d95e9d763799276bdf674f5f45deb611b46/datatypes.h#L1193) and observing on the can bus, `CAN_PACKET_STATUS_6` is sent with can id 58.

This PR corrects this in the documentation