### PR TITLE
1、取消了滤波；

### DIFF
--- a/conf_general.h
+++ b/conf_general.h
@@ -118,7 +118,7 @@
 // Correction factor for computations that depend on the old resistor division factor
 #define VDIV_CORR					((VIN_R2 / (VIN_R2 + VIN_R1)) / (2.2 / (2.2 + 33.0)))
 
-// Current ADC to amperes factor
+// Current ADC to amperes factor  转换电流因子
 #define FAC_CURRENT					((V_REG / 4095.0) / (CURRENT_SHUNT_RES * CURRENT_AMP_GAIN))
 
 #define VOLTAGE_TO_ADC_FACTOR	( VIN_R2 / (VIN_R2 + VIN_R1) ) * ( 4096.0 / V_REG )

--- a/hwconf/trampa/75_300/hw_75_300_core.h
+++ b/hwconf/trampa/75_300/hw_75_300_core.h
@@ -33,7 +33,7 @@
 // HW properties
 #define HW_HAS_3_SHUNTS
 #define HW_HAS_PHASE_SHUNTS
-#define HW_HAS_PHASE_FILTERS
+//#define HW_HAS_PHASE_FILTERS
 
 // Macros
 #ifdef HW75_300_VEDDER_FIRST_PCB
@@ -53,7 +53,7 @@
 #define LED_RED_ON()			palSetPad(LED_RED_GPIO, LED_RED_PIN)
 #define LED_RED_OFF()			palClearPad(LED_RED_GPIO, LED_RED_PIN)
 
-#if defined(HW75_300_REV_2) || defined(HW75_300_REV_3)
+#if defined(HW75_300_REV_2) || defined(HW75_300_REV_3)  //无滤波
 #define PHASE_FILTER_GPIO		GPIOC
 #define PHASE_FILTER_PIN		9
 #else
@@ -62,8 +62,10 @@
 #endif
 #define PHASE_FILTER_ON()		palSetPad(PHASE_FILTER_GPIO, PHASE_FILTER_PIN)
 #define PHASE_FILTER_OFF()		palClearPad(PHASE_FILTER_GPIO, PHASE_FILTER_PIN)
+// Default setting overrides
+#define MCCONF_FOC_PHASE_FILTER_ENABLE false
 
-#define AUX_GPIO				GPIOC
+#define AUX_GPIO				GPIOC   //无遥控
 #define AUX_PIN					12
 #define AUX_ON()				palSetPad(AUX_GPIO, AUX_PIN)
 #define AUX_OFF()				palClearPad(AUX_GPIO, AUX_PIN)
@@ -125,19 +127,19 @@
 
 // Component parameters (can be overridden)
 #ifndef V_REG
-#define V_REG					3.44
+#define V_REG					3.3
 #endif
 #ifndef VIN_R1
 #define VIN_R1					56000.0
 #endif
 #ifndef VIN_R2
-#define VIN_R2					2200.0
+#define VIN_R2					2210.0
 #endif
 #ifndef CURRENT_AMP_GAIN
 #define CURRENT_AMP_GAIN		20.0
 #endif
 #ifndef CURRENT_SHUNT_RES
-#define CURRENT_SHUNT_RES		(0.0005 / 3.0)
+#define CURRENT_SHUNT_RES		0.00025
 #endif
 
 // Input voltage
@@ -177,10 +179,10 @@
 #endif
 
 // COMM-port ADC GPIOs
-#define HW_ADC_EXT_GPIO			GPIOA
-#define HW_ADC_EXT_PIN			5
-#define HW_ADC_EXT2_GPIO		GPIOA
-#define HW_ADC_EXT2_PIN			6
+// #define HW_ADC_EXT_GPIO			GPIOA
+// #define HW_ADC_EXT_PIN			5
+// #define HW_ADC_EXT2_GPIO		GPIOA
+// #define HW_ADC_EXT2_PIN			6
 
 // UART Peripheral
 #define HW_UART_DEV				SD3
@@ -202,7 +204,7 @@
 #endif
 
 #ifdef HW75_300_REV_3
-// NRF SWD
+// // NRF SWD
 #define NRF5x_SWDIO_GPIO		GPIOA
 #define NRF5x_SWDIO_PIN			15
 #define NRF5x_SWCLK_GPIO		GPIOB
@@ -219,7 +221,7 @@
 #define HW_ICU_GPIO				GPIOB
 #define HW_ICU_PIN				6
 
-// I2C Peripheral
+// // I2C Peripheral
 #define HW_I2C_DEV				I2CD2
 #define HW_I2C_GPIO_AF			GPIO_AF_I2C2
 #define HW_I2C_SCL_PORT			GPIOB
@@ -273,10 +275,10 @@
 
 // Default setting overrides
 #ifndef MCCONF_L_MIN_VOLTAGE
-#define MCCONF_L_MIN_VOLTAGE			12.0		// Minimum input voltage
+#define MCCONF_L_MIN_VOLTAGE			11.0		// Minimum input voltage
 #endif
 #ifndef MCCONF_L_MAX_VOLTAGE
-#define MCCONF_L_MAX_VOLTAGE			72.0	// Maximum input voltage
+#define MCCONF_L_MAX_VOLTAGE			84.0	// Maximum input voltage
 #endif
 #ifndef MCCONF_DEFAULT_MOTOR_TYPE
 #define MCCONF_DEFAULT_MOTOR_TYPE		MOTOR_TYPE_FOC
@@ -300,13 +302,15 @@
 // Setting limits
 #define HW_LIM_CURRENT			-400.0, 400.0
 #define HW_LIM_CURRENT_IN		-400.0, 400.0
-#define HW_LIM_CURRENT_ABS		0.0, 480.0
-#define HW_LIM_VIN				11.0, 72.0
+#define HW_LIM_CURRENT_ABS		0.0, 420.0
+#define HW_LIM_VIN				11.0, 84.0
 #define HW_LIM_ERPM				-200e3, 200e3
 #define HW_LIM_DUTY_MIN			0.0, 0.1
 #define HW_LIM_DUTY_MAX			0.0, 0.99
 #define HW_LIM_TEMP_FET			-40.0, 110.0
 
+#define APPCONF_CAN_MODE CAN_MODE_UAVCAN
+#define APPCONF_UAVCAN_RAW_MODE UAVCAN_RAW_MODE_DUTY
 // HW-specific functions
 float hw75_300_get_temp(void);
 


### PR DESCRIPTION
2、将输入电压设置成了3.3V；
3、将测量电阻设置成了2210欧姆；
4、策略电流电阻设置成了0.00025；
5、把最大输入电压数值更改至84
6、设置了默认模式为uavCAN；
7、模式设置成占空比控制