### PR TITLE
Default phase filter settings in Makerbase 75_100 configs

### DIFF
--- a/hwconf/makerbase/75_100/hw_mksesc_75_100_core.h
+++ b/hwconf/makerbase/75_100/hw_mksesc_75_100_core.h
@@ -259,6 +259,13 @@
 #ifndef MCCONF_FOC_SAMPLE_V0_V7
 #define MCCONF_FOC_SAMPLE_V0_V7			false	// Run control loop in both v0 and v7 (requires phase shunts)
 #endif
+#ifndef MCCONF_FOC_PHASE_FILTER_ENABLE
+#ifdef HW_HAS_PHASE_FILTERS
+#define MCCONF_FOC_PHASE_FILTER_ENABLE	true	// Use phase voltage filters when available
+#else
+#define MCCONF_FOC_PHASE_FILTER_ENABLE	false	// Use phase voltage filters when available
+#endif
+#endif
 #ifndef MCCONF_L_IN_CURRENT_MAX
 #define MCCONF_L_IN_CURRENT_MAX			100.0	// Input current limit in Amperes (Upper)
 #endif

--- a/hwconf/makerbase/75_100_V2/hw_mksesc_75_100_v2_core.h
+++ b/hwconf/makerbase/75_100_V2/hw_mksesc_75_100_v2_core.h
@@ -271,6 +271,13 @@
 #ifndef MCCONF_FOC_SAMPLE_V0_V7
 #define MCCONF_FOC_SAMPLE_V0_V7		false	// Run control loop in both v0 and v7 (requires phase shunts)
 #endif
+#ifndef MCCONF_FOC_PHASE_FILTER_ENABLE
+#ifdef HW_HAS_PHASE_FILTERS
+#define MCCONF_FOC_PHASE_FILTER_ENABLE	true	// Use phase voltage filters when available
+#else
+#define MCCONF_FOC_PHASE_FILTER_ENABLE	false	// Use phase voltage filters when available
+#endif
+#endif
 #ifndef MCCONF_L_IN_CURRENT_MAX
 #define MCCONF_L_IN_CURRENT_MAX		100.0	// Input current limit in Amperes (Upper)
 #endif


### PR DESCRIPTION
This commit adds an #ifdef macro to the Makerbase `hw_mksesc_75_100_core.h` and `hw_mksesc_75_100_v2_core.h` hardware config headers to default phase filters to the appropriate setting (usually off) based on HW config. 

I added this as restoring defaults currently inherits the global fallback of true from `mcconf_default.h`. However, for config variants without phase filters, this seems to only affect the stored/default config value and not the actual behaviour.

I've compiled and flashed this to my own [MKSESC 75100](https://www.aliexpress.us/item/3256804277669942.html) from AliExpress, and it works fine, correctly defaulting phase filters to off on defaults. 