### PR TITLE
Add shutdown_disable to Package / C-interface

### DIFF
--- a/lispBM/c_libs/vesc_c_if.h
+++ b/lispBM/c_libs/vesc_c_if.h
@@ -667,6 +667,8 @@ typedef struct {
 	// Set priority of current thread
 	// Range: -5 to 5, -5 is lowest, 0 is normal, 5 is highest
 	void (*thread_set_priority)(int priority);
+	// Disable shutdown (for hw with momentary button / auto shutdown support)
+	void (*shutdown_disable)(bool disable);
 } vesc_c_if;
 
 typedef struct {

--- a/lispBM/lispif_c_lib.c
+++ b/lispBM/lispif_c_lib.c
@@ -45,6 +45,7 @@
 #include "pwm_servo.h"
 #include "flash_helper.h"
 #include "mcpwm_foc.h"
+#include "shutdown.h"
 
 // Function prototypes otherwise missing
 void packet_init(void (*s_func)(unsigned char *data, unsigned int len),
@@ -1045,6 +1046,7 @@ lbm_value ext_load_native_lib(lbm_value *args, lbm_uint argn) {
 
 		// 6.06+
 		cif.cif.thread_set_priority = lib_thread_set_priority;
+		cif.cif.shutdown_disable = shutdown_set_sampling_disabled;
 
 		lib_init_done = true;
 	}


### PR DESCRIPTION
In some situations a package may want to disable the shutdown feature. This disables both the button as well as the auto shutdown behavior.