### PR TITLE
Add FOCSTrot V3/V4 to firmware package

### DIFF
--- a/hwconf/BMESC/hw_FOCSTrot_V2.h
+++ b/hwconf/BMESC/hw_FOCSTrot_V2.h
@@ -1,0 +1,28 @@
+/*
+	Copyright 2016 Benjamin Vedder	benjamin@vedder.se
+
+	This file is part of the VESC firmware.
+
+	The VESC firmware is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    The VESC firmware is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    */
+
+#ifndef HW_FOCSTROT_V2_H_
+#define HW_FOCSTROT_V2_H_
+
+#define FOCSTROT_V2
+#define HW_NAME "FOCSTrot V2.0"
+
+#include "hw_FOCSTrot_core.h"
+
+#endif /* HW_FOCSTROT_V2_H_ */

--- a/hwconf/BMESC/hw_FOCSTrot_core.h
+++ b/hwconf/BMESC/hw_FOCSTrot_core.h
@@ -194,6 +194,7 @@
 // LSM6DS3
 #define IMU_DEV                 IMU_DEV_LSM6DS3
 #define IMU_COM                 IMU_COM_I2C_BB
+#define IMU_BUS_SPEED_HZ        700000
 #define IMU_I2C_SDA_GPIO        GPIOB
 #define IMU_I2C_SDA_PIN         2
 #define IMU_I2C_SCL_GPIO        GPIOA

--- a/hwconf/BMESC/hw_FOCSTrot_core.h
+++ b/hwconf/BMESC/hw_FOCSTrot_core.h
@@ -23,7 +23,7 @@
 // HW properties
 #define HW_HAS_3_SHUNTS
 
-#ifdef FOCSTROT_V3
+#if defined(FOCSTROT_V2) || defined(FOCSTROT_V3)
 #define HW_DEAD_TIME_NSEC       600.0
 #else
 #define HW_DEAD_TIME_NSEC       1200.0
@@ -81,7 +81,7 @@
 #define V_REG                   3.288
 #endif
 #ifndef VIN_R1
-#ifdef FOCSTROT_V3
+#if defined(FOCSTROT_V2) || defined(FOCSTROT_V3)
 #define VIN_R1                  68000.0
 #else
 #define VIN_R1                  110000.0
@@ -218,10 +218,16 @@
 
 // Default setting overrides
 #ifndef MCCONF_L_MIN_VOLTAGE
+#ifdef FOCSTROT_V2
 #define MCCONF_L_MIN_VOLTAGE            18.0        // Minimum input voltage
+#elif defined(FOCSTROT_V3)
+#define MCCONF_L_MIN_VOLTAGE            41.0        // Minimum input voltage
+#else
+#define MCCONF_L_MIN_VOLTAGE            52.0        // Minimum input voltage
+#endif
 #endif
 #ifndef MCCONF_L_MAX_VOLTAGE
-#ifdef FOCSTROT_V3
+#if defined(FOCSTROT_V2) || defined(FOCSTROT_V3)
 #define MCCONF_L_MAX_VOLTAGE            95.0    // Maximum input voltage
 #else
 #define MCCONF_L_MAX_VOLTAGE            140.0    // Maximum input voltage
@@ -256,14 +262,22 @@
 #endif
 
 // Setting limits
-#ifdef FOCSTROT_V3
+#if defined(FOCSTROT_V2) || defined(FOCSTROT_V3)
 #define HW_LIM_CURRENT          -180.0, 180.0
 #define HW_LIM_CURRENT_IN       -80.0, 80.0
 #define HW_LIM_CURRENT_ABS      0.0, 250.0
+#ifdef FOCSTROT_V2
 #define HW_LIM_VIN              18.0, 95.0
 #else
-#define HW_LIM_VIN              18.0, 140.0
+#define HW_LIM_VIN              41.0, 95.0
 #endif
+#else
+#define HW_LIM_CURRENT          -200.0, 200.0
+#define HW_LIM_CURRENT_IN       -100.0, 100.0
+#define HW_LIM_CURRENT_ABS      0.0, 300.0
+#define HW_LIM_VIN              52.0, 140.0
+#endif
+
 #define HW_LIM_ERPM             -200e3, 200e3
 #define HW_LIM_DUTY_MIN         0.0, 0.1
 #define HW_LIM_DUTY_MAX         0.0, 0.99

--- a/package_firmware.py
+++ b/package_firmware.py
@@ -72,9 +72,12 @@ package_dict["LUNA_M600_V2_Rev5_60V"] = [['luna_m600_Rev5_60V', default_name]]
 package_dict["UNITY"] = [['unity', default_name],
                     ['unity_no_limits', no_limits_name]]
 package_dict["Cheap_FOCer_2"] = [['Cheap_FOCer_2', default_name],
-                    ['Cheap_FOCer_2_no_limits', no_limits_name]]
+					['Cheap_FOCer_2_no_limits', no_limits_name]]
 package_dict["Cheap_FOCer_2_V09"] = [['Cheap_FOCer_2_V09', default_name],
-                    ['Cheap_FOCer_2_V09_no_limits', no_limits_name]]
+					['Cheap_FOCer_2_V09_no_limits', no_limits_name]]
+package_dict["FOCSTrot V2.0"] = [['FOCSTrot_V2', default_name]]
+package_dict["FOCSTrot V3.0"] = [['FOCSTrot_V3', default_name]]
+package_dict["FOCSTrot V4.0"] = [['FOCSTrot_V4', default_name]]
 package_dict["STORMCORE_60D"] = [['stormcore_60d', default_name],
                     ['stormcore_60d_no_limits', no_limits_name]]
 package_dict["STORMCORE_60Dxs"] = [['stormcore_60dxs', default_name],


### PR DESCRIPTION
This adds FOCSTrot V3.0 and FOCSTrot V4.0 to package_firmware.py so they are included in the generated firmware archive used by VESC Tool Download Latest.

Validation performed:
- python -m py_compile package_firmware.py
- python package_firmware.py make_targets confirms FOCSTrot_V3 and FOCSTrot_V4 are included

Note: this Windows environment does not have make / arm-none-eabi-gcc installed, so full firmware compilation should be verified in the maintainer build environment.

After merge, please regenerate and publish res_fw_7.00.rcc so these firmwares appear in VESC Tool via Download Latest.