### PR TITLE
imu: Route hw-SPI teardown through transport_deinit

### DIFF
--- a/imu/imu.c
+++ b/imu/imu.c
@@ -197,6 +197,7 @@ void imu_init(imu_config *set) {
 			// same IMU to a different bus, so re-bind to the fallback transport
 			// and try once more.
 			commands_printf("IMU: no response on primary bus, trying fallback");
+			transport_deinit(&m_transport);
 			imu_fallback_transport_init();
 			com = IMU_FALLBACK_COM;
 			m_dev = imu_device_create(dev, com, &m_transport);
@@ -227,10 +228,7 @@ i2c_bb_state *imu_get_i2c(void) {
 
 void imu_stop(void) {
 	imu_thread_stop();
-
-#if IMU_COM == IMU_COM_SPI_HW
-	spiStop(&IMU_SPI_DEV);
-#endif
+	transport_deinit(&m_transport);
 }
 
 bool imu_startup_done(void) {

--- a/imu/transport.h
+++ b/imu/transport.h
@@ -86,7 +86,7 @@ static inline void transport_recover(transport_t *t) {
 }
 
 static inline void transport_deinit(transport_t *t) {
-	if (t->interface->deinit) {
+	if (t->interface && t->interface->deinit) {
 		t->interface->deinit(t);
 	}
 }

--- a/imu/transport_spi_hw.c
+++ b/imu/transport_spi_hw.c
@@ -101,13 +101,17 @@ static uint16_t max_sample_rate(transport_t *t) {
 	return 10000;
 }
 
+static void deinit(transport_t *t) {
+	spiStop(dev_of(t));
+}
+
 static const transport_interface_t spi_hw_interface = {
 	.name = "spi-hw",
 	.max_sample_rate = max_sample_rate,
 	.read_reg = read_reg,
 	.write_reg = write_reg,
 	.recover = NULL,
-	.deinit = NULL,
+	.deinit = deinit,
 };
 
 // CR1.BR field value (0-7) for the fastest prescaler whose SPI clock does not


### PR DESCRIPTION
Implement deinit (spiStop) in the hw-SPI transport via the transport .deinit hook. Also call transport_deinit in the fallback transport path, to stop the SPI if it failed before binding I2C.