### PR TITLE
Package c_libs: Include all headers even if not enabling USE_STLIB

### DIFF
--- a/lispBM/c_libs/rules.mk
+++ b/lispBM/c_libs/rules.mk
@@ -33,7 +33,7 @@ ifeq ($(USE_OPT),)
 endif
 
 CFLAGS = -fpic -Os -Wall -Wextra -Wundef -std=gnu99 -I$(VESC_C_LIB_PATH)
-CFLAGS += -I$(STLIB_PATH)/CMSIS/include -I$(STLIB_PATH)/CMSIS/ST -I$(UTILS_PATH)/
+CFLAGS += -I$(STLIB_PATH)/CMSIS/include -I$(STLIB_PATH)/CMSIS/ST -I$(STLIB_PATH)/inc -I$(UTILS_PATH)/
 CFLAGS += -fomit-frame-pointer -falign-functions=16 -mthumb
 CFLAGS += -fsingle-precision-constant -Wdouble-promotion
 CFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mcpu=cortex-m4
@@ -42,7 +42,7 @@ CFLAGS += -DIS_VESC_LIB
 CFLAGS += $(USE_OPT)
 
 ifeq ($(USE_STLIB),yes)
-	CFLAGS += -DUSE_STLIB -I$(STLIB_PATH)/inc
+	CFLAGS += -DUSE_STLIB
 endif
 
 LDFLAGS = -nostartfiles -static -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mcpu=cortex-m4

--- a/lispBM/c_libs/st_types.h
+++ b/lispBM/c_libs/st_types.h
@@ -23,10 +23,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "system_stm32f4xx.h"
-
-#ifdef USE_STLIB
 #include "stm32f4xx_conf.h"
-#endif
 
 typedef struct {
 	volatile uint32_t MODER;


### PR DESCRIPTION
The headers contain structure definitions that can be used without the stlib functions to directly access the registers.

Context: I rewrote the Refloat LED driver to configure the registers directly instead of linking against stlib, because I somehow recalled the stlib added significant bloat to the resulting binary. Turns out that wasn't the case, but the result still saves over 400B of flash, so I decided to go with it. I needed these changes (well, the one in `st_types.h` is more for convenience) to make it work.

Here's my changes to the LED code for reference and in case you'd have a better idea how to do it: https://github.com/lukash/refloat/pull/55