### PR TITLE
Reduce flash usage

### DIFF
--- a/encoder/encoder.c
+++ b/encoder/encoder.c
@@ -469,7 +469,9 @@ void encoder_set_custom_callbacks (
 
 #pragma GCC pop_options
 
-float encoder_read_deg(void) {
+// The optimize pragma above disables -falign-functions=16 for the whole file,
+// even after pop_options. Align the hot function explicitly.
+__attribute__((aligned(16))) float encoder_read_deg(void) {
 	float res = 0.0;
 
 	switch (m_encoder_type_now) {

--- a/ld_eeprom_emu.ld
+++ b/ld_eeprom_emu.ld
@@ -106,7 +106,7 @@ SECTIONS
         PROVIDE(__fini_array_end = .);
     } > flash2
 
-    .text : ALIGN(16) SUBALIGN(16)
+    .text : ALIGN(16)
     {
         *(.text)
         *(.text.*)
@@ -117,7 +117,7 @@ SECTIONS
         *(.gcc*)
     } > flash2
 
-    .text2 : ALIGN(16) SUBALIGN(16)
+    .text2 : ALIGN(16)
     {
         *(.text2)
         *(.text2.*)

--- a/make/fw.mk
+++ b/make/fw.mk
@@ -7,7 +7,7 @@ USE_LISPBM ?= 1
 
 # Compiler options here.
 ifeq ($(USE_OPT),)
-  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16 -std=gnu99 -D_GNU_SOURCE
+  USE_OPT = -O2 -fno-math-errno -ggdb -fomit-frame-pointer -falign-functions=16 -std=gnu99 -D_GNU_SOURCE
   USE_OPT += -DBOARD_OTG_NOVBUSSENS $(build_args)
   USE_OPT += -DLBM_USE_DYN_FUNS -DLBM_USE_DYN_MACROS -DLBM_USE_DYN_LOOPS -DLBM_USE_TIME_QUOTA
   USE_OPT += -DLBM_USE_ERROR_LINENO -DLBM_USE_MACRO_REST_ARGS

--- a/motor/mc_interface.c
+++ b/motor/mc_interface.c
@@ -1876,7 +1876,9 @@ void mc_interface_fault_stop(mc_fault_code fault, bool is_second_motor, bool is_
 
 #pragma GCC pop_options
 
-void mc_interface_mc_timer_isr(bool is_second_motor, float dt) {
+// The optimize pragma above disables -falign-functions=16 for the whole file,
+// even after pop_options. Align the hot functions explicitly.
+__attribute__((aligned(16))) void mc_interface_mc_timer_isr(bool is_second_motor, float dt) {
 	FOC_PROFILE_LINE_FINE()
 	ledpwm_update_pwm();
 	FOC_PROFILE_LINE_FINE()
@@ -2219,7 +2221,7 @@ void mc_interface_mc_timer_isr(bool is_second_motor, float dt) {
 	FOC_PROFILE_LINE_FINE()
 }
 
-void mc_interface_adc_inj_int_handler(void) {
+__attribute__((aligned(16))) void mc_interface_adc_inj_int_handler(void) {
 	switch (m_motor_1.m_conf.motor_type) {
 	case MOTOR_TYPE_BLDC:
 	case MOTOR_TYPE_DC:


### PR DESCRIPTION
The SUBALIGN commit is a massive saving in flash usage. Maybe I'm not aware of some optimizations or other reasons why this was in place. The situation is also complicated by a GCC quirk forgetting the -falign-functions if you use `#pragma GCC optimize`. I've added explicit alignment to some hot functions where the removal of the SUBALIGN(16) broke their alignment due to that quirk.

The `no-math-errno` looks free.

If you'd just want to keep one of the commits (or any other edits, obviously), let me know.

Please don't squash commits :grin: 