### PR TITLE
Add the crash_diag terminal command for diagnosing resets and crashes

### DIFF
--- a/chconf.h
+++ b/chconf.h
@@ -486,7 +486,7 @@
 }
 
 #ifndef __ASSEMBLER__
-void main_stop_motor_and_reset(void);
+void main_system_halt(const char *reason);
 #endif
 
 /**
@@ -495,7 +495,7 @@ void main_stop_motor_and_reset(void);
  *          the system is halted.
  */
 #define CH_CFG_SYSTEM_HALT_HOOK(reason) {                                   \
-  main_stop_motor_and_reset();                                              \
+  main_system_halt(reason);                                                 \
 }
 
 /** @} */

--- a/irq_handlers.c
+++ b/irq_handlers.c
@@ -102,21 +102,21 @@ CH_IRQ_HANDLER(PVD_IRQHandler) {
 }
 
 CH_IRQ_HANDLER(NMI_Handler) {
-	main_stop_motor_and_reset();
+	main_fault_handler();
 }
 
 CH_IRQ_HANDLER(HardFault_Handler) {
-	main_stop_motor_and_reset();
+	main_fault_handler();
 }
 
 CH_IRQ_HANDLER(MemManage_Handler) {
-	main_stop_motor_and_reset();
+	main_fault_handler();
 }
 
 CH_IRQ_HANDLER(BusFault_Handler) {
-	main_stop_motor_and_reset();
+	main_fault_handler();
 }
 
 CH_IRQ_HANDLER(UsageFault_Handler) {
-	main_stop_motor_and_reset();
+	main_fault_handler();
 }

