### PR TITLE
Fix windows build issue: Build gets stuck if sh.exe is in PATH

### DIFF
--- a/ChibiOS_3.0.5/os/common/ports/ARMCMx/compilers/GCC/rules.mk
+++ b/ChibiOS_3.0.5/os/common/ports/ARMCMx/compilers/GCC/rules.mk
@@ -319,7 +319,7 @@ clean:
 # Include the dependency files, should be the last of the makefile
 #
 ifeq ($(OS),Windows_NT)
-  $(shell cmd /C if not exist "$(DEPPATH)" mkdir "$(DEPPATH)")
+  $(shell powershell -noprofile -command "New-Item -Force -ItemType Directory $(DEPPATH) | Out-Null")
 else
   $(shell mkdir $(DEPPATH) 2>/dev/null)
 endif


### PR DESCRIPTION
On Windows the `$(shell ...)` function uses `sh.exe` (bash) if it is in PATH, otherwise it uses `cmd.exe`.

If `sh` is used then the `/C` option is interpreted as the `C:\` drive and not the `cmd` option which tells the `cmd` to run the command and exit. Since `/C` is interpreted the wrong way `cmd` doesn't exit and the `make` process gets stuck (doesn't return an error or continue).

But if `cmd` is used then `/C` is interred correctly and the build continues. 

`sh` can get added to PATH when installing git, but it depends on the selected options. It is also added if git is installed via the Scoop package manager or MSYS2 is installed.

The solution is to just use `powershell` to create the directory.

I tested both options when `sh` is in PATH and when it is not and it worked both times.