### PR TITLE
hw_mksesc_84_100_hp.h change to correct voltage reading

### DIFF
--- a/hwconf/makerbase/84_100_HP/hw_mksesc_84_100_hp.h
+++ b/hwconf/makerbase/84_100_HP/hw_mksesc_84_100_hp.h
@@ -108,12 +108,12 @@
 #define V_REG				    3.30
 #endif
 
-//The voltage dividing acquisition circuit on the Makerbase VESC motherboard is 56K and 2.2K resistors.
+//The voltage dividing acquisition circuit on the Makerbase VESC motherboard is 56K and 2.118K resistors.
 #ifndef VIN_R1
 #define VIN_R1				    56000.0 
 #endif
 #ifndef VIN_R2
-#define VIN_R2				    2200.0 
+#define VIN_R2				    2118.0 
 #endif
 
 #ifndef CURRENT_AMP_GAIN


### PR DESCRIPTION
Minor change to vin_r2 to correct voltage divider reading, thoroughly tested also fixes a lot of hang ups before correction controllers would crash and have multiple voltage errors minor change seems to have fixed.
 now with hopefully no commit issues.