### PR TITLE
Update openocd config, add ChibiOS threads, rename for simplicity

### DIFF
--- a/openocd.cfg
+++ b/openocd.cfg
@@ -1,0 +1,7 @@
+source [find interface/stlink.cfg]
+source [find target/stm32f4x.cfg]
+
+# use hardware reset, connect under reset
+reset_config srst_only srst_nogate
+
+$_TARGETNAME configure -rtos chibios

--- a/stm32-bv_openocd.cfg
+++ b/stm32-bv_openocd.cfg
@@ -1,6 +1,0 @@
-source [find interface/stlink-v2.cfg]
-source [find target/stm32f4x_stlink.cfg]
-
-# use hardware reset, connect under reset
-reset_config srst_only srst_nogate
-


### PR DESCRIPTION
Not sure the openocd config is in active use, the source paths didn't work for me (using STLink v3 minie):
- `target/stm32f4x_stlink.cfg` was not found
- openocd says `interface/stlink-v2.cfg` is depracated

I also added support for listing ChibiOS threads and renamed the file to a simpler name.

I finally figured out how to properly debug the package in gdb, planning on writing a short documentation for it, I'd like to reference this file.