### PR TITLE
Incorrect default for Observer Gain

### DIFF
--- a/motor/mcconf_default.h
+++ b/motor/mcconf_default.h
@@ -299,7 +299,7 @@
 #define MCCONF_FOC_MOTOR_LD_LQ_DIFF		0.0
 #endif
 #ifndef MCCONF_FOC_OBSERVER_GAIN
-#define MCCONF_FOC_OBSERVER_GAIN		9e7		// Can be something like 600 / L
+#define MCCONF_FOC_OBSERVER_GAIN		9e5		// Can be something like 600 / L
 #endif
 #ifndef MCCONF_FOC_OBSERVER_GAIN_SLOW
 #define MCCONF_FOC_OBSERVER_GAIN_SLOW	0.05	// Observer gain scale at minimum duty cycle


### PR DESCRIPTION
The value shown in VESC Tool when one clicks Default under observer gain seems 100x higher than the values found in discussions of Observer Gain.  Observer Gain is often halved, but halving the value that appears when choosing Default will not provide the intended results.