### PR TITLE
Compile with newlib-nano

### DIFF
--- a/ChibiOS_3.0.5/os/common/ports/ARMCMx/compilers/GCC/rules.mk
+++ b/ChibiOS_3.0.5/os/common/ports/ARMCMx/compilers/GCC/rules.mk
@@ -114,7 +114,7 @@ ASFLAGS   = $(MCFLAGS) -Wa,-amhls=$(LSTDIR)/$(notdir $(<:.s=.lst)) $(ADEFS)
 ASXFLAGS  = $(MCFLAGS) -Wa,-amhls=$(LSTDIR)/$(notdir $(<:.S=.lst)) $(ADEFS)
 CFLAGS    = $(MCFLAGS) $(OPT) $(COPT) $(CWARN) -Wa,-alms=$(LSTDIR)/$(notdir $(<:.c=.lst)) $(DEFS)
 CPPFLAGS  = $(MCFLAGS) $(OPT) $(CPPOPT) $(CPPWARN) -Wa,-alms=$(LSTDIR)/$(notdir $(<:.cpp=.lst)) $(DEFS)
-LDFLAGS   = $(MCFLAGS) $(OPT) -nostartfiles $(LLIBDIR) -Wl,-Map=$(BUILDDIR)/$(PROJECT).map,--cref,--no-warn-mismatch,--library-path=$(RULESPATH),--script=$(LDSCRIPT)$(LDOPT)
+LDFLAGS   = $(MCFLAGS) $(OPT) -nostartfiles $(LLIBDIR) -Wl,-Map=$(BUILDDIR)/$(PROJECT).map,--cref,--no-warn-mismatch,--library-path=$(RULESPATH),--script=$(LDSCRIPT)$(LDOPT) --specs=nano.specs -u _printf_float -u _scanf_float
 
 # Thumb interwork enabled only if needed because it kills performance.
 ifneq ($(TSRC),)


### PR DESCRIPTION
With enabled floats for scanf and printf. Saves about 22kB of flash (with GCC 10). Haven't tested what this actually does on GCC 7.

I tested flashing and running motor control only briefly for now, will test more later. The float support for printf/scanf seems to be working fine in the terminal. I am not aware of other unsupported functionality in newlib-nano.

When changing to GCC 14, the size increased slightly (by <800B). The generated code size actually decreased significantly, but I guess new stuff was added to newlib again. Then again, I'd assume there are good reasons for that and expect the new newlib-nano to just work better than the 10 years old one...

I'd like to ask to get this in and start compiling with GCC 14 if everything works properly. There have been great improvements to GCC over the recent years. Meanwhile, GCC 7 has been deprecated and is being (or has been) phased out of most distros.

On a bit of a side note, changing from GCC 7 to GCC 10 for the on-CPU IMU bitbanging communication led to 5-10% decrease in CPU load. Might get even better with GCC 14, I haven't tested that yet.

Note: I don't think the way I added this to the ChibiOS makefile rules is the correct way to do it, but I haven't found a clean way to pass it in from the outside. May not bother you as much as it bothers me :smile:.