### PR TITLE
Fix boundary truncation bug in utils_norm_angle

### DIFF
--- a/util/utils_math.h
+++ b/util/utils_math.h
@@ -156,7 +156,7 @@ static inline void utils_norm_angle(float *angle) {
 
 	// This is much faster than fmodf
 	while (*angle < 0.0) { *angle += 360.0; }
-	while (*angle > 360.0) { *angle -= 360.0; }
+	while (*angle >= 360.0) { *angle -= 360.0; }
 }
 
 /**


### PR DESCRIPTION
The function left angles of exactly 360.0 degrees untouched because it checked strictly for values greater than 360.0. Changed to greater-than-or-equal-to to ensure proper wrapping to 0.0.