--- a/irq_handlers.c
+++ b/irq_handlers.c
@@ -39,6 +39,23 @@ CH_IRQ_HANDLER(ADC1_2_3_IRQHandler) {
 void irq_handlers_init(void) {
 	nvicEnableVector(EXTI9_5_IRQn, 6);
 	nvicEnableVector(EXTI15_10_IRQn, 6);
+
+	// Latch supply dips below the PVD threshold into crash_info: a sag that resets
+	// nothing is otherwise invisible, and one latched right before a reset is
+	// evidence of a supply-caused reset. 2.9V is the highest available threshold,
+	// well below normal 3.3V operation and above the ~1.7V POR level.
+	PWR->CR |= PWR_CR_PLS_LEV7 | PWR_CR_PVDE; // level 7 = 2.9V
+
+	// The PVD output is wired to EXTI line 16; the rising edge is VDD crossing
+	// below the threshold.
+	EXTI_InitTypeDef exti;
+	exti.EXTI_Line = EXTI_Line16;
+	exti.EXTI_Mode = EXTI_Mode_Interrupt;
+	exti.EXTI_Trigger = EXTI_Trigger_Rising;
+	exti.EXTI_LineCmd = ENABLE;
+	EXTI_Init(&exti);
+
+	nvicEnableVector(PVD_IRQn, 6);
 }
 
 // The STM32 multiplexes EXTI lines 5-9 and 10-15 onto one NVIC vector each. Every GPIO EXTI
@@ -94,6 +111,14 @@ CH_IRQ_HANDLER(PVD_IRQHandler) {
 		// Log the fault. Supply voltage dropped below 2.9V,
 		// could corrupt an ongoing flash programming
 		mc_interface_fault_stop(FAULT_CODE_MCU_UNDER_VOLTAGE, false, true);
+
+		// Latch the dip for the crash diagnostics
+		crash_info.pvd_dips++;
+		crash_info.pvd_last_uptime = chVTGetSystemTimeX() / CH_CFG_ST_FREQUENCY;
+
+		// Mask the line to bound a bouncing supply to one latched dip per
+		// timeout thread iteration (which re-arms it)
+		EXTI->IMR &= ~EXTI_Line16;
 
 		// Clear the PVD pending bit
 		EXTI_ClearITPendingBit(EXTI_Line16);

--- a/ld_eeprom_emu.ld
+++ b/ld_eeprom_emu.ld
@@ -200,7 +200,17 @@ SECTIONS
         . = ALIGN(4);
         PROVIDE(_bss_end = .);
         PROVIDE(end = .);
-    } > BSS_RAM    
+    } > BSS_RAM
+
+    /* Outside the ranges initialized at boot (data copy and bss zeroing), so
+       contents survive a reset. Used for crash diagnostics (crash_info). */
+    .noinit (NOLOAD) : ALIGN(4)
+    {
+        . = ALIGN(4);
+        *(.noinit)
+        *(.noinit.*)
+        . = ALIGN(4);
+    } > BSS_RAM
 
     .ram0 (NOLOAD) : ALIGN(4)
     {

--- a/main.c
+++ b/main.c
@@ -294,10 +294,14 @@ static bool should_reset_config(void) {
 }
 
 int main(void) {
-	if (RCC->CSR & RCC_CSR_PORRSTF) {
-		// In case of Power On reset erase the whole struct
+	if (crash_info.magic != CRASH_INFO_MAGIC) {
+		// Erase the struct when the contents did not survive: first power-up
+		// from cold, SRAM decay after a long power loss, or a firmware update
+		// moving the section.
 		memset(&crash_info, 0, sizeof(crash_info));
+		crash_info.magic = CRASH_INFO_MAGIC;
 	}
+	crash_info.boot_count++;
 	crash_info.reset_flags = RCC->CSR;
 
 	// Clear the reset flags
@@ -481,6 +485,7 @@ static void stop_motor_and_reset(void) {
 void main_system_halt(const char *reason) {
 	crash_info.halt_reason = reason;
 	crash_info.type = CRASH_HALT;
+	crash_info.crash_boot = crash_info.boot_count;
 
 	stop_motor_and_reset();
 }
@@ -518,6 +523,7 @@ void fault_handler_c(uint32_t *hardfault_args) {
 	crash_info.registers.shcsr = SCB->SHCSR;
 
 	crash_info.type = CRASH_REGISTERS;
+	crash_info.crash_boot = crash_info.boot_count;
 
 	stop_motor_and_reset();
 }

--- a/main.c
+++ b/main.c
@@ -93,6 +93,8 @@
 foc_profile g_foc_profile;
 #endif
 
+__attribute__((section(".noinit"))) CrashInfo crash_info;
+
 // Private variables
 static THD_WORKING_AREA(periodic_thread_wa, 256);
 static THD_WORKING_AREA(led_thread_wa, 256);
@@ -425,7 +427,7 @@ int main(void) {
 	}
 }
 
-void main_stop_motor_and_reset(void) {
+static void stop_motor_and_reset(void) {
 	TIM_SelectOCxM(TIM1, TIM_Channel_1, TIM_ForcedAction_InActive);
 	TIM_CCxCmd(TIM1, TIM_Channel_1, TIM_CCx_Enable);
 	TIM_CCxNCmd(TIM1, TIM_Channel_1, TIM_CCxN_Disable);
@@ -465,4 +467,48 @@ void main_stop_motor_and_reset(void) {
 #endif
 
 	NVIC_SystemReset();
+}
+
+void main_system_halt(const char *reason) {
+	crash_info.halt_reason = reason;
+	crash_info.type = CRASH_HALT;
+
+	stop_motor_and_reset();
+}
+
+void main_fault_handler(void) __attribute__((naked));
+void main_fault_handler(void) {
+	// Store the currently-in-use stack pointer to the first function argument
+	// and call fault_handler_c
+	__asm volatile (
+		"TST LR, #4\n"
+		"ITE EQ\n"
+		"MRSEQ R0, MSP\n"
+		"MRSNE R0, PSP\n"
+		"B fault_handler_c\n"
+	);
+}
+
+void fault_handler_c(uint32_t *hardfault_args) {
+	// Store the registers dumped on the stack after a crash
+	crash_info.registers.r0 = hardfault_args[0];
+	crash_info.registers.r1 = hardfault_args[1];
+	crash_info.registers.r2 = hardfault_args[2];
+	crash_info.registers.r3 = hardfault_args[3];
+	crash_info.registers.r12 = hardfault_args[4];
+	crash_info.registers.lr = hardfault_args[5];
+	crash_info.registers.pc = hardfault_args[6];
+	crash_info.registers.psr = hardfault_args[7];
+
+	// Store the crash information registers
+	crash_info.registers.cfsr = SCB->CFSR;
+	crash_info.registers.hfsr = SCB->HFSR;
+	crash_info.registers.mmfar = SCB->MMFAR;
+	crash_info.registers.bfar = SCB->BFAR;
+	crash_info.registers.afsr = SCB->AFSR;
+	crash_info.registers.shcsr = SCB->SHCSR;
+
+	crash_info.type = CRASH_REGISTERS;
+
+	stop_motor_and_reset();
 }

--- a/main.c
+++ b/main.c
@@ -109,7 +109,7 @@ static THD_FUNCTION(flash_integrity_check_thread, arg) {
 
 	for(;;) {
 		if (flash_helper_verify_flash_memory_chunk() == FAULT_CODE_FLASH_CORRUPTION) {
-			NVIC_SystemReset();
+			chSysHalt("Flash corruption detected.");
 		}
 
 		chThdSleepMilliseconds(6);

--- a/main.c
+++ b/main.c
@@ -294,6 +294,15 @@ static bool should_reset_config(void) {
 }
 
 int main(void) {
+	if (RCC->CSR & RCC_CSR_PORRSTF) {
+		// In case of Power On reset erase the whole struct
+		memset(&crash_info, 0, sizeof(crash_info));
+	}
+	crash_info.reset_flags = RCC->CSR;
+
+	// Clear the reset flags
+	RCC->CSR |= RCC_CSR_RMVF;
+
 	halInit();
 	chSysInit();
 

--- a/main.h
+++ b/main.h
@@ -50,6 +50,7 @@ typedef enum {
 } CrashType;
 
 typedef struct {
+	uint32_t reset_flags;
 	CrashType type;
 	const char *halt_reason;
 	CrashRegisters registers;

--- a/main.h
+++ b/main.h
@@ -50,11 +50,21 @@ typedef enum {
 } CrashType;
 
 typedef struct {
-	uint32_t reset_flags;
+	uint32_t magic;
+	uint32_t boot_count;   // number of boots since the struct was last wiped
+	uint32_t reset_flags;  // RCC_CSR snapshot of the current boot
 	CrashType type;
+	uint32_t crash_boot;   // boot_count at the time the crash/halt was stored
 	const char *halt_reason;
 	CrashRegisters registers;
 } CrashInfo;
+
+// Marks crash_info as valid. The struct lives in noinit RAM, so its contents are
+// only meaningful if RAM actually survived the reset: after a power loss (SRAM
+// decay) or a firmware update that moves the section, the magic won't match and
+// the struct is wiped at boot. Including the size also invalidates it on a
+// firmware update that changes the layout without moving the section.
+#define CRASH_INFO_MAGIC	(0xB0070000 | sizeof(CrashInfo))
 
 extern CrashInfo crash_info;
 

--- a/main.h
+++ b/main.h
@@ -22,6 +22,39 @@
 
 bool main_init_done(void);
 uint32_t main_calc_hw_crc(void);
-void main_stop_motor_and_reset(void);
+void main_system_halt(const char *reason);
+void main_fault_handler(void);
+
+typedef struct {
+	uint32_t r0;
+	uint32_t r1;
+	uint32_t r2;
+	uint32_t r3;
+	uint32_t r12;
+	uint32_t lr;
+	uint32_t pc;
+	uint32_t psr;
+
+	uint32_t cfsr;
+	uint32_t hfsr;
+	uint32_t mmfar;
+	uint32_t bfar;
+	uint32_t afsr;
+	uint32_t shcsr;
+} CrashRegisters;
+
+typedef enum {
+	CRASH_NONE = 0,   // zero so a struct wipe resets it
+	CRASH_HALT,       // halt_reason is valid
+	CRASH_REGISTERS,  // registers are valid
+} CrashType;
+
+typedef struct {
+	CrashType type;
+	const char *halt_reason;
+	CrashRegisters registers;
+} CrashInfo;
+
+extern CrashInfo crash_info;
 
 #endif /* MAIN_H_ */

--- a/main.h
+++ b/main.h
@@ -54,7 +54,9 @@ typedef struct {
 	uint32_t boot_count;   // number of boots since the struct was last wiped
 	uint32_t reset_flags;  // RCC_CSR snapshot of the current boot
 	CrashType type;
-	uint32_t crash_boot;   // boot_count at the time the crash/halt was stored
+	uint32_t crash_boot;      // boot_count at the time the crash/halt was stored
+	uint32_t pvd_dips;        // number of supply dips below the PVD threshold (2.9V)
+	uint32_t pvd_last_uptime; // uptime in seconds at the last supply dip
 	const char *halt_reason;
 	CrashRegisters registers;
 } CrashInfo;

--- a/terminal.c
+++ b/terminal.c
@@ -71,6 +71,7 @@ static int callback_write = 0;
 static void crash_diag(void) {
 	// Reference manual (RM0090) names for the RCC_CSR reset source flags
 	uint32_t f = crash_info.reset_flags;
+	commands_printf("Boot number: %u", crash_info.boot_count);
 	commands_printf("Uptime: %u s", (uint32_t)(chVTGetSystemTimeX() / CH_CFG_ST_FREQUENCY));
 	commands_printf("Reset flags:%s%s%s%s%s%s%s",
 			(f & RCC_CSR_BORRSTF) ? " BOR" : "", (f & RCC_CSR_PADRSTF) ? " PIN" : "",
@@ -78,15 +79,34 @@ static void crash_diag(void) {
 			(f & RCC_CSR_WDGRSTF) ? " IWDG" : "", (f & RCC_CSR_WWDGRSTF) ? " WWDG" : "",
 			(f & RCC_CSR_LPWRRSTF) ? " LPWR" : "");
 
+	if (crash_info.boot_count > 1 && (crash_info.reset_flags & RCC_CSR_PORRSTF)) {
+		// A POR normally means a power loss long enough to decay SRAM and wipe the
+		// struct (resetting the boot count). Surviving contents mean the supply only
+		// dipped below the POR threshold briefly.
+		commands_printf("POR with RAM intact: brief supply dip");
+	}
+
+	if (crash_info.type == CRASH_NONE) {
+		return;
+	}
+
+	const char *crash_type = crash_info.type == CRASH_HALT ? "halt" : "crash";
+	uint32_t boots_ago = crash_info.boot_count - crash_info.crash_boot;
+	if (boots_ago == 1) {
+		commands_printf("Previous boot %sed.", crash_type);
+	} else {
+		commands_printf("Stale %s from %u boots ago.", crash_type, boots_ago);
+	}
+
 	if (crash_info.type == CRASH_HALT) {
 		// The reason points to a string literal in flash. After partial SRAM decay it
 		// can be garbage even with the crash_info magic intact, and dereferencing an
 		// unmapped address hardfaults, so only print it if it points into flash.
 		uint32_t addr = (uint32_t)crash_info.halt_reason;
 		if (addr >= FLASH_BASE && addr < FLASH_BASE + 1024 * 1024) {
-			commands_printf("OS halted, reason: %s", crash_info.halt_reason);
+			commands_printf("Reason: %s", crash_info.halt_reason);
 		} else {
-			commands_printf("OS halted, bad reason ptr %08x", addr);
+			commands_printf("Bad reason ptr: %08x", addr);
 		}
 	}
 
@@ -97,7 +117,7 @@ static void crash_diag(void) {
 				"reg_names must match CrashRegisters");
 		const uint32_t *regs = (const uint32_t *)&crash_info.registers;
 
-		commands_printf("System crashed, registers:");
+		commands_printf("Registers:");
 		for (unsigned i = 0; i < sizeof(reg_names) / sizeof(reg_names[0]); i++) {
 			commands_printf("%s: %08x", reg_names[i], regs[i]);
 		}

--- a/terminal.c
+++ b/terminal.c
@@ -38,6 +38,7 @@
 #include "mempools.h"
 #include "crc.h"
 #include "firmware_metadata.h"
+#include "main.h"
 
 #include <string.h>
 #include <ctype.h>
@@ -66,6 +67,42 @@ static volatile fault_data fault_vec[FAULT_VEC_LEN];
 static volatile int fault_vec_write = 0;
 static terminal_callback_struct callbacks[CALLBACK_LEN];
 static int callback_write = 0;
+
+static void crash_diag(void) {
+	// Reference manual (RM0090) names for the RCC_CSR reset source flags
+	uint32_t f = crash_info.reset_flags;
+	commands_printf("Uptime: %u s", (uint32_t)(chVTGetSystemTimeX() / CH_CFG_ST_FREQUENCY));
+	commands_printf("Reset flags:%s%s%s%s%s%s%s",
+			(f & RCC_CSR_BORRSTF) ? " BOR" : "", (f & RCC_CSR_PADRSTF) ? " PIN" : "",
+			(f & RCC_CSR_PORRSTF) ? " POR" : "", (f & RCC_CSR_SFTRSTF) ? " SFT" : "",
+			(f & RCC_CSR_WDGRSTF) ? " IWDG" : "", (f & RCC_CSR_WWDGRSTF) ? " WWDG" : "",
+			(f & RCC_CSR_LPWRRSTF) ? " LPWR" : "");
+
+	if (crash_info.type == CRASH_HALT) {
+		// The reason points to a string literal in flash. After partial SRAM decay it
+		// can be garbage even with the crash_info magic intact, and dereferencing an
+		// unmapped address hardfaults, so only print it if it points into flash.
+		uint32_t addr = (uint32_t)crash_info.halt_reason;
+		if (addr >= FLASH_BASE && addr < FLASH_BASE + 1024 * 1024) {
+			commands_printf("OS halted, reason: %s", crash_info.halt_reason);
+		} else {
+			commands_printf("OS halted, bad reason ptr %08x", addr);
+		}
+	}
+
+	if (crash_info.type == CRASH_REGISTERS) {
+		static const char reg_names[14][6] = {"r0", "r1", "r2", "r3", "r12", "lr", "pc",
+				"psr", "cfsr", "hfsr", "mmfar", "bfar", "afsr", "shcsr"};
+		_Static_assert(sizeof(CrashRegisters) == sizeof(reg_names) / sizeof(reg_names[0]) * 4,
+				"reg_names must match CrashRegisters");
+		const uint32_t *regs = (const uint32_t *)&crash_info.registers;
+
+		commands_printf("System crashed, registers:");
+		for (unsigned i = 0; i < sizeof(reg_names) / sizeof(reg_names[0]); i++) {
+			commands_printf("%s: %08x", reg_names[i], regs[i]);
+		}
+	}
+}
 
 __attribute__((section(".text2"))) void terminal_process_string(char *str) {
 	// Echo command so user can see what they previously ran
@@ -1161,6 +1198,8 @@ __attribute__((section(".text2"))) void terminal_process_string(char *str) {
 	} else if (strcmp(argv[0], "rebootwdt") == 0) {
 		chSysLock();
 		for (;;) {__NOP();}
+	} else if (strcmp(argv[0], "crash_diag") == 0) {
+		crash_diag();
 	}
 
 	// The help command
@@ -1281,6 +1320,9 @@ __attribute__((section(".text2"))) void terminal_process_string(char *str) {
 
 		commands_printf("rebootwdt");
 		commands_printf("  Reboot using the watchdog timer.");
+
+		commands_printf("crash_diag");
+		commands_printf("  Print crash/reset diagnostics.");
 
 		for (int i = 0;i < callback_write;i++) {
 			if (callbacks[i].cbf == 0) {

--- a/terminal.c
+++ b/terminal.c
@@ -79,6 +79,11 @@ static void crash_diag(void) {
 			(f & RCC_CSR_WDGRSTF) ? " IWDG" : "", (f & RCC_CSR_WWDGRSTF) ? " WWDG" : "",
 			(f & RCC_CSR_LPWRRSTF) ? " LPWR" : "");
 
+	if (crash_info.pvd_dips > 0) {
+		commands_printf("Supply dips <2.9V: %u, last at uptime %u s",
+				crash_info.pvd_dips, crash_info.pvd_last_uptime);
+	}
+
 	if (crash_info.boot_count > 1 && (crash_info.reset_flags & RCC_CSR_PORRSTF)) {
 		// A POR normally means a power loss long enough to decay SRAM and wipe the
 		// struct (resetting the boot count). Surviving contents mean the supply only

--- a/terminal.c
+++ b/terminal.c
@@ -1219,7 +1219,16 @@ __attribute__((section(".text2"))) void terminal_process_string(char *str) {
 		chSysLock();
 		for (;;) {__NOP();}
 	} else if (strcmp(argv[0], "crash_diag") == 0) {
-		crash_diag();
+		if (argc == 2 && strcmp(argv[1], "clear") == 0) {
+			// Erase the data, keeping the reset_flags as they still describe the current boot
+			uint32_t reset_flags = crash_info.reset_flags;
+			memset(&crash_info, 0, sizeof(crash_info));
+			crash_info.magic = CRASH_INFO_MAGIC;
+			crash_info.boot_count = 1;
+			crash_info.reset_flags = reset_flags;
+		} else {
+			crash_diag();
+		}
 	}
 
 	// The help command
@@ -1341,8 +1350,8 @@ __attribute__((section(".text2"))) void terminal_process_string(char *str) {
 		commands_printf("rebootwdt");
 		commands_printf("  Reboot using the watchdog timer.");
 
-		commands_printf("crash_diag");
-		commands_printf("  Print crash/reset diagnostics.");
+		commands_printf("crash_diag [clear]");
+		commands_printf("  Print (or clear) the crash/reset diagnostics.");
 
 		for (int i = 0;i < callback_write;i++) {
 			if (callbacks[i].cbf == 0) {

--- a/timeout.c
+++ b/timeout.c
@@ -22,6 +22,7 @@
 #include "stm32f4xx_conf.h"
 #include "shutdown.h"
 #include "utils.h"
+#include "main.h"
 
 // Private variables
 static volatile bool init_done = false;
@@ -178,15 +179,9 @@ void timeout_configure_IWDT(void) {
 }
 
 bool timeout_had_IWDG_reset(void) {
-	// Check if the system has resumed from IWDG reset
-	if (RCC_GetFlagStatus(RCC_FLAG_IWDGRST) != RESET) {
-		/* IWDGRST flag set */
-		/* Clear reset flags */
-		RCC_ClearFlag();
-		return true;
-	}
-
-	return false;
+	// The live RCC_CSR flags are captured and cleared at the start of main(),
+	// check the stored snapshot.
+	return (crash_info.reset_flags & RCC_CSR_WDGRSTF) != 0;
 }
 
 static THD_FUNCTION(timeout_thread, arg) {

--- a/timeout.c
+++ b/timeout.c
@@ -262,6 +262,14 @@ static THD_FUNCTION(timeout_thread, arg) {
 
 		kill_sw_active = kill_sw;
 
+		// Re-arm the PVD supply dip latch (its ISR masks the line to rate-limit a
+		// bouncing supply to one latched dip per iteration). Locked because IMR is
+		// also read-modified-written by EXTI_Init calls from other threads.
+		chSysLock();
+		EXTI->IMR |= EXTI_Line16;
+		chSysUnlock();
+
+
 		bool threads_ok = true;
 
 		// Monitored threads (foc, can, timer) must report at least one iteration,


### PR DESCRIPTION
Changes the fault handlers so that on a fault all the relevant registers (those dumped on the stack by the MCU and the fault information registers) are stored in a RAM struct (in the .noinit section) before resetting. Same with the Chibios halt, stores the pointer to the reason string before resetting.

On a bootup, the RAM struct is only initialized if Power On reset flag is set, and the reset flags are also stored in the struct.

This is all the possible information about why a reset could have occurred, which is then exposed via the `crash_diag` terminal command. Example output:
```
-> crash_diag 

Reset flags: Reset Pin,Software
System crashed, registers:
r0: 0x00000000
r1: 0x080728a6
r2: 0x00000000
r3: 0x20000800
r12: 0x50000020
lr: 0x080145a5
pc: 0x080145a8
psr: 0x61000000

cfsr: 0x00010000
hfsr: 0x40000000
mmfar: 0xe000ed34
bfar: 0xe000ed38
afsr: 0x00000000
shcsr: 0x00000000
```

With this output and the firmware .elf file (and in case of a package crash the package .elf) it should be possible to find the causes of a lot of in-the-field crashes and resets in general.