### PR TITLE
Fix motor not stopping on repeated faults by clearing fault code on the same tick as the stop time expires

### DIFF
--- a/motor/mc_interface.c
+++ b/motor/mc_interface.c
@@ -2576,14 +2576,17 @@ static void run_timer_tasks(volatile motor_if_state_t *motor) {
 		m_motor_1.m_runtime_last = runtime;
 	}
 
+	utils_sys_lock_cnt();
 	// Decrease fault iterations
 	if (motor->m_ignore_iterations > 0) {
 		motor->m_ignore_iterations--;
-	} else {
+	}
+	if (motor->m_ignore_iterations == 0) {
 		if (!(is_motor_1 ? IS_DRV_FAULT() : IS_DRV_FAULT_2())) {
 			motor->m_fault_now = FAULT_CODE_NONE;
 		}
 	}
+	utils_sys_unlock_cnt();
 
 	if (is_motor_1 ? IS_DRV_FAULT() : IS_DRV_FAULT_2()) {
 		motor->m_drv_fault_iterations++;


### PR DESCRIPTION
This fixes a bug where where the motor can end up running an old current command indefinitely while faulted, set-current 0 and brake commands are silently ignored, and only the estop in vesctool or erasing the lisp code would stop it.
It can be reproduced quite easily in 7.00 by setting "Absolute Maximum Current" lower than "Motor Current Max", in my case i set it to 1A. If you then run
```
(define start-time (systime))

(loopwhile (< (secs-since start-time) 10) {
    (set-current 10)
    (sleep 0.001)
})

(loopwhile t {
    (set-current 0)
    (sleep 0.01)
})
```
The motor will spin up really fast, and it won't stop even when the set-current 0 loop starts.


The issues stems from:
```
// Decrease fault iterations
if (motor->m_ignore_iterations > 0) {
    motor->m_ignore_iterations--;
} else {
    if (!(is_motor_1 ? IS_DRV_FAULT() : IS_DRV_FAULT_2())) {
        motor->m_fault_now = FAULT_CODE_NONE;
    }
}
```

https://github.com/vedderb/bldc/blob/9ff7e2ef1d3a507e588eeca3fa05516d642f0e35/motor/mc_interface.c#L2579-L2586

If m_ignore_iterations is 1 then it will get decreased to 0 but fault code in m_fault_now won't be cleared until the next time this runs. Now since m_ignore_iterations is 0 the motor can receive commands again, but the fault logic only stops the motor if it has a new fault code https://github.com/vedderb/bldc/blob/9ff7e2ef1d3a507e588eeca3fa05516d642f0e35/motor/mc_interface.c#L2969-L2972.

So the bug is if the motor faults (due to a too high current) and then receives a high set-current command right after m_ignore_iterations becomes 0 (i.e. when the first fault expires) that causes the motor to instantly fault again the set-current command won't be cleared by the fault logic and now the motor will get stuck in a loop where it continously faults and therefore never clears the problematic set-current.

The reason I added the lock is that if this thread somehow gets preempted by another thread that sets current after ignore_iterations has been set to 0 but before the fault code has been set we would get the same issue.