### PR TITLE
Require correct length on CAN_PACKET_UPDATE_BAUD to trigger change

### DIFF
--- a/comm/comm_can.c
+++ b/comm/comm_can.c
@@ -2219,17 +2219,19 @@ static void decode_msg(uint32_t eid, uint8_t *data8, int len, bool is_replaced) 
 	} break;
 
 	case CAN_PACKET_UPDATE_BAUD: {
-		ind = 0;
-		int kbits = buffer_get_int16(data8, &ind);
-		int delay_msec = buffer_get_int16(data8, &ind);
+		if (len == 4) {
+			ind = 0;
+			int kbits = buffer_get_int16(data8, &ind);
+			int delay_msec = buffer_get_int16(data8, &ind);
 
-		CAN_BAUD baud = comm_can_kbits_to_baud(kbits);
-		if (baud != CAN_BAUD_INVALID) {
-			comm_can_set_baud(baud, delay_msec);
+			CAN_BAUD baud = comm_can_kbits_to_baud(kbits);
+			if (baud != CAN_BAUD_INVALID) {
+				comm_can_set_baud(baud, delay_msec);
 
-			app_configuration *appconf = (app_configuration*)app_get_configuration();
-			appconf->can_baud_rate = baud;
-			conf_general_store_app_configuration(appconf);
+				app_configuration *appconf = (app_configuration*)app_get_configuration();
+				appconf->can_baud_rate = baud;
+				conf_general_store_app_configuration(appconf);
+			}
 		}
 	} break;
 


### PR DESCRIPTION
Only process the baud update if the frame payload is exactly 4 bytes (two int16s: kbits + delay_msec). Prevents unrelated CAN traffic that happens to share the packet ID from triggering a baud change.

This is certainly because of misbehaving things on the CAN BUS which is arguably the root cause. This just adds a little insurance before doing something that can possibly cut off communications. 

Addresses issue #898 

